### PR TITLE
Guard frontend API debug logging by environment

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -124,6 +124,7 @@
             "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -482,6 +483,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -505,6 +507,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1517,6 +1520,7 @@
             "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
             "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@tanstack/query-core": "5.90.20"
             },
@@ -1640,8 +1644,7 @@
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -1782,6 +1785,7 @@
             "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.10.0"
             }
@@ -1799,6 +1803,7 @@
             "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -1810,6 +1815,7 @@
             "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
@@ -2194,14 +2200,6 @@
             "license": "Apache-2.0",
             "optional": true
         },
-        "node_modules/bare-url": {
-
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "bare-path": "^3.0.0"
-            }
-        },
         "node_modules/base32.js": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
@@ -2296,6 +2294,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001737",
                 "electron-to-chromium": "^1.5.211",
@@ -2793,8 +2792,7 @@
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/dom-helpers": {
             "version": "5.2.1",
@@ -3637,6 +3635,7 @@
             "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.2.1",
                 "data-urls": "^5.0.0",
@@ -3760,7 +3759,6 @@
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -4192,6 +4190,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -4328,7 +4327,6 @@
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -4344,7 +4342,6 @@
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4355,7 +4352,6 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4368,8 +4364,7 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
@@ -4439,6 +4434,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -4451,6 +4447,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -4587,6 +4584,16 @@
             },
             "engines": {
                 "bare": ">=1.10.0"
+            }
+        },
+        "node_modules/require-addon/node_modules/bare-url": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+            "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "bare-path": "^3.0.0"
             }
         },
         "node_modules/resolve": {
@@ -5140,6 +5147,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -5362,6 +5370,7 @@
             "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.18.10",
                 "postcss": "^8.4.27",
@@ -5418,6 +5427,7 @@
             "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.0.18",
                 "@vitest/mocker": "4.0.18",
@@ -5957,6 +5967,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6015,6 +6026,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -645,10 +645,9 @@ const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
                         <div className="grid lg:grid-cols-3 gap-6 mb-8">
                             {loading ? (
                                 // Show skeleton cards while loading
-                                [1, 2, 3].map((i) => {
-                                    console.log("Rendering asset card skeleton", i);
-                                    return <AssetCard key={`skeleton-${i}`} isLoading={true} />
-                                })
+                                [1, 2, 3].map((i) => (
+                                    <AssetCard key={`skeleton-${i}`} isLoading={true} />
+                                ))
                             ) : (
                                 // Show actual asset cards when data is loaded
                                 allocationData.map((asset: any, index: number) => (

--- a/frontend/src/config/api.test.ts
+++ b/frontend/src/config/api.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../services/browserPriceService', () => ({
     browserPriceService: {
         getCurrentPrices: vi.fn(),
         testConnection: vi.fn()
     }
+}))
+
+vi.mock('../services/authService', () => ({
+    getAccessToken: vi.fn(() => null),
+    refresh: vi.fn(async () => false)
 }))
 
 describe('apiRequest envelope handling', () => {
@@ -53,6 +58,7 @@ describe('apiRequest envelope handling', () => {
 
         const { apiRequest } = await import('./api')
 
+        await expect(apiRequest('/api/v1/portfolio')).rejects.toMatchObject({
             name: 'ApiClientError',
             status: 409,
             code: 'CONFLICT',

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,5 +1,11 @@
 import { browserPriceService } from '../services/browserPriceService'
 import { getAccessToken, refresh } from '../services/authService'
+import {
+    debugLog,
+    getFrontendDebugConfig,
+    logApiRequest,
+    logApiResponse,
+} from '../utils/debug'
 import { getApiResourceRoot } from './apiVersion'
 
 /** Resolved once at load; see `getApiResourceRoot` and `frontend/src/config/apiVersion.ts`. */
@@ -123,14 +129,13 @@ export function getWebSocketUrl(): string {
     return path.startsWith('/') ? `${base}${path}` : `${base}/${path}`
 }
 
-// Debug logging
 const viteEnv = (import.meta as any).env
-console.log('API Configuration:', {
+debugLog('API Configuration', {
     baseUrl: API_CONFIG.BASE_URL,
     apiResourceRoot: API_RESOURCE_ROOT,
-    isDev: !viteEnv?.PROD,
+    isDev: getFrontendDebugConfig(viteEnv).isDevelopment,
     envApiUrl: viteEnv?.VITE_API_URL,
-    mode: viteEnv?.MODE
+    mode: viteEnv?.MODE,
 })
 
 export const createApiUrl = (endpoint: string, params?: Record<string, string>): string => {
@@ -150,7 +155,7 @@ export const apiRequest = async <T>(
 ): Promise<T> => {
     // Special handling for prices endpoint - use browser service
     if (API_CONFIG.USE_BROWSER_PRICES && endpoint.includes('/prices') && !endpoint.includes('enhanced')) {
-        console.log('Using browser price service instead of backend')
+        debugLog('Using browser price service instead of backend')
         try {
             const prices = await browserPriceService.getCurrentPrices()
             return prices as unknown as T
@@ -195,14 +200,18 @@ export const apiRequest = async <T>(
     defaultOptions.signal = controller.signal
 
     try {
-        console.log(`API Request: ${options.method || 'GET'} ${url}`)
-        console.log('Request headers:', headers)
+        logApiRequest(`API Request: ${options.method || 'GET'} ${url}`, {
+            headers,
+            body: defaultOptions.body,
+        }, viteEnv)
 
         const response = await fetch(url, defaultOptions)
         clearTimeout(timeoutId)
 
-        console.log(`API Response: ${response.status} ${response.statusText}`)
-        console.log('Response headers:', Object.fromEntries(response.headers.entries()))
+        logApiResponse(`API Response: ${response.status} ${response.statusText}`, {
+            status: response.status,
+            headers: response.headers,
+        }, viteEnv)
 
         const contentType = response.headers.get('content-type')
         if (!contentType || !contentType.includes('application/json')) {
@@ -211,7 +220,10 @@ export const apiRequest = async <T>(
         }
 
         const body = await response.json()
-        console.log('API Response Data:', body)
+        logApiResponse('API Response Data', {
+            status: response.status,
+            body,
+        }, viteEnv)
 
         if (response.status === 401 && retryCount === 0 && isApiRequest) {
             const refreshed = await refresh()
@@ -254,7 +266,9 @@ export const apiRequest = async <T>(
             if (retryCount < API_CONFIG.RETRY_ATTEMPTS &&
                 !endpoint.includes('/prices') &&
                 (error.message.includes('fetch') || error.message.includes('network') || error.message.includes('Failed to fetch'))) {
-                console.log(`Retrying request (${retryCount + 1}/${API_CONFIG.RETRY_ATTEMPTS})...`)
+                debugLog(`Retrying request (${retryCount + 1}/${API_CONFIG.RETRY_ATTEMPTS})...`, {
+                    url,
+                })
                 await new Promise(resolve => setTimeout(resolve, API_CONFIG.RETRY_DELAY * (retryCount + 1)))
                 return apiRequest<T>(endpoint, options, retryCount + 1)
             }
@@ -341,9 +355,9 @@ export const fetchPricesDirectly = async () => {
 // Test functions
 export const testBrowserPrices = async (): Promise<boolean> => {
     try {
-        console.log('Testing browser price service...')
+        debugLog('Testing browser price service...')
         const testResult = await browserPriceService.testConnection()
-        console.log('Browser price test result:', testResult)
+        debugLog('Browser price test result', testResult)
         return testResult.success
     } catch (error) {
         console.error('Browser price test failed:', error)

--- a/frontend/src/services/browserPriceService.ts
+++ b/frontend/src/services/browserPriceService.ts
@@ -1,3 +1,5 @@
+import { debugLog } from '../utils/debug'
+
 interface PriceData {
     price: number
     change?: number
@@ -16,10 +18,10 @@ class BrowserPriceService {
     private readonly REQUEST_TIMEOUT = 10000 // 10 seconds
 
     private readonly COIN_IDS = {
-        'XLM': 'stellar',
-        'BTC': 'bitcoin',
-        'ETH': 'ethereum',
-        'USDC': 'usd-coin'
+        XLM: 'stellar',
+        BTC: 'bitcoin',
+        ETH: 'ethereum',
+        USDC: 'usd-coin'
     }
 
     async getCurrentPrices(): Promise<PricesMap> {
@@ -27,13 +29,12 @@ class BrowserPriceService {
             // Check cache first
             const cached = this.cache.get('prices')
             if (cached && (Date.now() - cached.timestamp) < this.CACHE_DURATION) {
-                console.log('Using cached prices from browser service')
+                debugLog('Using cached prices from browser service')
                 return cached.data
             }
 
-            console.log('Fetching fresh prices from CoinGecko (browser)')
+            debugLog('Fetching fresh prices from CoinGecko (browser)')
 
-            // Build the API URL
             const coinIds = Object.values(this.COIN_IDS).join(',')
             const url = `https://api.coingecko.com/api/v3/simple/price?ids=${coinIds}&vs_currencies=usd&include_24hr_change=true&include_last_updated_at=true`
 
@@ -43,7 +44,7 @@ class BrowserPriceService {
             const response = await fetch(url, {
                 method: 'GET',
                 headers: {
-                    'Accept': 'application/json',
+                    Accept: 'application/json',
                 },
                 signal: controller.signal
             })
@@ -55,9 +56,10 @@ class BrowserPriceService {
             }
 
             const data = await response.json()
-            console.log('CoinGecko browser response:', data)
+            debugLog('CoinGecko browser response', {
+                assets: Object.keys(data as Record<string, unknown>)
+            })
 
-            // Transform the data to match your existing format
             const prices: PricesMap = {}
 
             Object.entries(this.COIN_IDS).forEach(([asset, coinId]) => {
@@ -70,7 +72,11 @@ class BrowserPriceService {
                         source: 'coingecko_browser',
                         volume: coinData.usd_24h_vol || 0
                     }
-                    console.log(`✓ ${asset}: $${coinData.usd} (${coinData.usd_24h_change > 0 ? '+' : ''}${(coinData.usd_24h_change || 0).toFixed(2)}%)`)
+
+                    debugLog(`Price loaded for ${asset}`, {
+                        price: coinData.usd,
+                        hasChange: coinData.usd_24h_change !== undefined
+                    })
                 }
             })
 
@@ -78,7 +84,6 @@ class BrowserPriceService {
                 throw new Error('No price data received from CoinGecko')
             }
 
-            // Cache the results
             this.cache.set('prices', {
                 data: prices,
                 timestamp: Date.now()
@@ -89,20 +94,18 @@ class BrowserPriceService {
         } catch (error) {
             console.error('Browser price fetch failed:', error)
 
-            // Return cached data if available
             const cached = this.cache.get('prices')
             if (cached) {
-                console.log('Using stale cached data due to error')
+                debugLog('Using stale cached data due to error')
                 return cached.data
             }
 
-            // Final fallback
             return this.getFallbackPrices()
         }
     }
 
     private getFallbackPrices(): PricesMap {
-        console.warn('Using fallback prices in browser service')
+        debugLog('Using fallback prices in browser service')
 
         const now = Math.floor(Date.now() / 1000)
         const addVariation = (basePrice: number) => {
@@ -140,7 +143,7 @@ class BrowserPriceService {
 
     clearCache(): void {
         this.cache.clear()
-        console.log('Browser price cache cleared')
+        debugLog('Browser price cache cleared')
     }
 
     async testConnection(): Promise<{ success: boolean, error?: string }> {

--- a/frontend/src/utils/debug.test.ts
+++ b/frontend/src/utils/debug.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+    getFrontendDebugConfig,
+    logApiRequest,
+    logApiResponse,
+    sanitizeHeadersForLog,
+    summarizePayloadForLog,
+    summarizeResponseForLog,
+} from './debug'
+
+describe('debug utilities', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('enables API debug logs in development and disables them in production by default', () => {
+        expect(getFrontendDebugConfig({ DEV: true, PROD: false }).enableApiDebugLogs).toBe(true)
+        expect(getFrontendDebugConfig({ DEV: false, PROD: true, MODE: 'production' }).enableApiDebugLogs).toBe(false)
+    })
+
+    it('keeps production API logs disabled by default', () => {
+        expect(getFrontendDebugConfig({ DEV: false, PROD: true, MODE: 'production' }).enableProductionApiLogs).toBe(false)
+    })
+
+    it('redacts sensitive request headers', () => {
+        expect(sanitizeHeadersForLog({
+            Authorization: 'Bearer token',
+            Accept: 'application/json',
+            'X-Trace-Id': 'abc123',
+        })).toEqual({
+            Authorization: '[REDACTED]',
+            Accept: 'application/json',
+            'X-Trace-Id': 'abc123',
+        })
+    })
+
+    it('summarizes sensitive payloads without dumping secrets', () => {
+        expect(summarizePayloadForLog({
+            address: 'GABC',
+            refreshToken: 'super-secret',
+            nested: { foo: 'bar' },
+            items: [1, 2, 3],
+        })).toEqual({
+            address: {
+                type: 'string',
+                length: 4,
+            },
+            refreshToken: '[REDACTED]',
+            nested: {
+                type: 'object',
+                keys: ['foo'],
+            },
+            items: {
+                type: 'array',
+                length: 3,
+            },
+        })
+    })
+
+    it('reduces response logging to a safe summary', () => {
+        expect(summarizeResponseForLog({
+            success: false,
+            data: { id: 'p1', amount: 12 },
+            error: { code: 'INVALID' },
+        })).toEqual({
+            keys: ['success', 'data', 'error'],
+            success: false,
+            errorCode: 'INVALID',
+        })
+    })
+
+    it('logs sanitized request details in development only', () => {
+        const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+        logApiRequest('API Request', {
+            headers: { Authorization: 'Bearer token', Accept: 'application/json' },
+            body: { refreshToken: 'secret', amount: 42 },
+        }, { DEV: true, PROD: false, MODE: 'development' })
+
+        expect(debugSpy).toHaveBeenCalledWith('API Request', {
+            headers: {
+                Authorization: '[REDACTED]',
+                Accept: 'application/json',
+            },
+            body: {
+                refreshToken: '[REDACTED]',
+                amount: 42,
+            },
+        })
+    })
+
+    it('suppresses request and response console logs in production by default', () => {
+        const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+        logApiRequest('API Request', {
+            headers: { Authorization: 'Bearer token' },
+            body: { refreshToken: 'secret' },
+        }, { DEV: false, PROD: true, MODE: 'production' })
+
+        logApiResponse('API Response', {
+            status: 200,
+            headers: { Authorization: 'Bearer token' },
+            body: { success: true, data: { id: 'p1' } },
+        }, { DEV: false, PROD: true, MODE: 'production' })
+
+        expect(debugSpy).not.toHaveBeenCalled()
+        expect(infoSpy).not.toHaveBeenCalled()
+    })
+
+    it('allows an explicit production-safe response summary when enabled', () => {
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+        logApiResponse('API Response', {
+            status: 500,
+            headers: { Authorization: 'Bearer token' },
+            body: { success: false, error: { code: 'SERVER_ERROR', details: { secret: 'hidden' } } },
+        }, { DEV: false, PROD: true, MODE: 'production', VITE_ENABLE_API_PROD_LOGS: 'true' })
+
+        expect(infoSpy).toHaveBeenCalledWith('API Response', {
+            status: 500,
+            body: {
+                keys: ['success', 'error'],
+                success: false,
+                errorCode: 'SERVER_ERROR',
+            },
+        })
+    })
+})

--- a/frontend/src/utils/debug.ts
+++ b/frontend/src/utils/debug.ts
@@ -1,0 +1,170 @@
+type ImportMetaEnvLike = {
+    DEV?: boolean
+    PROD?: boolean
+    MODE?: string
+    VITE_ENABLE_API_DEBUG_LOGS?: string
+    VITE_ENABLE_API_PROD_LOGS?: string
+}
+
+const REDACTED = '[REDACTED]'
+
+const SENSITIVE_KEY_PATTERN = /(authorization|token|secret|password|cookie|session|key|credential|jwt)/i
+
+function isSensitiveKey(key: string): boolean {
+    return SENSITIVE_KEY_PATTERN.test(key)
+}
+
+function summarizeValue(value: unknown): unknown {
+    if (value == null) return value
+    if (Array.isArray(value)) {
+        return {
+            type: 'array',
+            length: value.length,
+        }
+    }
+    if (typeof value === 'object') {
+        return {
+            type: 'object',
+            keys: Object.keys(value as Record<string, unknown>),
+        }
+    }
+    if (typeof value === 'string') {
+        return {
+            type: 'string',
+            length: value.length,
+        }
+    }
+    return value
+}
+
+export function getFrontendDebugConfig(env: ImportMetaEnvLike = (import.meta as any).env ?? {}) {
+    const isDevelopment = env.DEV === true || env.MODE === 'development'
+    const forceApiDebugLogs = env.VITE_ENABLE_API_DEBUG_LOGS === 'true'
+    const enableProductionApiLogs = env.VITE_ENABLE_API_PROD_LOGS === 'true'
+
+    return {
+        isDevelopment,
+        enableApiDebugLogs: isDevelopment || forceApiDebugLogs,
+        enableProductionApiLogs,
+    }
+}
+
+export function sanitizeHeadersForLog(
+    headers?: HeadersInit | Record<string, unknown> | null,
+): Record<string, string> {
+    if (!headers) return {}
+
+    const rawEntries = headers instanceof Headers
+        ? Array.from(headers.entries())
+        : Array.isArray(headers)
+            ? headers.map(([key, value]) => [key, String(value)] as const)
+            : Object.entries(headers).map(([key, value]) => [key, String(value)] as const)
+
+    return Object.fromEntries(
+        rawEntries.map(([key, value]) => [key, isSensitiveKey(key) ? REDACTED : value]),
+    )
+}
+
+export function summarizePayloadForLog(payload: unknown): unknown {
+    if (payload == null) return undefined
+
+    if (typeof payload === 'string') {
+        try {
+            return summarizePayloadForLog(JSON.parse(payload))
+        } catch {
+            return {
+                type: 'string',
+                length: payload.length,
+            }
+        }
+    }
+
+    if (Array.isArray(payload)) {
+        return {
+            type: 'array',
+            length: payload.length,
+        }
+    }
+
+    if (typeof payload === 'object') {
+        return Object.fromEntries(
+            Object.entries(payload as Record<string, unknown>).map(([key, value]) => [
+                key,
+                isSensitiveKey(key) ? REDACTED : summarizeValue(value),
+            ]),
+        )
+    }
+
+    return summarizeValue(payload)
+}
+
+export function summarizeResponseForLog(payload: unknown): unknown {
+    if (payload == null) return payload
+
+    if (typeof payload === 'object' && !Array.isArray(payload)) {
+        const record = payload as Record<string, unknown>
+        return {
+            keys: Object.keys(record),
+            success: typeof record.success === 'boolean' ? record.success : undefined,
+            errorCode:
+                record.error && typeof record.error === 'object'
+                    ? (record.error as Record<string, unknown>).code
+                    : undefined,
+        }
+    }
+
+    return summarizeValue(payload)
+}
+
+export function debugLog(message: string, details?: unknown): void {
+    if (!getFrontendDebugConfig().enableApiDebugLogs) return
+    if (details === undefined) {
+        console.debug(message)
+        return
+    }
+    console.debug(message, details)
+}
+
+export function logApiRequest(
+    message: string,
+    details?: {
+        headers?: HeadersInit | Record<string, unknown> | null
+        body?: unknown
+    },
+    env: ImportMetaEnvLike = (import.meta as any).env ?? {},
+): void {
+    const config = getFrontendDebugConfig(env)
+    if (!config.enableApiDebugLogs) return
+
+    console.debug(message, {
+        headers: sanitizeHeadersForLog(details?.headers),
+        body: summarizePayloadForLog(details?.body),
+    })
+}
+
+export function logApiResponse(
+    message: string,
+    details?: {
+        status?: number
+        headers?: HeadersInit | Record<string, unknown> | null
+        body?: unknown
+    },
+    env: ImportMetaEnvLike = (import.meta as any).env ?? {},
+): void {
+    const config = getFrontendDebugConfig(env)
+    if (config.enableApiDebugLogs) {
+        console.debug(message, {
+            status: details?.status,
+            headers: sanitizeHeadersForLog(details?.headers),
+            body: summarizeResponseForLog(details?.body),
+        })
+        return
+    }
+
+    if (!config.enableProductionApiLogs) return
+
+    console.info(message, {
+        status: details?.status,
+        body: summarizeResponseForLog(details?.body),
+    })
+}


### PR DESCRIPTION
Close: #184

Updated the frontend API logging so verbose request/response tracing stays local and production stays quiet by default.

In [api.ts] , the client now routes request/response logs through environment-aware helpers instead of dumping raw headers and payloads directly. In [debug.ts], I added guarded logApiRequest / logApiResponse helpers that redact sensitive headers, summarize payloads, and suppress production console noise unless someone explicitly opts into a safe production summary via VITE_ENABLE_API_PROD_LOGS=true.

I also expanded coverage in [debug.test.ts] to verify dev logging remains useful, production request/response logs are off by default, and any opt-in production response log stays sanitized.