### PR TITLE
test(backend): expand consent and privacy integration coverage

### DIFF
--- a/backend/src/test/consentPrivacy.integration.test.ts
+++ b/backend/src/test/consentPrivacy.integration.test.ts
@@ -26,6 +26,7 @@ beforeAll(async () => {
     process.env.RATE_LIMIT_WRITE_MAX = '100'
     process.env.RATE_LIMIT_WRITE_BURST_MAX = '200'
     process.env.RATE_LIMIT_BURST_MAX = '200'
+    process.env.RATE_LIMIT_AUTH_MAX = '100'
 
     const express = (await import('express')).default
     const cors = (await import('cors')).default
@@ -63,6 +64,11 @@ describe('consent and privacy API', () => {
     it('GET /api/consent/status returns 400 when userId is missing', async () => {
         const res = await request(app).get('/api/consent/status').expect(400)
         expect(res.body.success).toBe(false)
+        expect(res.body.error?.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('GET /api/consent/status returns 400 when userId is empty', async () => {
+        const res = await request(app).get('/api/consent/status').query({ userId: '' }).expect(400)
         expect(res.body.error?.code).toBe('VALIDATION_ERROR')
     })
 
@@ -106,6 +112,28 @@ describe('consent and privacy API', () => {
         expect(res.body.error?.code).toBe('VALIDATION_ERROR')
     })
 
+    it('POST /api/consent returns 400 for empty JSON body', async () => {
+        const res = await request(app).post('/api/consent').send({}).expect(400)
+        expect(res.body.error?.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('POST /api/consent returns 400 when userId is empty string', async () => {
+        const res = await request(app)
+            .post('/api/consent')
+            .send({ userId: '', terms: true, privacy: true, cookies: true })
+            .expect(400)
+        expect(res.body.error?.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('POST /api/consent returns 400 when terms, privacy, or cookies are omitted', async () => {
+        const userId = `GOMIT${Math.random().toString(36).slice(2, 12)}`
+        const res = await request(app)
+            .post('/api/consent')
+            .send({ userId, terms: true, privacy: true })
+            .expect(400)
+        expect(res.body.error?.code).toBe('VALIDATION_ERROR')
+    })
+
     it('POST /api/consent returns 400 when boolean fields are not booleans', async () => {
         const userId = `GINVALID${Math.random().toString(36).slice(2, 12)}`
         const res = await request(app)
@@ -139,6 +167,15 @@ describe('consent and privacy API', () => {
     it('DELETE /api/user/:address/data returns 401 without Authorization when JWT is required', async () => {
         const userId = `GNOAUTH${Math.random().toString(36).slice(2, 12)}`
         const res = await request(app).delete(`/api/user/${userId}/data`).expect(401)
+        expect(res.body.error?.code).toBe('UNAUTHORIZED')
+    })
+
+    it('DELETE /api/user/:address/data returns 401 for invalid access token', async () => {
+        const userId = `GINVJWT${Math.random().toString(36).slice(2, 12)}`
+        const res = await request(app)
+            .delete(`/api/user/${userId}/data`)
+            .set('Authorization', 'Bearer not.a.valid.jwt')
+            .expect(401)
         expect(res.body.error?.code).toBe('UNAUTHORIZED')
     })
 
@@ -192,5 +229,64 @@ describe('consent and privacy API', () => {
             .send({ refreshToken })
             .expect(401)
         expect(refreshAfter.body.error?.code).toBe('UNAUTHORIZED')
+    })
+
+    it('POST /api/auth/refresh returns 400 when refreshToken is missing', async () => {
+        const res = await request(app).post('/api/auth/refresh').send({}).expect(400)
+        expect(res.body.error?.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('POST /api/auth/refresh returns 400 when refreshToken is not a string', async () => {
+        const res = await request(app).post('/api/auth/refresh').send({ refreshToken: 12345 }).expect(400)
+        expect(res.body.error?.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('after DELETE user data, all issued refresh tokens for that user are rejected', async () => {
+        const userId = `GMULTIRT${Math.random().toString(36).slice(2, 10)}`
+        const { issueTokens, generateAccessToken } = await import('../services/authService.js')
+        const first = await issueTokens(userId)
+        const second = await issueTokens(userId)
+        const rt1 = first.refreshToken
+        const rt2 = second.refreshToken
+        expect(rt1).toBeTruthy()
+        expect(rt2).toBeTruthy()
+        expect(rt1).not.toBe(rt2)
+
+        await request(app)
+            .delete(`/api/user/${userId}/data`)
+            .set('Authorization', `Bearer ${generateAccessToken(userId)}`)
+            .expect(200)
+
+        for (const token of [rt1, rt2]) {
+            const out = await request(app).post('/api/auth/refresh').send({ refreshToken: token }).expect(401)
+            expect(out.body.error?.code).toBe('UNAUTHORIZED')
+        }
+    })
+
+    it('after DELETE user data, consent can be recorded again and status shows accepted', async () => {
+        const userId = `GRECONSENT${Math.random().toString(36).slice(2, 10)}`
+        await request(app)
+            .post('/api/consent')
+            .send({ userId, terms: true, privacy: true, cookies: true })
+            .expect(200)
+        let status = await request(app).get('/api/consent/status').query({ userId }).expect(200)
+        expect(status.body.data.accepted).toBe(true)
+
+        const { generateAccessToken } = await import('../services/authService.js')
+        await request(app)
+            .delete(`/api/user/${userId}/data`)
+            .set('Authorization', `Bearer ${generateAccessToken(userId)}`)
+            .expect(200)
+
+        status = await request(app).get('/api/consent/status').query({ userId }).expect(200)
+        expect(status.body.data.accepted).toBe(false)
+
+        await request(app)
+            .post('/api/consent')
+            .send({ userId, terms: true, privacy: true, cookies: true })
+            .expect(200)
+        status = await request(app).get('/api/consent/status').query({ userId }).expect(200)
+        expect(status.body.data.accepted).toBe(true)
+        expect(status.body.data.termsAcceptedAt).toBeTruthy()
     })
 })


### PR DESCRIPTION
## Summary

Extends **integration tests** for consent and privacy flows so regressions in validation, ownership, and post-delete behavior are caught in CI.

## What changed

- **`GET /api/consent/status`:** assert `400` when `userId` is empty.
- **`POST /api/consent`:** assert `400` for empty body, empty `userId`, and omitted `terms` / `privacy` / `cookies`.
- **`DELETE /api/user/:address/data`:** assert `401` for an invalid Bearer access token (in addition to existing 401/403 cases).
- **`POST /api/auth/refresh`:** assert `400` when `refreshToken` is missing or not a string.
- **Post-delete:** after erasure, **all** refresh tokens for that user are rejected (`401`); consent can be **recorded again** and status shows accepted.
- **Test harness:** set `RATE_LIMIT_AUTH_MAX` high in this suite so login/refresh assertions are not flaky under the default auth rate limit.

## Scope

Test-only change in `backend/src/test/consentPrivacy.integration.test.ts` — no API behavior changes.

fixes #195