### PR TITLE
S

### DIFF
--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -449,6 +449,19 @@ router.get('/portfolio/:id/rebalance-plan', async (req: Request, res: Response) 
     }
 })
 
+router.get('/portfolio/:id/rebalance-estimate', async (req: Request, res: Response) => {
+    try {
+        const portfolioId = req.params.id
+        if (!portfolioId) return fail(res, 400, 'VALIDATION_ERROR', 'Portfolio ID required')
+        const estimate = await stellarService.estimateRebalanceGas(portfolioId)
+
+        return ok(res, estimate)
+    } catch (error) {
+        logger.error('[ERROR] Rebalance estimate failed', { error: getErrorObject(error), portfolioId: req.params.id })
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
 // Manual portfolio rebalance
 router.post('/portfolio/:id/rebalance', ...protectedCriticalLimiter, idempotencyMiddleware, async (req: Request, res: Response) => {
 

--- a/backend/src/services/dex.ts
+++ b/backend/src/services/dex.ts
@@ -113,6 +113,19 @@ export class StellarDEXService {
         }
     }
 
+    async estimateNetworkFeeXlm(tradeCount: number): Promise<{ totalFeeXlm: number, feePerTradeXlm: number, baseFeeStroops: number }> {
+        const safeTradeCount = Math.max(0, Math.floor(tradeCount))
+        const baseFeeStroops = await this.server.fetchBaseFee()
+        const feePerTradeXlm = Dec.addStroopFee(0, baseFeeStroops)
+        const totalFeeXlm = Dec.roundStellar(feePerTradeXlm * safeTradeCount)
+
+        return {
+            totalFeeXlm,
+            feePerTradeXlm,
+            baseFeeStroops
+        }
+    }
+
     async executeRebalanceTrades(
         userAddress: string,
         trades: DEXTradeRequest[],

--- a/backend/src/services/rebalanceHistory.ts
+++ b/backend/src/services/rebalanceHistory.ts
@@ -38,6 +38,11 @@ export interface RebalanceEvent {
         actualSlippageBps?: number
         slippageExceededTolerance?: boolean
         totalSlippageBps?: number
+        gasFeeXlm?: number
+        gasFeeUsd?: number
+        gasPerTradeXlm?: number
+        gasWarning?: boolean
+        gasBreakdown?: Array<{ tradeId: string, fromAsset?: string, toAsset?: string, feeXlm: number }>
     }
 }
 
@@ -76,6 +81,11 @@ export class RebalanceHistoryService {
         slippageExceededTolerance?: boolean
         /** Optional aggregate slippage in basis points for backwards compatibility. */
         totalSlippageBps?: number
+        gasFeeXlm?: number
+        gasFeeUsd?: number
+        gasPerTradeXlm?: number
+        gasWarning?: boolean
+        gasBreakdown?: Array<{ tradeId: string, fromAsset?: string, toAsset?: string, feeXlm: number }>
     }): Promise<RebalanceEvent> {
         const featureFlags = getFeatureFlags()
         const eventSource: RebalanceEvent['eventSource'] = eventData.eventSource
@@ -92,7 +102,12 @@ export class RebalanceHistoryService {
             estimatedSlippageBps: eventData.estimatedSlippageBps,
             actualSlippageBps: eventData.actualSlippageBps,
             slippageExceededTolerance: eventData.slippageExceededTolerance,
-            ...(eventData.totalSlippageBps != null && { totalSlippageBps: eventData.totalSlippageBps })
+            ...(eventData.totalSlippageBps != null && { totalSlippageBps: eventData.totalSlippageBps }),
+            gasFeeXlm: eventData.gasFeeXlm,
+            gasFeeUsd: eventData.gasFeeUsd,
+            gasPerTradeXlm: eventData.gasPerTradeXlm,
+            gasWarning: eventData.gasWarning,
+            gasBreakdown: eventData.gasBreakdown
         }
 
         if (eventData.prices && eventData.portfolio) {

--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -32,6 +32,17 @@ export interface ExecuteRebalanceOptions extends Partial<RebalanceExecutionConfi
     tradeSlippageOverrides?: Record<string, number>
 }
 
+export interface RebalanceGasEstimate {
+    portfolioId: string
+    tradeCount: number
+    gasEstimateXlm: number
+    gasEstimateUsd: number
+    gasPerTradeXlm: number
+    gasWarning: boolean
+    breakdown: Array<{ tradeId: string, estimateXlm: number }>
+    xlmPriceUsd: number
+}
+
 export class StellarService {
     private server: Horizon.Server
     private contractAddress: string
@@ -210,6 +221,40 @@ export class StellarService {
         }
     }
 
+    async estimateRebalanceGas(portfolioId: string): Promise<RebalanceGasEstimate> {
+        const { portfolioStorage } = await import('./portfolioStorage.js')
+        const { ReflectorService } = await import('./reflector.js')
+
+        const portfolio = await portfolioStorage.getPortfolio(portfolioId) as StoredPortfolio | undefined
+        if (!portfolio) {
+            throw new Error('Portfolio not found')
+        }
+
+        const reflector = new ReflectorService()
+        const prices = await reflector.getCurrentPrices()
+        const portfolioSlippagePct = (portfolio as { slippageTolerancePercent?: number; slippageTolerance?: number }).slippageTolerancePercent
+            ?? (portfolio as { slippageTolerance?: number }).slippageTolerance ?? 1
+        const slippageBps = Math.round(portfolioSlippagePct * 100)
+        const { trades } = this.calculateRebalanceTrades(portfolio, prices, undefined, slippageBps)
+        const feeEstimate = await this.dexService.estimateNetworkFeeXlm(trades.length)
+        const xlmPriceUsd = prices.XLM?.price ?? 0
+        const gasEstimateUsd = Dec.roundStellar(feeEstimate.totalFeeXlm * xlmPriceUsd)
+
+        return {
+            portfolioId,
+            tradeCount: trades.length,
+            gasEstimateXlm: feeEstimate.totalFeeXlm,
+            gasEstimateUsd,
+            gasPerTradeXlm: feeEstimate.feePerTradeXlm,
+            gasWarning: feeEstimate.totalFeeXlm > 0.5,
+            breakdown: trades.map((trade) => ({
+                tradeId: trade.tradeId,
+                estimateXlm: feeEstimate.feePerTradeXlm
+            })),
+            xlmPriceUsd
+        }
+    }
+
     async executeRebalance(portfolioId: string, options: ExecuteRebalanceOptions = {}): Promise<RebalanceResult> {
         try {
             const { portfolioStorage } = await import('./portfolioStorage.js')
@@ -381,12 +426,15 @@ export class StellarService {
 
             const actualSlippageBps = dexResult.totalSlippageBps ?? 0
             const maxAllowedBps = Math.round(portfolioSlippagePct * 100)
+            const executedTradeCount = dexResult.executedTrades.filter(t => t.executedAmount > 0 && !t.rolledBack).length
+            const gasFeeXlm = Dec.roundStellar(dexResult.totalEstimatedFeeXLM)
+            const gasFeeUsd = Dec.roundStellar(gasFeeXlm * (prices.XLM?.price ?? 0))
             const event = await rebalanceHistoryService.recordRebalanceEvent({
                 portfolioId,
                 trigger: dexResult.status === 'failed'
                     ? `Execution Failed: ${dexResult.failureReason || 'unknown reason'}`
                     : trigger,
-                trades: dexResult.executedTrades.filter(t => t.executedAmount > 0 && !t.rolledBack).length,
+                trades: executedTradeCount,
                 gasUsed: `${dexResult.totalEstimatedFeeXLM.toFixed(7)} XLM`,
                 status: historyStatus,
                 fromAsset: firstExecuted?.fromAsset,
@@ -398,7 +446,17 @@ export class StellarService {
                 estimatedSlippageBps: slippageBps,
                 actualSlippageBps: actualSlippageBps,
                 slippageExceededTolerance: actualSlippageBps > maxAllowedBps,
-                totalSlippageBps: dexResult.totalSlippageBps
+                totalSlippageBps: dexResult.totalSlippageBps,
+                gasFeeXlm,
+                gasFeeUsd,
+                gasPerTradeXlm: executedTradeCount > 0 ? Dec.roundStellar(gasFeeXlm / executedTradeCount) : 0,
+                gasWarning: gasFeeXlm > 0.5,
+                gasBreakdown: dexResult.executedTrades.map((trade) => ({
+                    tradeId: trade.tradeId,
+                    fromAsset: trade.fromAsset,
+                    toAsset: trade.toAsset,
+                    feeXlm: executedTradeCount > 0 ? Dec.roundStellar(gasFeeXlm / executedTradeCount) : 0
+                }))
             })
 
             const overallStatus = dexResult.status === 'success'

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -93,6 +93,11 @@ export interface RebalanceEvent {
         riskMetrics?: any
         marketConditions?: any
         totalSlippageBps?: number
+        gasFeeXlm?: number
+        gasFeeUsd?: number
+        gasPerTradeXlm?: number
+        gasWarning?: boolean
+        gasBreakdown?: Array<{ tradeId: string, fromAsset?: string, toAsset?: string, feeXlm: number }>
     }
 }
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -13,7 +13,7 @@ import PriceTracker from './PriceTracker'
 import { API_CONFIG } from '../config/api'
 
 // TanStack Query Hooks
-import { useUserPortfolios, usePortfolioDetails } from '../hooks/queries/usePortfolioQuery'
+import { useUserPortfolios, usePortfolioDetails, useRebalanceEstimate } from '../hooks/queries/usePortfolioQuery'
 import { usePrices } from '../hooks/queries/usePricesQuery'
 import { useExecuteRebalanceMutation } from '../hooks/mutations/usePortfolioMutations'
 import { api, ENDPOINTS } from '../config/api'
@@ -46,6 +46,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
 
     // Query for prices
     const { data: priceData, isLoading: pricesLoading } = usePrices()
+    const { data: rebalanceEstimate } = useRebalanceEstimate(latestPortfolioId)
 
     // Mutation for rebalancing
     const executeRebalanceMutation = useExecuteRebalanceMutation(latestPortfolioId)
@@ -92,6 +93,10 @@ const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
             alert(isSlippage ? `Slippage too high: ${msg}` : msg)
         }
     }
+
+    const estimateXlm = rebalanceEstimate?.gasEstimateXlm ?? 0
+    const estimateUsd = rebalanceEstimate?.gasEstimateUsd ?? 0
+    const hasHighGasWarning = rebalanceEstimate?.gasWarning || estimateXlm > 0.5
 
     const refreshData = async () => {
         // TanStack Query handles background refresh automatically, but we can force it
@@ -522,6 +527,27 @@ const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
                                         <p className="text-sm text-orange-700 dark:text-orange-400 mb-2">
                                             Your portfolio has drifted from target allocation
                                         </p>
+                                        <p className="text-sm text-orange-700 dark:text-orange-400 mb-2 font-medium">
+                                            Estimated gas: {estimateXlm.toFixed(2)} XLM (~${estimateUsd.toFixed(3)})
+                                        </p>
+                                        <p className="text-xs text-orange-600 dark:text-orange-400 mb-3">
+                                            {rebalanceEstimate?.tradeCount ?? 0} estimated trade{(rebalanceEstimate?.tradeCount ?? 0) === 1 ? '' : 's'} @ {(rebalanceEstimate?.gasPerTradeXlm ?? 0).toFixed(4)} XLM each
+                                        </p>
+                                        {hasHighGasWarning && (
+                                            <p className="text-xs text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900/40 rounded px-2 py-1 mb-3">
+                                                Warning: estimated gas is unusually high (&gt; 0.5 XLM). Consider reducing trade count.
+                                            </p>
+                                        )}
+                                        {(rebalanceEstimate?.breakdown?.length ?? 0) > 0 && (
+                                            <div className="text-xs text-orange-700 dark:text-orange-300 mb-3 space-y-1">
+                                                {rebalanceEstimate.breakdown.map((item: any) => (
+                                                    <div key={item.tradeId} className="flex justify-between">
+                                                        <span>{item.tradeId}</span>
+                                                        <span>{Number(item.estimateXlm || 0).toFixed(4)} XLM</span>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        )}
                                         {(portfolioData as any)?.slippageTolerancePercent != null && (
                                             <p className="text-xs text-orange-600 dark:text-orange-400 mb-4">
                                                 Max slippage: {(portfolioData as any).slippageTolerancePercent}% — trades beyond this will be rejected

--- a/frontend/src/components/RebalanceHistory.tsx
+++ b/frontend/src/components/RebalanceHistory.tsx
@@ -36,6 +36,11 @@ interface RebalanceEvent {
         actualSlippageBps?: number
         slippageExceededTolerance?: boolean
         totalSlippageBps?: number
+        gasFeeXlm?: number
+        gasFeeUsd?: number
+        gasPerTradeXlm?: number
+        gasWarning?: boolean
+        gasBreakdown?: Array<{ tradeId: string, fromAsset?: string, toAsset?: string, feeXlm: number }>
     }
 }
 
@@ -81,6 +86,16 @@ const RebalanceHistory: React.FC<RebalanceHistoryProps> = ({ portfolioId }) => {
                     performanceImpact: 'neutral',
                     executionTime: 2400,
                     chain: 'Stellar'
+                    ,
+                    gasFeeXlm: 0.0234,
+                    gasFeeUsd: 0.0028,
+                    gasPerTradeXlm: 0.0078,
+                    gasWarning: false,
+                    gasBreakdown: [
+                        { tradeId: 'trade-1', fromAsset: 'XLM', toAsset: 'ETH', feeXlm: 0.0078 },
+                        { tradeId: 'trade-2', fromAsset: 'USDC', toAsset: 'XLM', feeXlm: 0.0078 },
+                        { tradeId: 'trade-3', fromAsset: 'BTC', toAsset: 'USDC', feeXlm: 0.0078 }
+                    ]
                 }
             },
             {
@@ -102,6 +117,15 @@ const RebalanceHistory: React.FC<RebalanceHistoryProps> = ({ portfolioId }) => {
                     performanceImpact: 'positive',
                     executionTime: 1800,
                     chain: 'Stellar'
+                    ,
+                    gasFeeXlm: 0.0156,
+                    gasFeeUsd: 0.0019,
+                    gasPerTradeXlm: 0.0078,
+                    gasWarning: false,
+                    gasBreakdown: [
+                        { tradeId: 'trade-1', fromAsset: 'XLM', toAsset: 'USDC', feeXlm: 0.0078 },
+                        { tradeId: 'trade-2', fromAsset: 'ETH', toAsset: 'XLM', feeXlm: 0.0078 }
+                    ]
                 }
             }
         ]
@@ -374,6 +398,12 @@ const RebalanceHistory: React.FC<RebalanceHistoryProps> = ({ portfolioId }) => {
 
                                             <div className="flex items-center space-x-4 text-sm text-gray-500 dark:text-gray-400 mb-2">
                                                 <span>Gas: {event.gasUsed}</span>
+                                                {event.details?.gasFeeUsd != null && (
+                                                    <span>(~${event.details.gasFeeUsd.toFixed(4)})</span>
+                                                )}
+                                                {event.details?.gasPerTradeXlm != null && (
+                                                    <span>{event.details.gasPerTradeXlm.toFixed(4)} XLM/trade</span>
+                                                )}
                                                 {event.details?.executionTime && (
                                                     <span>Execution: {formatExecutionTime(event.details.executionTime)}</span>
                                                 )}
@@ -384,6 +414,19 @@ const RebalanceHistory: React.FC<RebalanceHistoryProps> = ({ portfolioId }) => {
                                                     <span>Slippage: {(event.details.totalSlippageBps / 100).toFixed(2)}%</span>
                                                 )}
                                             </div>
+                                            {(event.details?.gasBreakdown?.length ?? 0) > 0 && (
+                                                <div className="text-xs text-gray-600 dark:text-gray-400 mb-2">
+                                                    {event.details?.gasWarning && (
+                                                        <div className="text-red-600 dark:text-red-400 mb-1 font-medium">High gas warning (&gt; 0.5 XLM)</div>
+                                                    )}
+                                                    {event.details?.gasBreakdown?.map((item) => (
+                                                        <div key={item.tradeId} className="flex justify-between">
+                                                            <span>{item.tradeId}: {item.fromAsset ?? '—'} → {item.toAsset ?? '—'}</span>
+                                                            <span>{item.feeXlm.toFixed(4)} XLM</span>
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            )}
 
                                             {/* Enhanced badges */}
                                             <div className="flex items-center space-x-2 mb-2">

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -77,6 +77,7 @@ export const API_CONFIG = {
         PORTFOLIO_DETAIL: (id: string) => `/api/portfolio/${id}`,
         PORTFOLIO_EXPORT: (id: string, format: 'json' | 'csv' | 'pdf') => `/api/portfolio/${id}/export?format=${format}`,
         PORTFOLIO_REBALANCE: (id: string) => `/api/portfolio/${id}/rebalance`,
+        PORTFOLIO_REBALANCE_ESTIMATE: (id: string) => `/api/portfolio/${id}/rebalance-estimate`,
         PORTFOLIO_REBALANCE_STATUS: (id: string) => `/api/portfolio/${id}/rebalance-status`,
         PRICES: '/api/prices',
         PRICES_ENHANCED: '/api/prices/enhanced',

--- a/frontend/src/hooks/mutations/usePortfolioMutations.ts
+++ b/frontend/src/hooks/mutations/usePortfolioMutations.ts
@@ -25,6 +25,7 @@ export const useExecuteRebalanceMutation = (portfolioId: string | null) => {
             // Invalidate the specific portfolio details and history
             if (portfolioId) {
                 queryClient.invalidateQueries({ queryKey: portfolioKeys.detail(portfolioId) })
+                queryClient.invalidateQueries({ queryKey: [...portfolioKeys.detail(portfolioId), 'rebalance-estimate'] })
                 queryClient.invalidateQueries({ queryKey: historyKeys.list(portfolioId) })
                 queryClient.invalidateQueries({ queryKey: analyticsKeys.portfolio(portfolioId) })
             }

--- a/frontend/src/hooks/queries/usePortfolioQuery.ts
+++ b/frontend/src/hooks/queries/usePortfolioQuery.ts
@@ -26,3 +26,13 @@ export const usePortfolioDetails = (id: string | null) => {
         staleTime: 30000, // 30 seconds
     })
 }
+
+export const useRebalanceEstimate = (id: string | null) => {
+    return useQuery({
+        queryKey: [...portfolioKeys.detail(id || ''), 'rebalance-estimate'],
+        queryFn: () => api.get<any>(ENDPOINTS.PORTFOLIO_REBALANCE_ESTIMATE(id!)),
+        enabled: !!id && id !== 'demo',
+        refetchInterval: 30000,
+        staleTime: 25000,
+    })
+}


### PR DESCRIPTION
Closes #112

---


#112 Add gas fee estimation before rebalance
### Motivation

- Users do not know expected network gas before executing a rebalance, so provide an upfront estimate and per-trade breakdown to improve decision making. 
- Track and store gas used in history so historical fees are visible and can trigger warnings when unusually high.

### Description

- Add a network fee estimator: `StellarDEXService.estimateNetworkFeeXlm(tradeCount)` computes base-fee-based XLM estimates and `StellarService.estimateRebalanceGas(portfolioId)` produces a per-portfolio estimate (trade count, total XLM, USD estimate, per-trade XLM, breakdown, and `gasWarning`).
- Add API endpoint `GET /api/portfolio/:id/rebalance-estimate` that returns the estimate for UI consumption.
- Persist richer gas metadata with rebalance events by extending types and history recording to include `gasFeeXlm`, `gasFeeUsd`, `gasPerTradeXlm`, `gasWarning`, and `gasBreakdown` and thread these into `RebalanceHistoryService` and event payloads.
- Frontend: add `useRebalanceEstimate` query, wire the `PORTFOLIO_REBALANCE_ESTIMATE` endpoint, invalidate the estimate after executing a rebalance, show the estimate in the Dashboard as `Estimated gas: X XLM (~$Y)` with a warning when > `0.5 XLM`, and display a per-trade breakdown; update `RebalanceHistory` UI to surface USD, per-trade fee, warning and breakdown rows (demo data also updated).

### Testing

- Ran `npm --prefix backend run build` and TypeScript build for backend succeeded (passed).
- Ran the frontend targeted unit tests: `npm --prefix frontend run test -- src/components/RebalanceHistory.test.tsx` and the test file passed (3 tests passed).
- Attempted `npm --prefix frontend run build` but the full frontend build failed due to a pre-existing parse error in `src/components/PortfolioSetup.tsx` unrelated to these changes, so full frontend build did not complete.

------
