### PR TITLE
feat: add rate limiting middleware for API abuse protection

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-rate-limit": "^7.4.1",
         "node-cron": "^3.0.3",
         "ws": "^8.14.2"
     },

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -6,6 +6,7 @@ import { RiskManagementService } from '../services/riskManagements.js'
 import { portfolioStorage } from '../services/portfolioStorage.js'
 import { CircuitBreakers } from '../services/circuitBreakers.js'
 import { logger } from '../utils/logger.js'
+import { writeRateLimiter } from '../middleware/rateLimit.js'
 
 const router = Router()
 const stellarService = new StellarService()
@@ -70,7 +71,7 @@ router.get('/health', (req, res) => {
 // ================================
 
 // Create portfolio with enhanced validation
-router.post('/portfolio', async (req, res) => {
+router.post('/portfolio', writeRateLimiter, async (req, res) => {
     try {
         const { userAddress, allocations, threshold } = req.body
 
@@ -184,7 +185,7 @@ router.get('/user/:address/portfolios', async (req, res) => {
 // ================================
 
 // Enhanced rebalance with comprehensive safety checks
-router.post('/portfolio/:id/rebalance', async (req, res) => {
+router.post('/portfolio/:id/rebalance', writeRateLimiter, async (req, res) => {
     try {
         const portfolioId = req.params.id
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import { createServer } from 'node:http'
 import { WebSocketServer } from 'ws'
 import { portfolioRouter } from './api/routes.js'
 import { errorHandler, notFound } from './middleware/errorHandler.js'
+import { globalRateLimiter } from './middleware/rateLimit.js'
 import { RebalancingService } from './monitoring/rebalancer.js'
 import { AutoRebalancerService } from './services/autoRebalancer.js'
 import { logger } from './utils/logger.js'
@@ -40,6 +41,8 @@ app.use((req, res, next) => {
     console.log(`${req.method} ${req.url}`)
     next()
 })
+
+app.use(globalRateLimiter)
 
 // Health check endpoint
 app.get('/health', (req, res) => {

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -1,0 +1,36 @@
+import { rateLimit, type Options } from 'express-rate-limit'
+
+const windowMs = Number(process.env.RATE_LIMIT_WINDOW_MS) || 60 * 1000
+const max = Number(process.env.RATE_LIMIT_MAX) || 100
+const writeMax = Number(process.env.RATE_LIMIT_WRITE_MAX) || 10
+
+function createHandler(ms: number) {
+    const retryAfterSec = Math.ceil(ms / 1000)
+    return (req: import('express').Request, res: import('express').Response) => {
+        res.setHeader('Retry-After', String(retryAfterSec))
+        res.status(429).json({
+            success: false,
+            error: 'Too Many Requests',
+            message: 'Rate limit exceeded. Please try again later.',
+            retryAfter: retryAfterSec
+        })
+    }
+}
+
+const baseOptions: Partial<Options> = {
+    windowMs,
+    standardHeaders: true,
+    legacyHeaders: false
+}
+
+export const globalRateLimiter = rateLimit({
+    ...baseOptions,
+    max,
+    handler: createHandler(windowMs)
+})
+
+export const writeRateLimiter = rateLimit({
+    ...baseOptions,
+    max: writeMax,
+    handler: createHandler(windowMs)
+})


### PR DESCRIPTION
# Add Express rate limiting middleware

## Summary

Adds rate limiting to the backend API to reduce abuse. Uses `express-rate-limit` with a global limit and stricter limits on write endpoints.

## Changes

### Backend

- **New middleware** `backend/src/middleware/rateLimit.ts`
  - Global rate limiter: configurable max requests per window (default 100/minute per IP).
  - Write rate limiter: stricter limit for write endpoints (default 10/minute per IP).
  - 429 responses include `Retry-After` header and a consistent JSON body.

- **Configuration**
  - `RATE_LIMIT_WINDOW_MS` – window length in ms (default: 60000).
  - `RATE_LIMIT_MAX` – max requests per window for all routes (default: 100).
  - `RATE_LIMIT_WRITE_MAX` – max requests per window for write endpoints (default: 10).

- **Integration**
  - Global limiter applied to all routes in `index.ts`.
  - Write limiter applied to `POST /portfolio` and `POST /portfolio/:id/rebalance` in `routes.ts`.

### Dependency

- Added `express-rate-limit` to `backend/package.json`.

## Acceptance criteria

- [x] Rate limiting middleware applied to all routes
- [x] Configurable via environment variables (`RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`)
- [x] Write endpoints have stricter limits than read endpoints
- [x] 429 Too Many Requests with `Retry-After` header and proper error body

## 429 response format

```json
{
  "success": false,
  "error": "Too Many Requests",
  "message": "Rate limit exceeded. Please try again later.",
  "retryAfter": 60
}
```

Response includes `Retry-After` header (seconds until the window resets).

## Testing

- Run backend: `cd backend && npm run dev`
- Exceed global limit: send > 100 requests per minute to any endpoint
- Exceed write limit: send > 10 requests per minute to `POST /portfolio` or `POST /portfolio/:id/rebalance`

---

Fixes #5
