### PR TITLE
Enforce portfolio export ownership checks

### DIFF
--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -413,6 +413,11 @@ router.get('/portfolio/:id/export', requireJwtWhenEnabled, async (req: Request, 
         if (!['json', 'csv', 'pdf'].includes(format)) {
             return fail(res, 400, 'VALIDATION_ERROR', 'Query parameter format must be one of: json, csv, pdf')
         }
+        const portfolio = await portfolioStorage.getPortfolio(portfolioId)
+        if (!portfolio) return fail(res, 404, 'NOT_FOUND', 'Portfolio not found')
+        if (req.user && portfolio.userAddress !== req.user.address) {
+            return fail(res, 403, 'FORBIDDEN', 'You can only export your own portfolio')
+        }
         const result = await getPortfolioExport(portfolioId, format as 'json' | 'csv' | 'pdf')
         if (!result) return fail(res, 404, 'NOT_FOUND', 'Portfolio not found')
         res.setHeader('Content-Type', result.contentType)

--- a/backend/src/test/consentPrivacy.integration.test.ts
+++ b/backend/src/test/consentPrivacy.integration.test.ts
@@ -258,6 +258,62 @@ describe('consent and privacy API', () => {
         expect(portfoliosRes.body.data.portfolios.every((p: any) => p.userAddress === userId)).toBe(true)
     })
 
+    it('GET /api/portfolio/:id/export allows authenticated owner export', async () => {
+        const { generateAccessToken } = await import('../services/authService.js')
+        const owner = `GOWNEREXP${Math.random().toString(36).slice(2, 10)}`
+
+        const createRes = await request(app)
+            .post('/api/portfolio')
+            .send({
+                userAddress: owner,
+                allocations: { XLM: 60, USDC: 40 },
+                threshold: 5
+            })
+        expect([200, 201]).toContain(createRes.status)
+        const portfolioId = (createRes.body?.data?.portfolioId ?? createRes.body?.portfolioId) as string
+        expect(portfolioId).toBeTruthy()
+
+        const token = generateAccessToken(owner)
+        const exportRes = await request(app)
+            .get(`/api/portfolio/${portfolioId}/export`)
+            .query({ format: 'json' })
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200)
+
+        expect(exportRes.headers['content-type']).toContain('application/json')
+        expect(exportRes.headers['content-disposition']).toContain('attachment; filename=')
+        const payload = JSON.parse(exportRes.text)
+        expect(payload.portfolioId).toBe(portfolioId)
+        expect(payload.portfolio.userAddress).toBe(owner)
+        expect(payload.meta?.purpose).toBe('GDPR data export')
+    })
+
+    it('GET /api/portfolio/:id/export returns 403 for authenticated non-owner', async () => {
+        const { generateAccessToken } = await import('../services/authService.js')
+        const owner = `GOWNERVICT${Math.random().toString(36).slice(2, 10)}`
+        const attacker = `GATTACKER${Math.random().toString(36).slice(2, 10)}`
+
+        const createRes = await request(app)
+            .post('/api/portfolio')
+            .send({
+                userAddress: owner,
+                allocations: { XLM: 55, USDC: 45 },
+                threshold: 5
+            })
+        expect([200, 201]).toContain(createRes.status)
+        const portfolioId = (createRes.body?.data?.portfolioId ?? createRes.body?.portfolioId) as string
+        expect(portfolioId).toBeTruthy()
+
+        const token = generateAccessToken(attacker)
+        const res = await request(app)
+            .get(`/api/portfolio/${portfolioId}/export`)
+            .query({ format: 'json' })
+            .set('Authorization', `Bearer ${token}`)
+            .expect(403)
+
+        expect(res.body.error?.code).toBe('FORBIDDEN')
+    })
+
     it('after DELETE user data, refresh token is rejected', async () => {
         const userId = `GREFRESH${Math.random().toString(36).slice(2, 12)}`
         const loginRes = await request(app).post('/api/auth/login').send({ address: userId }).expect(200)


### PR DESCRIPTION
closes #193 

Summary
enforce owner-only access for GET /api/portfolio/:id/export
load portfolio before export and compare portfolio.userAddress with req.user.address
return 403 FORBIDDEN for authenticated non-owners
add integration tests for owner export success and non-owner rejection

Validation
npm test -- src/test/consentPrivacy.integration.test.ts
confirms export owner/non-owner access behavior
Privacy/GDPR
export endpoint now defaults to privacy-safe behavior by preventing cross-user exports
