### PR TITLE
feat: admin/ws tests, logout-all security fix, contributor guide

### DIFF
--- a/backend/src/api/authRoutes.ts
+++ b/backend/src/api/authRoutes.ts
@@ -71,13 +71,14 @@ router.post('/logout', requireJwt, async (req: Request, res: Response) => {
     }
 })
 
-router.post('/logout-all', authRateLimiter, async (req: Request, res: Response) => {
+router.post('/logout-all', requireJwt, async (req: Request, res: Response) => {
     try {
-        const address = req.body?.address
-        if (!address || typeof address !== 'string') {
-            return fail(res, 400, 'VALIDATION_ERROR', 'address is required')
+        const address = req.user!.address
+        const bodyAddress = req.body?.address
+        if (bodyAddress && typeof bodyAddress === 'string' && bodyAddress.trim() !== address) {
+            return fail(res, 403, 'FORBIDDEN', 'Address mismatch')
         }
-        await logout(undefined, address.trim())
+        await logout(undefined, address)
         return ok(res, { message: 'Logged out' })
     } catch (error) {
         return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))

--- a/backend/src/test/adminRoutes.test.ts
+++ b/backend/src/test/adminRoutes.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import express, { Express } from 'express'
+import request from 'supertest'
+import { Keypair } from '@stellar/stellar-sdk'
+import { mkdirSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+function makeAdminHeaders(kp: Keypair) {
+    const msg = Date.now().toString()
+    const sig = kp.sign(Buffer.from(msg, 'utf8')).toString('base64')
+    return {
+        'x-public-key': kp.publicKey(),
+        'x-message': msg,
+        'x-signature': sig,
+    }
+}
+
+// ─── No ADMIN_PUBLIC_KEYS configured ─────────────────────────────────────────
+
+describe('Admin routes – no ADMIN_PUBLIC_KEYS configured', () => {
+    it('returns 503 on any admin route when keys are not set', async () => {
+        vi.stubEnv('ADMIN_PUBLIC_KEYS', '')
+        vi.resetModules()
+        const { requireAdmin } = await import('../middleware/auth.js')
+        const app = express()
+        app.get('/test', requireAdmin, (_req, res) => res.json({ ok: true }))
+        const res = await request(app).get('/test')
+        expect(res.status).toBe(503)
+        vi.unstubAllEnvs()
+    })
+})
+
+// ─── Auth protection on admin asset + metrics routes ─────────────────────────
+
+describe('Admin routes – unauthenticated, non-admin, and admin access', () => {
+    let app: Express
+    let adminKp: Keypair
+    let nonAdminKp: Keypair
+    let testDbPath: string
+
+    beforeAll(async () => {
+        adminKp = Keypair.random()
+        nonAdminKp = Keypair.random()
+        vi.stubEnv('ADMIN_PUBLIC_KEYS', adminKp.publicKey())
+        vi.resetModules()
+
+        const testDir = join(tmpdir(), `admin-routes-test-${Date.now()}`)
+        mkdirSync(testDir, { recursive: true })
+        testDbPath = join(testDir, 'test.db')
+        process.env.DB_PATH = testDbPath
+
+        const { portfolioRouter } = await import('../api/routes.js')
+        app = express()
+        app.use(express.json())
+        app.set('trust proxy', 1)
+        app.use('/api', portfolioRouter)
+    })
+
+    afterAll(() => {
+        vi.unstubAllEnvs()
+        if (existsSync(testDbPath)) {
+            try { rmSync(testDbPath, { force: true }) } catch { /* ignore */ }
+        }
+        delete process.env.DB_PATH
+    })
+
+    // ── GET /api/admin/assets ─────────────────────────────────────────────────
+
+    describe('GET /api/admin/assets', () => {
+        it('returns 401 without admin headers', async () => {
+            const res = await request(app).get('/api/admin/assets')
+            expect(res.status).toBe(401)
+        })
+
+        it('returns 403 for a key not in ADMIN_PUBLIC_KEYS', async () => {
+            const res = await request(app)
+                .get('/api/admin/assets')
+                .set(makeAdminHeaders(nonAdminKp))
+            expect(res.status).toBe(403)
+        })
+
+        it('returns 200 for a valid admin key', async () => {
+            const res = await request(app)
+                .get('/api/admin/assets')
+                .set(makeAdminHeaders(adminKp))
+            expect(res.status).toBe(200)
+            expect(res.body.data.assets).toBeDefined()
+        })
+    })
+
+    // ── GET /api/admin/rate-limits/metrics ────────────────────────────────────
+
+    describe('GET /api/admin/rate-limits/metrics', () => {
+        it('returns 401 without admin headers', async () => {
+            const res = await request(app).get('/api/admin/rate-limits/metrics')
+            expect(res.status).toBe(401)
+        })
+
+        it('returns 403 for a key not in ADMIN_PUBLIC_KEYS', async () => {
+            const res = await request(app)
+                .get('/api/admin/rate-limits/metrics')
+                .set(makeAdminHeaders(nonAdminKp))
+            expect(res.status).toBe(403)
+        })
+
+        it('returns 200 for a valid admin key', async () => {
+            const res = await request(app)
+                .get('/api/admin/rate-limits/metrics')
+                .set(makeAdminHeaders(adminKp))
+            expect(res.status).toBe(200)
+            expect(res.body.data.metrics).toBeDefined()
+        })
+    })
+
+    // ── POST /api/admin/assets ────────────────────────────────────────────────
+
+    describe('POST /api/admin/assets', () => {
+        it('returns 401 without admin headers', async () => {
+            const res = await request(app)
+                .post('/api/admin/assets')
+                .send({ symbol: 'TST', name: 'Test' })
+            expect(res.status).toBe(401)
+        })
+
+        it('returns 403 for a key not in ADMIN_PUBLIC_KEYS', async () => {
+            const res = await request(app)
+                .post('/api/admin/assets')
+                .set(makeAdminHeaders(nonAdminKp))
+                .send({ symbol: 'TST', name: 'Test' })
+            expect(res.status).toBe(403)
+        })
+
+        it('passes auth check for a valid admin key', async () => {
+            const res = await request(app)
+                .post('/api/admin/assets')
+                .set({ ...makeAdminHeaders(adminKp), 'Idempotency-Key': `admin-add-${Date.now()}` })
+                .send({ symbol: 'ADMTEST', name: 'Admin Test Asset' })
+            expect([201, 400, 409]).toContain(res.status) // auth passed, business logic decides outcome
+        })
+    })
+
+    // ── DELETE /api/admin/assets/:symbol ─────────────────────────────────────
+
+    describe('DELETE /api/admin/assets/:symbol', () => {
+        it('returns 401 without admin headers', async () => {
+            const res = await request(app).delete('/api/admin/assets/ADMTEST')
+            expect(res.status).toBe(401)
+        })
+
+        it('returns 403 for a key not in ADMIN_PUBLIC_KEYS', async () => {
+            const res = await request(app)
+                .delete('/api/admin/assets/ADMTEST')
+                .set(makeAdminHeaders(nonAdminKp))
+            expect(res.status).toBe(403)
+        })
+
+        it('passes auth check for a valid admin key', async () => {
+            const res = await request(app)
+                .delete('/api/admin/assets/ADMTEST')
+                .set(makeAdminHeaders(adminKp))
+            expect([200, 404]).toContain(res.status) // auth passed, business logic decides outcome
+        })
+    })
+
+    // ── PATCH /api/admin/assets/:symbol ──────────────────────────────────────
+
+    describe('PATCH /api/admin/assets/:symbol', () => {
+        it('returns 401 without admin headers', async () => {
+            const res = await request(app)
+                .patch('/api/admin/assets/XLM')
+                .send({ enabled: true })
+            expect(res.status).toBe(401)
+        })
+
+        it('returns 403 for a key not in ADMIN_PUBLIC_KEYS', async () => {
+            const res = await request(app)
+                .patch('/api/admin/assets/XLM')
+                .set(makeAdminHeaders(nonAdminKp))
+                .send({ enabled: true })
+            expect(res.status).toBe(403)
+        })
+
+        it('passes auth check for a valid admin key', async () => {
+            const res = await request(app)
+                .patch('/api/admin/assets/XLM')
+                .set({ ...makeAdminHeaders(adminKp), 'Idempotency-Key': `admin-patch-${Date.now()}` })
+                .send({ enabled: true })
+            expect([200, 404]).toContain(res.status) // auth passed, business logic decides outcome
+        })
+    })
+})

--- a/backend/src/test/authLogoutAll.test.ts
+++ b/backend/src/test/authLogoutAll.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import express, { Express } from 'express'
+import request from 'supertest'
+
+const failMock = vi.fn()
+const okMock = vi.fn()
+const logoutMock = vi.fn()
+const verifyAccessTokenMock = vi.fn()
+
+vi.mock('../utils/apiResponse.js', () => ({
+    fail: failMock,
+    ok: okMock,
+}))
+
+vi.mock('../services/authService.js', () => ({
+    logout: logoutMock,
+    getAuthConfig: () => ({ enabled: true }),
+    issueTokens: vi.fn(),
+    refreshTokens: vi.fn(),
+    verifyAccessToken: verifyAccessTokenMock,
+}))
+
+async function buildApp(): Promise<Express> {
+    vi.resetModules()
+    const { authRouter } = await import('../api/authRoutes.js')
+    const app = express()
+    app.use(express.json())
+    app.use('/api/auth', authRouter)
+    return app
+}
+
+describe('POST /api/auth/logout-all', () => {
+    let app: Express
+
+    beforeEach(async () => {
+        failMock.mockReset()
+        okMock.mockReset()
+        logoutMock.mockReset()
+        verifyAccessTokenMock.mockReset()
+
+        // Default: make ok/fail write a real response so supertest doesn't hang
+        failMock.mockImplementation((res, status, code, msg) => {
+            res.status(status).json({ success: false, error: { code, message: msg } })
+        })
+        okMock.mockImplementation((res, data) => {
+            res.status(200).json({ success: true, data })
+        })
+
+        app = await buildApp()
+    })
+
+    it('returns 401 when no Authorization header is provided', async () => {
+        verifyAccessTokenMock.mockReturnValue(null)
+
+        const res = await request(app)
+            .post('/api/auth/logout-all')
+            .send({ address: 'GUSER123' })
+
+        expect(res.status).toBe(401)
+        expect(logoutMock).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 when the Bearer token is invalid', async () => {
+        verifyAccessTokenMock.mockReturnValue(null)
+
+        const res = await request(app)
+            .post('/api/auth/logout-all')
+            .set('Authorization', 'Bearer invalid-token')
+            .send({})
+
+        expect(res.status).toBe(401)
+        expect(logoutMock).not.toHaveBeenCalled()
+    })
+
+    it('logs out the authenticated user and returns 200', async () => {
+        const address = 'GOWNER123456789'
+        verifyAccessTokenMock.mockReturnValue({ sub: address, type: 'access' })
+        logoutMock.mockResolvedValue(true)
+
+        const res = await request(app)
+            .post('/api/auth/logout-all')
+            .set('Authorization', 'Bearer valid-token')
+            .send({})
+
+        expect(res.status).toBe(200)
+        expect(logoutMock).toHaveBeenCalledWith(undefined, address)
+    })
+
+    it('uses the JWT address, not the body address', async () => {
+        const jwtAddress = 'GJWT_ADDRESS_123'
+        verifyAccessTokenMock.mockReturnValue({ sub: jwtAddress, type: 'access' })
+        logoutMock.mockResolvedValue(true)
+
+        await request(app)
+            .post('/api/auth/logout-all')
+            .set('Authorization', 'Bearer valid-token')
+            .send({}) // no body address
+
+        expect(logoutMock).toHaveBeenCalledWith(undefined, jwtAddress)
+    })
+
+    it('returns 403 when body address does not match JWT address', async () => {
+        const jwtAddress = 'GOWNER123456789'
+        verifyAccessTokenMock.mockReturnValue({ sub: jwtAddress, type: 'access' })
+
+        const res = await request(app)
+            .post('/api/auth/logout-all')
+            .set('Authorization', 'Bearer valid-token')
+            .send({ address: 'GDIFFERENT_ADDRESS' })
+
+        expect(res.status).toBe(403)
+        expect(logoutMock).not.toHaveBeenCalled()
+    })
+
+    it('accepts a matching body address and logs out successfully', async () => {
+        const address = 'GOWNER123456789'
+        verifyAccessTokenMock.mockReturnValue({ sub: address, type: 'access' })
+        logoutMock.mockResolvedValue(true)
+
+        const res = await request(app)
+            .post('/api/auth/logout-all')
+            .set('Authorization', 'Bearer valid-token')
+            .send({ address })
+
+        expect(res.status).toBe(200)
+        expect(logoutMock).toHaveBeenCalledWith(undefined, address)
+    })
+})

--- a/backend/src/test/websocket.test.ts
+++ b/backend/src/test/websocket.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { WebSocketServer, WebSocket } from 'ws'
+import { createServer } from 'node:http'
+import { initRobustWebSocket } from '../services/websocket.service.js'
+import { PROTOCOL_VERSION } from '../types/websocket.js'
+
+function waitForMessage(ws: WebSocket): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('Message timeout')), 3000)
+        ws.once('message', (data) => {
+            clearTimeout(timer)
+            resolve(JSON.parse(data.toString()))
+        })
+    })
+}
+
+async function createTestServer(): Promise<{ port: number; close: () => Promise<void> }> {
+    const server = createServer()
+    const wss = new WebSocketServer({ server })
+    initRobustWebSocket(wss)
+    return new Promise((resolve) => {
+        server.listen(0, () => {
+            const addr = server.address() as { port: number }
+            resolve({
+                port: addr.port,
+                close: () => new Promise<void>((res) => wss.close(() => server.close(() => res())))
+            })
+        })
+    })
+}
+
+function connectClient(port: number): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+        const ws = new WebSocket(`ws://localhost:${port}`)
+        ws.once('open', () => resolve(ws))
+        ws.once('error', reject)
+    })
+}
+
+describe('WebSocket protocol', () => {
+    let port: number
+    let close: () => Promise<void>
+
+    beforeEach(async () => {
+        ;({ port, close } = await createTestServer())
+    })
+
+    afterEach(async () => {
+        await close()
+    })
+
+    // ── Initial connection message ─────────────────────────────────────────────
+
+    it('sends a connection message immediately on connect', async () => {
+        const ws = await connectClient(port)
+        const msg = await waitForMessage(ws)
+
+        expect(msg.type).toBe('connection')
+        expect(msg.message).toBe('Validation and Monitoring Active')
+        expect(msg.version).toBe(PROTOCOL_VERSION)
+
+        ws.close()
+    })
+
+    // ── PING / PONG ───────────────────────────────────────────────────────────
+
+    it('responds to PING with PONG at the correct protocol version', async () => {
+        const ws = await connectClient(port)
+        await waitForMessage(ws) // connection message
+
+        ws.send(JSON.stringify({ version: PROTOCOL_VERSION, type: 'PING', timestamp: Date.now() }))
+
+        const pong = await waitForMessage(ws)
+        expect(pong.type).toBe('PONG')
+        expect(pong.version).toBe(PROTOCOL_VERSION)
+
+        ws.close()
+    })
+
+    // ── Invalid message rejection ─────────────────────────────────────────────
+
+    it('rejects malformed JSON with an ERROR message', async () => {
+        const ws = await connectClient(port)
+        await waitForMessage(ws) // connection message
+
+        ws.send('this is not json {{{{')
+
+        const err = await waitForMessage(ws)
+        expect(err.type).toBe('ERROR')
+        expect(String(err.payload)).toContain(PROTOCOL_VERSION)
+
+        ws.close()
+    })
+
+    it('rejects a message with an unknown type with an ERROR message', async () => {
+        const ws = await connectClient(port)
+        await waitForMessage(ws) // connection message
+
+        ws.send(JSON.stringify({ version: PROTOCOL_VERSION, type: 'UNKNOWN_TYPE', timestamp: Date.now() }))
+
+        const err = await waitForMessage(ws)
+        expect(err.type).toBe('ERROR')
+
+        ws.close()
+    })
+
+    // ── Protocol version mismatch ─────────────────────────────────────────────
+
+    it('rejects a message with a mismatched protocol version', async () => {
+        const ws = await connectClient(port)
+        await waitForMessage(ws) // connection message
+
+        ws.send(JSON.stringify({ version: '0.0.1', type: 'PING', timestamp: Date.now() }))
+
+        const err = await waitForMessage(ws)
+        expect(err.type).toBe('ERROR')
+        expect(String(err.payload)).toContain(PROTOCOL_VERSION)
+
+        ws.close()
+    })
+
+    it('rejects a message with a missing version field', async () => {
+        const ws = await connectClient(port)
+        await waitForMessage(ws) // connection message
+
+        ws.send(JSON.stringify({ type: 'PING', timestamp: Date.now() }))
+
+        const err = await waitForMessage(ws)
+        expect(err.type).toBe('ERROR')
+
+        ws.close()
+    })
+
+    // ── Heartbeat / stale connection ──────────────────────────────────────────
+
+    it('keeps an active connection open through a heartbeat tick', async () => {
+        vi.useFakeTimers()
+        try {
+            const ws = await connectClient(port)
+            await new Promise<void>((resolve) => ws.once('message', () => resolve()))
+
+            // Advance past the 30 s heartbeat interval
+            await vi.advanceTimersByTimeAsync(30_001)
+
+            expect(ws.readyState).toBe(WebSocket.OPEN)
+            ws.close()
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('terminates a connection that does not respond to pings', async () => {
+        vi.useFakeTimers()
+        try {
+            const ws = await connectClient(port)
+            await new Promise<void>((resolve) => ws.once('message', () => resolve()))
+
+            // Kill the socket so it cannot send pong back to server
+            ws.terminate()
+
+            // First tick: server sets isAlive=false, pings (no pong arrives)
+            await vi.advanceTimersByTimeAsync(30_001)
+            // Second tick: server detects isAlive still false and terminates
+            await vi.advanceTimersByTimeAsync(30_001)
+
+            // Server ran without throwing — stale connection was cleaned up
+            expect(ws.readyState).toBe(WebSocket.CLOSED)
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+})

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,285 @@
+# Contributor Setup Guide
+
+One path to a fully running local stack. Follow each section in order; services marked **optional** can be skipped if you are not working on that area.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Node.js | 18+ | Use [nvm](https://github.com/nvm-sh/nvm) to manage versions |
+| npm | 9+ | Comes with Node 18 |
+| PostgreSQL | 14+ | Optional — SQLite fallback works for most dev work |
+| Redis | 6+ | Optional — queue workers are skipped when unavailable |
+| Rust + Cargo | stable | Only needed for contract development |
+| Soroban CLI | latest | Only needed for contract deployment |
+
+---
+
+## 1. Clone and install
+
+```bash
+git clone https://github.com/your-org/stellar-portfolio-rebalancer.git
+cd stellar-portfolio-rebalancer
+
+# Backend
+cd backend && npm install
+
+# Frontend (separate terminal)
+cd ../frontend && npm install
+```
+
+---
+
+## 2. Backend environment
+
+```bash
+cd backend
+cp .env.example .env
+```
+
+Open `.env` and set at minimum:
+
+```env
+# Stellar
+STELLAR_NETWORK=testnet
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# Auth (required for JWT endpoints — must be ≥32 characters)
+JWT_SECRET=change-me-to-a-random-string-at-least-32-chars
+
+# Admin (comma-separated Stellar public keys allowed to call /admin/* routes)
+ADMIN_PUBLIC_KEYS=G...YOUR_PUBLIC_KEY
+
+# Feature flags (safe defaults for local dev)
+DEMO_MODE=true
+ENABLE_AUTO_REBALANCER=false
+ENABLE_DEBUG_ROUTES=true
+```
+
+All other variables have working defaults for local development.
+
+---
+
+## 3. Database migrations
+
+SQLite is used automatically when `DATABASE_URL` is not set. For PostgreSQL:
+
+```env
+DATABASE_URL=postgresql://user:password@localhost:5432/stellar_portfolio
+```
+
+Run migrations (works for both SQLite and PostgreSQL):
+
+```bash
+cd backend
+npm run db:migrate          # apply all pending migrations
+npm run db:migrate --status # show applied/pending migrations
+npm run db:migrate --dry-run # preview without applying
+```
+
+To roll back the last migration:
+
+```bash
+npm run db:migrate --rollback
+```
+
+Migration files live in `backend/src/db/migrations/`. Add new ones as `NNN_description.up.sql` / `.down.sql`.
+
+---
+
+## 4. Redis and queue workers (optional)
+
+Queue workers (portfolio checks, rebalancing, analytics snapshots) require Redis. If Redis is not running, workers are silently skipped and the API still starts.
+
+```env
+REDIS_URL=redis://localhost:6379
+```
+
+Start Redis locally:
+
+```bash
+# macOS
+brew install redis && brew services start redis
+
+# Linux
+sudo apt install redis-server && sudo systemctl start redis
+
+# Docker
+docker run -d -p 6379:6379 redis:7
+```
+
+Verify:
+
+```bash
+redis-cli ping   # should return PONG
+```
+
+---
+
+## 5. Auth environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `JWT_SECRET` | Yes (≥32 chars) | Signs access and refresh tokens |
+| `JWT_ACCESS_EXPIRY_SEC` | No (default: 900) | Access token TTL in seconds |
+| `JWT_REFRESH_EXPIRY_SEC` | No (default: 604800) | Refresh token TTL in seconds |
+| `ADMIN_PUBLIC_KEYS` | Yes for admin routes | Comma-separated Stellar public keys |
+
+If `JWT_SECRET` is shorter than 32 characters, JWT auth is automatically disabled and `/api/auth/*` routes return `503`.
+
+To generate a strong secret:
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+---
+
+## 6. Notification environment variables (optional)
+
+Email notifications use SMTP. Leave these unset to disable notifications entirely.
+
+```env
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=your-email@gmail.com
+SMTP_PASS=your-app-password
+SMTP_FROM=your-email@gmail.com
+```
+
+For Gmail, use an [App Password](https://myaccount.google.com/apppasswords) instead of your account password. Other supported providers: SendGrid, Mailgun, AWS SES.
+
+Test that notifications are wired up:
+
+```bash
+curl -X POST http://localhost:3001/api/v1/notifications/test \
+  -H "Content-Type: application/json" \
+  -d '{"userId": "YOUR_STELLAR_ADDRESS", "eventType": "rebalance"}'
+```
+
+---
+
+## 7. Start development servers
+
+```bash
+# Terminal 1 — backend (hot reload)
+cd backend && npm run dev
+# → API: http://localhost:3001
+# → WebSocket: ws://localhost:3001
+
+# Terminal 2 — frontend (hot reload)
+cd frontend && npm run dev
+# → UI: http://localhost:3000
+```
+
+Verify the backend is up:
+
+```bash
+curl http://localhost:3001/api/health
+# {"status":"healthy","timestamp":"..."}
+```
+
+---
+
+## 8. Running tests
+
+### Backend unit + integration tests
+
+```bash
+cd backend
+npm test              # run all tests
+npm test -- --watch   # watch mode
+```
+
+Tests use an isolated SQLite database per run (no external dependencies required).
+
+### Frontend unit tests
+
+```bash
+cd frontend
+npm test
+```
+
+### E2E tests (Playwright)
+
+E2E tests require both servers to be running.
+
+```bash
+# Terminal 1
+cd backend && npm run dev
+
+# Terminal 2
+cd frontend && npm run dev
+
+# Terminal 3 — run E2E suite
+cd frontend
+npx playwright install   # first time only — installs browser binaries
+npm run test:e2e
+
+# Run a specific spec
+npx playwright test tests/e2e/auth.spec.ts
+```
+
+Playwright config: `frontend/playwright.config.ts`. Reports are written to `frontend/playwright-report/`.
+
+---
+
+## 9. Contract and indexer setup (optional)
+
+Only needed if you are working on Soroban smart contracts or on-chain event indexing.
+
+### Build contracts
+
+```bash
+cd contracts
+cargo build --target wasm32-unknown-unknown --release
+```
+
+### Deploy to testnet
+
+```bash
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/portfolio_rebalancer.wasm \
+  --source deployer \
+  --network testnet
+```
+
+Copy the returned contract address into `backend/.env`:
+
+```env
+STELLAR_CONTRACT_ADDRESS=C...YOUR_CONTRACT_ADDRESS
+STELLAR_REBALANCE_SECRET=S...YOUR_SIGNING_SECRET
+```
+
+### Contract tests
+
+```bash
+cd contracts
+cargo test
+```
+
+---
+
+## 10. Common setup failures
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `JWT auth not configured (set JWT_SECRET)` | `JWT_SECRET` missing or < 32 chars | Set a valid secret in `.env` |
+| `Admin auth not configured` | `ADMIN_PUBLIC_KEYS` empty | Add your Stellar public key |
+| `503 Service Unavailable` on queue endpoints | Redis not running | Start Redis or set `REDIS_URL` |
+| `ECONNREFUSED` on DB queries | PostgreSQL not running | Start Postgres or remove `DATABASE_URL` to use SQLite |
+| Playwright `net::ERR_CONNECTION_REFUSED` | Dev servers not started | Start backend and frontend before running E2E |
+| `Cannot find module` TypeScript errors | Dependencies not installed | Run `npm install` in backend/ and frontend/ |
+| Stellar horizon errors on contract calls | Wrong network | Check `STELLAR_NETWORK` and `STELLAR_HORIZON_URL` match |
+
+---
+
+## Further reading
+
+- [API reference](API.md)
+- [Database migrations](MIGRATION.md)
+- [Notification system](NOTIFICATIONS.md)
+- [Rebalancing strategies](REBALANCING_STRATEGIES.md)


### PR DESCRIPTION
closes #190  — Admin auth & permission tests
→ [adminRoutes.test.ts](vscode-webview://0bappca7ii1gn1krqtrabqfr37pp2gq72t88hm3veacvn2um9490/stellar-portfolio-rebalancer/backend/src/test/adminRoutes.test.ts)

Tests 503 when ADMIN_PUBLIC_KEYS not configured
Tests 401 (no headers), 403 (wrong key), 200 (valid admin) for all 5 endpoints: GET /admin/assets, GET /admin/rate-limits/metrics, POST /admin/assets, DELETE /admin/assets/:symbol, PATCH /admin/assets/:symbol
closes #199 — WebSocket protocol tests
→ [websocket.test.ts](vscode-webview://0bappca7ii1gn1krqtrabqfr37pp2gq72t88hm3veacvn2um9490/stellar-portfolio-rebalancer/backend/src/test/websocket.test.ts)

Connection message, PING→PONG, invalid JSON rejection, version mismatch, missing version, unknown type, heartbeat keeps alive connections open, stale connection termination
closes #167 — Contributor setup guide
→ [docs/CONTRIBUTING.md](vscode-webview://0bappca7ii1gn1krqtrabqfr37pp2gq72t88hm3veacvn2um9490/stellar-portfolio-rebalancer/docs/CONTRIBUTING.md)

Covers: backend/frontend setup, migrations, Redis/queue, auth env vars, notification env vars, E2E tests, contracts/indexer, common failures table
closes #170 — Secure logout-all
→ [authRoutes.ts](vscode-webview://0bappca7ii1gn1krqtrabqfr37pp2gq72t88hm3veacvn2um9490/stellar-portfolio-rebalancer/backend/src/api/authRoutes.ts) — replaced authRateLimiter with requireJwt, address now resolved from req.user.address, body address validated for mismatch → 403
→ [authLogoutAll.test.ts](vscode-webview://0bappca7ii1gn1krqtrabqfr37pp2gq72t88hm3veacvn2um9490/stellar-portfolio-rebalancer/backend/src/test/authLogoutAll.test.ts) — tests: no token 401, invalid token 401, own address 200, mismatched address 403, matching body address 200Issue #190 — Admin auth & permission tests
→ [adminRoutes.test.ts](vscode-webview://0bappca7ii1gn1krqtrabqfr37pp2gq72t88hm3veacvn2um9490/stellar-portfolio-rebalancer/backend/src/test/adminRoutes.test.ts)

