### PR TITLE
feat: expand idempotency coverage to consent, admin asset endpoints

### DIFF
--- a/API.md
+++ b/API.md
@@ -51,6 +51,54 @@ Error responses:
 }
 ```
 
+## Idempotency
+
+Select write endpoints support the `Idempotency-Key` request header. When provided, the server stores the response of the first successful call and returns the same response for any subsequent request that carries the same key, preventing duplicate side effects from client retries.
+
+### How it works
+
+1. Include an `Idempotency-Key` header (1–255 characters, e.g. a UUID) on any supported `POST` or `PATCH` request.
+2. On the **first** call the server processes the request normally and caches the response (TTL: 24 hours).
+3. On any **repeat** call with the same key _and identical body_, the server returns the cached response with an `Idempotency-Replayed: true` header — no side effects are triggered again.
+4. If the same key is reused with a **different body**, the server returns `409 CONFLICT`.
+
+### Conflict handling
+
+| Scenario | HTTP Status | Error code |
+|----------|-------------|------------|
+| Same key, same body (retry) | Cached status | — (`Idempotency-Replayed: true`) |
+| Same key, different body | `409` | `CONFLICT` |
+| Key is empty or > 255 chars | `400` | `VALIDATION_ERROR` |
+
+### Supported endpoints
+
+| Method | Path | Notes |
+|--------|------|-------|
+| `POST` | `/api/consent` | Consent recording — replay is safe; double-submit has no additional effect |
+| `POST` | `/api/portfolio` | Portfolio creation — prevents duplicate portfolios on retry |
+| `POST` | `/api/portfolio/:id/rebalance` | Rebalance execution — prevents double-execution on retry |
+| `POST` | `/api/rebalance/history` | Rebalance event recording — prevents duplicate history entries |
+| `POST` | `/api/notifications/subscribe` | Notification subscription — idempotent preference upsert |
+| `POST` | `/api/admin/assets` | Asset registry — prevents duplicate asset creation on retry |
+| `PATCH` | `/api/admin/assets/:symbol` | Asset enable/disable — safe to replay the same state change |
+
+### Example
+
+```http
+POST /api/consent
+Content-Type: application/json
+Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000
+
+{
+  "userId": "GABC...",
+  "terms": true,
+  "privacy": true,
+  "cookies": true
+}
+```
+
+A retry with the same `Idempotency-Key` and body returns the cached `200` response immediately. A retry with a different body returns `409 CONFLICT`.
+
 ## Endpoints overview
 
 ### Health and info
@@ -60,18 +108,18 @@ Error responses:
 
 ### Portfolio
 
-- **POST /api/portfolio** — Create portfolio (`userAddress`, `allocations`, `threshold`, optional `slippageTolerance`). Allocations must sum to 100%; threshold 1–50%.
+- **POST /api/portfolio** — Create portfolio (`userAddress`, `allocations`, `threshold`, optional `slippageTolerance`). Allocations must sum to 100%; threshold 1–50%. Supports `Idempotency-Key`.
 - **GET /api/portfolio/{id}** — Get portfolio by ID.
 - **GET /api/user/{address}/portfolios** — List portfolios for a Stellar address.
 - **GET /api/portfolio/{id}/rebalance-plan** — Get rebalance plan (total value, slippage, prices).
-- **POST /api/portfolio/{id}/rebalance** — Execute rebalance (body optional: `{ options: { simulateOnly, ignoreSafetyChecks, slippageOverrides } }`).
+- **POST /api/portfolio/{id}/rebalance** — Execute rebalance (body optional: `{ options: { simulateOnly, ignoreSafetyChecks, slippageOverrides } }`). Supports `Idempotency-Key`.
 - **GET /api/portfolio/{id}/analytics** — Analytics time series (query: `days`, default 30).
 - **GET /api/portfolio/{id}/performance-summary** — Performance summary.
 
 ### Rebalance history
 
 - **GET /api/rebalance/history** — List rebalance events (query: `portfolioId`, `limit`, `source`, `startTimestamp`, `endTimestamp`, `syncOnChain`).
-- **POST /api/rebalance/history** — Record a rebalance event (idempotent).
+- **POST /api/rebalance/history** — Record a rebalance event. Supports `Idempotency-Key`.
 - **POST /api/rebalance/history/sync-onchain** — Sync on-chain rebalance history (admin).
 
 ### Risk
@@ -101,7 +149,7 @@ Error responses:
 
 ### Notifications
 
-- **POST /api/notifications/subscribe** — Subscribe (userId, email/webhook, events).
+- **POST /api/notifications/subscribe** — Subscribe (userId, email/webhook, events). Supports `Idempotency-Key`.
 - **GET /api/notifications/preferences** — Get preferences (query: `userId`).
 - **DELETE /api/notifications/unsubscribe** — Unsubscribe (query: `userId`).
 

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -88,7 +88,7 @@ router.get('/consent/status', (req: Request, res: Response) => {
 })
 
 /** Record user acceptance of ToS, Privacy Policy, Cookie Policy. */
-router.post('/consent', ...protectedWriteLimiter, (req: Request, res: Response) => {
+router.post('/consent', ...protectedWriteLimiter, idempotencyMiddleware, (req: Request, res: Response) => {
     try {
         const { userId, terms, privacy, cookies } = req.body ?? {}
         if (!userId || typeof userId !== 'string') return fail(res, 400, 'VALIDATION_ERROR', 'userId is required')
@@ -175,7 +175,7 @@ router.get('/admin/rate-limits/metrics', requireAdmin, (_req: Request, res: Resp
 })
 
 /** Admin: add asset */
-router.post('/admin/assets', requireAdmin, adminRateLimiter, async (req: Request, res: Response) => {
+router.post('/admin/assets', requireAdmin, adminRateLimiter, idempotencyMiddleware, async (req: Request, res: Response) => {
     try {
         const { symbol, name, contractAddress, issuerAccount, coingeckoId } = req.body ?? {}
         assetRegistryService.add(
@@ -245,7 +245,7 @@ router.delete('/admin/assets/:symbol', requireAdmin, adminRateLimiter, async (re
 })
 
 /** Admin: enable/disable asset */
-router.patch('/admin/assets/:symbol', requireAdmin, async (req: Request, res: Response) => {
+router.patch('/admin/assets/:symbol', requireAdmin, adminRateLimiter, idempotencyMiddleware, async (req: Request, res: Response) => {
     try {
         const symbol = req.params.symbol
         const enabled = req.body?.enabled


### PR DESCRIPTION
Closes #203

## Problem

Three retryable write endpoints lacked `Idempotency-Key` support, leaving clients with no safe way to retry on flaky networks without risking duplicate side effects.

## Changes

### New idempotency coverage

| Endpoint | Why it's safe |
|----------|---------------|
| `POST /api/consent` | Consent recording is naturally idempotent — replaying the same acceptance payload has no additional effect |
| `POST /api/admin/assets` | Prevents duplicate asset creation on network retry |
| `PATCH /api/admin/assets/:symbol` | Toggling the same `enabled` state twice is idempotent |

The `PATCH /admin/assets/:symbol` route also gains the `adminRateLimiter` it was missing (every other admin mutation route already carries it).

### Existing coverage (unchanged)

- `POST /api/portfolio`
- `POST /api/portfolio/:id/rebalance`
- `POST /api/rebalance/history`
- `POST /api/notifications/subscribe`

### Intentionally excluded

| Endpoint | Reason |
|----------|--------|
| `DELETE` routes | HTTP DELETEs are already idempotent at the protocol level |
| `POST /auto-rebalancer/force-check` | Triggers live rebalance side effects — unsafe to replay |
| `POST /rebalance/history/sync-onchain` | Triggers on-chain sync — unsafe to replay |

### Documentation (`API.md`)

Added a full **Idempotency** section covering:
- How the header works (first call processed, subsequent retries return cached response)
- TTL (24 hours)
- Conflict handling (409 when same key is reused with a different body)
- Complete table of all 7 supported endpoints with notes
- Worked example with HTTP snippet

## Test plan

- [ ] `POST /api/consent` with an `Idempotency-Key` twice with the same body → second response has `Idempotency-Replayed: true`, no duplicate DB record
- [ ] `POST /api/consent` same key, different body → `409 CONFLICT`
- [ ] `POST /api/admin/assets` with `Idempotency-Key` → same asset not duplicated on retry
- [ ] `PATCH /api/admin/assets/:symbol` with `Idempotency-Key` → second call replays cached response
- [ ] All previously covered endpoints unaffected