### PR TITLE
refactor(backend): split index startup into startup modules

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,46 +1,15 @@
 import 'dotenv/config'
-import express from 'express'
-import cors from 'cors'
 import { validateStartupConfigOrThrow, buildStartupSummary } from './config/startupConfig.js'
 import { logger } from './utils/logger.js'
-import { portfolioRouter } from './api/routes.js'
-import { authRouter } from './api/authRoutes.js'
-import { apiErrorHandler } from './middleware/apiErrorHandler.js'
-import { requestContextMiddleware } from './middleware/requestContext.js'
-import { startQueueScheduler } from './queue/scheduler.js'
+import { createApp } from './startup/appFactory.js'
+import { createHttpServer } from './startup/httpServer.js'
+import { startQueueSchedulerOnListen } from './startup/workers.js'
 
 const config = validateStartupConfigOrThrow()
+const app = createApp(config)
+const server = createHttpServer(app)
 
-const app = express()
-
-const corsOptions: cors.CorsOptions = {
-    origin: config.corsOrigins.length > 0 ? config.corsOrigins : true,
-    credentials: true,
-    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH', 'HEAD'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'Accept', 'Origin', 'X-Requested-With', 'X-Request-Id']
-}
-
-app.use(cors(corsOptions))
-app.options('*', cors(corsOptions))
-
-app.use(requestContextMiddleware)
-app.use(express.json({ limit: '10mb' }))
-app.use(express.urlencoded({ extended: true, limit: '10mb' }))
-app.set('trust proxy', 1)
-
-/** Plain-text liveness for load balancers, curl, and frontend clients using GET /health on the API host. */
-app.get('/health', (_req, res) => {
-    res.status(200).type('text/plain').send('ok')
-})
-
-app.use('/api', portfolioRouter)
-app.use('/api/auth', authRouter)
-
-app.use(apiErrorHandler)
-
-app.listen(config.port, () => {
+server.listen(config.port, () => {
     logger.info('[SERVER] Listening', buildStartupSummary(config) as Record<string, unknown>)
-    void startQueueScheduler().catch((err: unknown) => {
-        logger.warn('[SERVER] Queue scheduler did not start', { error: String(err) })
-    })
+    startQueueSchedulerOnListen()
 })

--- a/backend/src/startup/appFactory.ts
+++ b/backend/src/startup/appFactory.ts
@@ -1,0 +1,11 @@
+import express, { type Express } from 'express'
+import type { StartupConfig } from '../config/startupConfig.js'
+import { applyCoreMiddleware } from './middleware.js'
+import { registerHttpRoutes } from './routes.js'
+
+export function createApp(config: StartupConfig): Express {
+    const app = express()
+    applyCoreMiddleware(app, config)
+    registerHttpRoutes(app)
+    return app
+}

--- a/backend/src/startup/httpServer.ts
+++ b/backend/src/startup/httpServer.ts
@@ -1,0 +1,6 @@
+import http from 'node:http'
+import type { Express } from 'express'
+
+export function createHttpServer(app: Express): http.Server {
+    return http.createServer(app)
+}

--- a/backend/src/startup/middleware.ts
+++ b/backend/src/startup/middleware.ts
@@ -1,0 +1,32 @@
+import type { Express } from 'express'
+import express from 'express'
+import cors from 'cors'
+import type { StartupConfig } from '../config/startupConfig.js'
+import { requestContextMiddleware } from '../middleware/requestContext.js'
+
+export function buildCorsOptions(config: StartupConfig): cors.CorsOptions {
+    return {
+        origin: config.corsOrigins.length > 0 ? config.corsOrigins : true,
+        credentials: true,
+        methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH', 'HEAD'],
+        allowedHeaders: [
+            'Content-Type',
+            'Authorization',
+            'Accept',
+            'Origin',
+            'X-Requested-With',
+            'X-Request-Id'
+        ]
+    }
+}
+
+export function applyCoreMiddleware(app: Express, config: StartupConfig): void {
+    const corsOptions = buildCorsOptions(config)
+    app.use(cors(corsOptions))
+    app.options('*', cors(corsOptions))
+
+    app.use(requestContextMiddleware)
+    app.use(express.json({ limit: '10mb' }))
+    app.use(express.urlencoded({ extended: true, limit: '10mb' }))
+    app.set('trust proxy', 1)
+}

--- a/backend/src/startup/routes.ts
+++ b/backend/src/startup/routes.ts
@@ -1,0 +1,15 @@
+import type { Express } from 'express'
+import { portfolioRouter } from '../api/routes.js'
+import { authRouter } from '../api/authRoutes.js'
+import { apiErrorHandler } from '../middleware/apiErrorHandler.js'
+
+export function registerHttpRoutes(app: Express): void {
+    app.get('/health', (_req, res) => {
+        res.status(200).type('text/plain').send('ok')
+    })
+
+    app.use('/api', portfolioRouter)
+    app.use('/api/auth', authRouter)
+
+    app.use(apiErrorHandler)
+}

--- a/backend/src/startup/workers.ts
+++ b/backend/src/startup/workers.ts
@@ -1,0 +1,8 @@
+import { startQueueScheduler } from '../queue/scheduler.js'
+import { logger } from '../utils/logger.js'
+
+export function startQueueSchedulerOnListen(): void {
+    void startQueueScheduler().catch((err: unknown) => {
+        logger.warn('[SERVER] Queue scheduler did not start', { error: String(err) })
+    })
+}


### PR DESCRIPTION
## Summary

Splits backend server startup out of `backend/src/index.ts` into focused modules under `backend/src/startup/` so the entrypoint only orchestrates config, app creation, HTTP server, listen, and background workers.

## Changes

- **`startup/middleware.ts`** — CORS options and core Express middleware (`requestContext`, JSON/body limits, `trust proxy`).
- **`startup/routes.ts`** — Root `/health`, `/api` + `/api/auth` mounts, `apiErrorHandler`.
- **`startup/appFactory.ts`** — `createApp(config)` composes middleware + routes (usable in tests without binding a port).
- **`startup/httpServer.ts`** — `http.createServer(app)` for a shared `http.Server` (e.g. future WebSocket attachment).
- **`startup/workers.ts`** — Queue scheduler startup after listen (same behavior and error handling as before).
- **`index.ts`** — Thin orchestration only.

## Behavior

No intentional runtime or API behavior changes; `npm run build` and `npm test` pass in `backend/`.

fixes #200 