### PR TITLE
fix: update integration tests to envelope format, fix encoding corrup……tion, add contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to Stellar Portfolio Rebalancer
+
+Thanks for your interest in contributing!
+
+The full contributor setup guide is at **[docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)**.
+
+It covers:
+
+- Minimum local setup (backend + frontend)
+- Optional services: PostgreSQL, Redis, SMTP
+- Database migrations (PostgreSQL and SQLite paths)
+- Running backend and frontend tests
+- API doc generation (`npm run codegen`)
+- Queue worker setup and expectations
+- Frontend E2E tests with Playwright
+- Contract build and deploy steps
+- Common setup failures and fixes
+
+For a quick overview of the API contract see [API.md](API.md).
+
+## Workflow
+
+1. Fork the repository and create a feature branch: `git checkout -b feature/your-feature`
+2. Follow the setup guide in [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)
+3. Make your changes and ensure all tests pass: `cd backend && npm test && cd ../frontend && npm test`
+4. Open a pull request targeting `main`

--- a/README.md
+++ b/README.md
@@ -244,10 +244,14 @@ docker compose -f deployment/docker-compose.yml up --build -d
 ```
 
 ## Contributing
+
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the canonical contributor guide. It includes minimum local setup, optional services (Redis, PostgreSQL, SMTP), test commands, API doc generation, queue worker expectations, and frontend E2E setup.
+
+Quick steps:
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature/awesome-feature`
-3. Commit changes: `git commit -m "Add awesome feature"`
-4. Push: `git push origin feature/awesome-feature`
+3. Follow setup in [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)
+4. Ensure tests pass: `cd backend && npm test && cd ../frontend && npm test`
 5. Open a Pull Request
 
 ## License

--- a/backend/src/test/api.integration.test.ts
+++ b/backend/src/test/api.integration.test.ts
@@ -92,9 +92,11 @@ describe('Portfolio Management - POST /api/portfolio', () => {
                 expect([200, 201]).toContain(res.status)
             })
 
-        expect(response.body.portfolioId).toBeDefined()
-        expect(response.body.status).toBe('created')
-        expect(response.body.mode).toBe('demo')
+        expect(response.body.success).toBe(true)
+        expect(response.body.error).toBeNull()
+        expect(response.body.data.portfolioId).toBeDefined()
+        expect(response.body.data.status).toBe('created')
+        expect(response.body.data.mode).toBe('demo')
     })
 
     it('should return 400 for missing required fields', async () => {
@@ -108,8 +110,10 @@ describe('Portfolio Management - POST /api/portfolio', () => {
             .send(testPayload)
             .expect(400)
 
+        expect(response.body.success).toBe(false)
+        expect(response.body.data).toBeNull()
         expect(response.body.error).toBeDefined()
-        expect(response.body.error).toContain('Missing required fields')
+        expect(response.body.error.code).toBe('VALIDATION_ERROR')
     })
 
     it('should return 400 if allocations do not sum to 100%', async () => {
@@ -124,7 +128,9 @@ describe('Portfolio Management - POST /api/portfolio', () => {
             .send(testPayload)
             .expect(400)
 
-        expect(response.body.error).toContain('100%')
+        expect(response.body.success).toBe(false)
+        expect(response.body.data).toBeNull()
+        expect(response.body.error.code).toBe('VALIDATION_ERROR')
     })
 
     it('should return 400 if threshold is out of range', async () => {
@@ -139,13 +145,15 @@ describe('Portfolio Management - POST /api/portfolio', () => {
             .send(testPayload)
             .expect(400)
 
-        expect(response.body.error).toContain('Threshold')
+        expect(response.body.success).toBe(false)
+        expect(response.body.data).toBeNull()
+        expect(response.body.error.code).toBe('VALIDATION_ERROR')
     })
 
     it('should return 400 if asset allocation is invalid', async () => {
         const testPayload = {
             userAddress: 'GTEST123456789ABCDEF3',
-            allocations: { XLM: 120, USDC: -20 }, 
+            allocations: { XLM: 120, USDC: -20 },
             threshold: 5
         }
 
@@ -154,7 +162,10 @@ describe('Portfolio Management - POST /api/portfolio', () => {
             .send(testPayload)
             .expect(400)
 
+        expect(response.body.success).toBe(false)
+        expect(response.body.data).toBeNull()
         expect(response.body.error).toBeDefined()
+        expect(response.body.error.code).toBe('VALIDATION_ERROR')
     })
 })
 
@@ -176,7 +187,7 @@ describe('Portfolio Management - GET /api/portfolio/:id', () => {
                 expect([200, 201]).toContain(res.status)
             })
 
-        const portfolioId = createResponse.body.portfolioId
+        const portfolioId = createResponse.body.data.portfolioId
         expect(portfolioId).toBeDefined()
 
         // Now fetch it
@@ -186,9 +197,11 @@ describe('Portfolio Management - GET /api/portfolio/:id', () => {
                 expect([200, 201]).toContain(res.status)
             })
 
-        expect(getResponse.body.portfolio).toBeDefined()
-        expect(getResponse.body.prices).toBeDefined()
-        expect(getResponse.body.mode).toBe('demo')
+        expect(getResponse.body.success).toBe(true)
+        expect(getResponse.body.error).toBeNull()
+        expect(getResponse.body.data.portfolio).toBeDefined()
+        expect(getResponse.body.data.prices).toBeDefined()
+        expect(getResponse.body.data.mode).toBe('demo')
     })
 
     it('should return 400 for missing portfolio ID', async () => {
@@ -207,7 +220,8 @@ describe('Portfolio Management - GET /api/portfolio/:id', () => {
                 expect([400, 404, 500]).toContain(res.status)
             })
 
-        expect(response.body.error || response.body.message).toBeDefined()
+        expect(response.body.success).toBe(false)
+        expect(response.body.error).toBeDefined()
     })
 })
 
@@ -219,11 +233,13 @@ describe('Price Data - GET /api/prices', () => {
             .get('/api/prices')
             .expect(200)
 
+        expect(response.body.success).toBe(true)
+        expect(response.body.error).toBeNull()
         // Should have at least one asset
-        expect(Object.keys(response.body).length).toBeGreaterThan(0)
+        expect(Object.keys(response.body.data).length).toBeGreaterThan(0)
 
         // Check for common assets (might be fallback data)
-        const hasAssets = response.body.XLM || response.body.BTC || response.body.ETH || response.body.USDC
+        const hasAssets = response.body.data.XLM || response.body.data.BTC || response.body.data.ETH || response.body.data.USDC
         expect(hasAssets).toBeTruthy()
     })
 
@@ -232,7 +248,8 @@ describe('Price Data - GET /api/prices', () => {
             .get('/api/prices')
             .expect(200)
 
-        const assets = Object.values(response.body) as any[]
+        expect(response.body.success).toBe(true)
+        const assets = Object.values(response.body.data) as any[]
         expect(assets.length).toBeGreaterThan(0)
 
         const firstAsset = assets[0]
@@ -247,8 +264,9 @@ describe('Price Data - GET /api/prices', () => {
             .get('/api/prices')
             .expect(200)
 
+        expect(response.body.success).toBe(true)
         // All assets should have consistent structure
-        for (const [assetName, assetData] of Object.entries(response.body)) {
+        for (const [, assetData] of Object.entries(response.body.data)) {
             const asset = assetData as any
             expect(asset.price).toBeDefined()
             expect(typeof asset.price).toBe('number')
@@ -275,7 +293,7 @@ describe('Rebalancing - POST /api/portfolio/:id/rebalance', () => {
                 expect([200, 201]).toContain(res.status)
             })
 
-        const portfolioId = createResponse.body.portfolioId
+        const portfolioId = createResponse.body.data.portfolioId
         expect(portfolioId).toBeDefined()
 
         // Now try to rebalance
@@ -286,12 +304,15 @@ describe('Rebalancing - POST /api/portfolio/:id/rebalance', () => {
                 expect([200, 201, 400, 409]).toContain(res.status)
             })
 
-        // Response should contain either status or error
-        expect(
-            rebalanceResponse.body.status ||
-            rebalanceResponse.body.error ||
-            rebalanceResponse.body.reason
-        ).toBeDefined()
+        // Response must be a standard envelope
+        expect(typeof rebalanceResponse.body.success).toBe('boolean')
+        if (rebalanceResponse.body.success) {
+            expect(rebalanceResponse.body.data).toBeDefined()
+            expect(rebalanceResponse.body.error).toBeNull()
+        } else {
+            expect(rebalanceResponse.body.error).toBeDefined()
+            expect(rebalanceResponse.body.data).toBeNull()
+        }
     })
 
     it('should return error for invalid portfolio ID', async () => {
@@ -302,7 +323,8 @@ describe('Rebalancing - POST /api/portfolio/:id/rebalance', () => {
                 expect([400, 404, 500]).toContain(res.status)
             })
 
-        expect(response.body.error || response.body.message).toBeDefined()
+        expect(response.body.success).toBe(false)
+        expect(response.body.error).toBeDefined()
     })
 
     it('should require portfolio ID in URL', async () => {

--- a/docs/REBALANCING_STRATEGIES.md
+++ b/docs/REBALANCING_STRATEGIES.md
@@ -62,7 +62,7 @@ Portfolios can use different strategies to decide when to rebalance. You choose 
 |--------------------------|--------|--------|--------------------------------------|
 | `minDaysBetweenRebalance`| number | 1      | Minimum days between rebalances (0–365). |
 
-**Use case:** Reduce trading frequency while still reacting to drift (e.g. “rebalance at most once per week, and only when drift &gt; 5%”).
+**Use case:** Reduce trading frequency while still reacting to drift (e.g. “rebalance at most once per week, and only when drift > 5%”).
 
 ---
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -534,7 +534,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
                                         </p>
                                         {hasHighGasWarning && (
                                             <p className="text-xs text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900/40 rounded px-2 py-1 mb-3">
-                                                Warning: estimated gas is unusually high (&gt; 0.5 XLM). Consider reducing trade count.
+                                                Warning: estimated gas is unusually high ({'>'} 0.5 XLM). Consider reducing trade count.
                                             </p>
                                         )}
                                         {(rebalanceEstimate?.breakdown?.length ?? 0) > 0 && (

--- a/frontend/src/components/RebalanceHistory.tsx
+++ b/frontend/src/components/RebalanceHistory.tsx
@@ -416,7 +416,7 @@ const RebalanceHistory: React.FC<RebalanceHistoryProps> = ({ portfolioId }) => {
                                             {(event.details?.gasBreakdown?.length ?? 0) > 0 && (
                                                 <div className="text-xs text-gray-600 dark:text-gray-400 mb-2">
                                                     {event.details?.gasWarning && (
-                                                        <div className="text-red-600 dark:text-red-400 mb-1 font-medium">High gas warning (&gt; 0.5 XLM)</div>
+                                                        <div className="text-red-600 dark:text-red-400 mb-1 font-medium">High gas warning ({'>'} 0.5 XLM)</div>
                                                     )}
                                                     {event.details?.gasBreakdown?.map((item) => (
                                                         <div key={item.tradeId} className="flex justify-between">


### PR DESCRIPTION

## Fix integration tests envelope, encoding corruption, and add contributor guide

Closes #189,
Closes #201 
Closes #159 
Closes #160

## Summary
- **#189** — Updated `backend/src/test/api.integration.test.ts` to assert the current `{ success, data, error, timestamp }` response envelope on all endpoints (portfolio create/get, prices, rebalance, error responses). Removed old ad-hoc field assertions (`response.body.portfolioId`, `response.body.status`, etc.) and raw string error checks.
- **#201** — Replaced HTML entity `&gt;` with `{'>'}` JSX expression in `Dashboard.tsx` and `RebalanceHistory.tsx` gas warning strings so users see `>` instead of literal `&gt;`.
- **#159** — Fixed `&gt;` encoding corruption in `docs/REBALANCING_STRATEGIES.md` (plain markdown text now uses `>`).
- **#160** — Added root-level `CONTRIBUTING.md` linking to `docs/CONTRIBUTING.md`; updated README Contributing section to direct new contributors to the full setup guide covering all optional services, test commands, and E2E setup.

## Test plan
- [ ] `cd backend && npm test` — all integration tests pass with updated envelope assertions
- [ ] Verify Dashboard and RebalanceHistory gas warnings render `>` not `&gt;` in browser
- [ ] README Contributing section renders cleanly on GitHub
- [ ] `CONTRIBUTING.md` links resolve correctly to `docs/CONTRIBUTING.md`
