### PR TITLE
fix: stop swallowing auth login failures during wallet connect and reconnect

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,13 +31,43 @@ function App() {
         }
     }
 
+    /**
+     * Returns true when the authLogin error is a soft/infrastructure failure
+     * (e.g. JWT not configured on the server) that should not block the user.
+     * All other failures are hard auth errors that must be surfaced.
+     */
+    const isAuthServiceUnavailable = (err: unknown): boolean => {
+        const msg = String((err as any)?.message ?? '')
+        return (
+            msg.includes('503') ||
+            msg.toLowerCase().includes('service_unavailable') ||
+            msg.toLowerCase().includes('not configured')
+        )
+    }
+
     const checkWalletConnection = async () => {
         try {
             const pk = await walletManager.reconnect()
             if (pk) {
                 const accepted = await checkConsent(pk)
                 if (accepted) {
-                    try { await authLogin(pk) } catch (_) {}
+                    try {
+                        await authLogin(pk)
+                    } catch (authErr: unknown) {
+                        if (isAuthServiceUnavailable(authErr)) {
+                            // Auth service not configured – soft fail, allow access.
+                            console.warn('Auth service unavailable during reconnect; proceeding without JWT:', authErr)
+                        } else {
+                            // Hard auth failure: wallet is reconnected but the backend
+                            // rejected authentication.  Do NOT navigate to the dashboard.
+                            console.error('Auth login failed during wallet reconnect:', authErr)
+                            setError(
+                                'Wallet reconnected but authentication failed. ' +
+                                'Please reconnect your wallet to try again.'
+                            )
+                            return
+                        }
+                    }
                     setPublicKey(pk)
                     setCurrentView('dashboard')
                 } else {
@@ -45,8 +75,19 @@ function App() {
                     setPendingConsentPublicKey(pk)
                 }
             }
-        } catch (err) {
-            console.error('Error checking wallet connection:', err)
+        } catch (err: unknown) {
+            // Reconnect itself failed – surface a clear message instead of
+            // swallowing the error.
+            console.error('Wallet reconnect failed:', err)
+            if (err instanceof WalletError) {
+                if (err.code === 'USER_DECLINED') {
+                    setError('Wallet reconnect was declined. Please approve in your wallet.')
+                } else {
+                    setError('Failed to reconnect wallet. Please try connecting again.')
+                }
+            } else {
+                setError('Failed to reconnect wallet. Please try connecting again.')
+            }
         }
     }
 
@@ -56,7 +97,24 @@ function App() {
         try {
             const pk = walletManager.getPublicKey()
             if (pk) {
-                try { await authLogin(pk) } catch (_) {}
+                try {
+                    await authLogin(pk)
+                } catch (authErr: unknown) {
+                    if (isAuthServiceUnavailable(authErr)) {
+                        // Auth service not configured – soft fail, allow access.
+                        console.warn('Auth service unavailable during connect; proceeding without JWT:', authErr)
+                    } else {
+                        // Hard auth failure: wallet is connected but the backend
+                        // rejected authentication.  Do NOT navigate to the dashboard.
+                        console.error('Auth login failed during wallet connect:', authErr)
+                        setError(
+                            'Wallet connected but authentication failed. ' +
+                            'Please try reconnecting your wallet.'
+                        )
+                        setIsConnecting(false)
+                        return
+                    }
+                }
                 setPublicKey(pk)
                 setCurrentView('dashboard')
             } else {


### PR DESCRIPTION


## Problem

`frontend/src/App.tsx` had two places where `authLogin(pk)` failures were silently swallowed:

```ts
// checkWalletConnection
try { await authLogin(pk) } catch (_) {}
setPublicKey(pk)
setCurrentView('dashboard')   // ← reached even when auth failed

// connectWallet
try { await authLogin(pk) } catch (_) {}
setPublicKey(pk)
setCurrentView('dashboard')   // ← same issue
```

This left the UI in a misleading "partially authenticated" dashboard state when auth genuinely failed, and the outer `catch` in `checkWalletConnection` only called `console.error`, hiding reconnect errors from users entirely.

## Changes

- **Hard auth failures** (any backend error that is _not_ a 503 / "not configured") now set a user-facing error message and return early — the app **does not navigate to the dashboard**.
- **Soft/infra failures** (503 SERVICE_UNAVAILABLE — JWT not configured on the server) are logged as a warning and treated as a pass-through, preserving existing dev-environment behaviour.
- **Reconnect failures** (`walletManager.reconnect()` throws) are now surfaced to the user with a descriptive message, including differentiation for `USER_DECLINED`.
- A small `isAuthServiceUnavailable()` helper centralises the 503 detection so both paths stay consistent.

Closes #183

## Acceptance criteria

- [x] UI does not enter dashboard state after a silent auth failure
- [x] Users get a clear error when wallet auth fails
- [x] Reconnect failures are surfaced (no longer only `console.error`)
- [x] `USER_DECLINED` during reconnect shows its own message
- [x] 503 / unconfigured-auth environments continue to work as before