### PR TITLE
feat: wallet-signed challenge auth and notification ownership enforcement (#171 #178)

### DIFF
--- a/backend/src/api/authRoutes.ts
+++ b/backend/src/api/authRoutes.ts
@@ -3,7 +3,9 @@ import {
     getAuthConfig,
     issueTokens,
     refreshTokens,
-    logout
+    logout,
+    issueChallenge,
+    verifyWalletSignature
 } from '../services/authService.js'
 import { requireJwt } from '../middleware/requireJwt.js'
 import { authRateLimiter } from '../middleware/rateLimit.js'
@@ -12,7 +14,15 @@ import { getErrorMessage } from '../utils/helpers.js'
 
 const router = Router()
 
-router.post('/login', authRateLimiter, async (req: Request, res: Response) => {
+/**
+ * Issue a one-time challenge nonce that the client must sign with their
+ * Stellar wallet private key.
+ *
+ * POST /api/auth/challenge
+ * Body: { address: string }
+ * Response: { challenge: string }  — sign this exact string (UTF-8) with the wallet
+ */
+router.post('/challenge', authRateLimiter, async (req: Request, res: Response) => {
     try {
         const config = getAuthConfig()
         if (!config.enabled) {
@@ -22,7 +32,41 @@ router.post('/login', authRateLimiter, async (req: Request, res: Response) => {
         if (!address || typeof address !== 'string' || !address.trim()) {
             return fail(res, 400, 'VALIDATION_ERROR', 'address is required')
         }
+        const challenge = issueChallenge(address.trim())
+        return ok(res, { challenge })
+    } catch (error) {
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
+/**
+ * Complete wallet-signed challenge authentication and receive JWT tokens.
+ *
+ * POST /api/auth/login
+ * Body: { address: string, signature: string }
+ *   address   — Stellar public key (G…)
+ *   signature — base64-encoded Ed25519 signature over the challenge string
+ *               returned by POST /api/auth/challenge
+ */
+router.post('/login', authRateLimiter, async (req: Request, res: Response) => {
+    try {
+        const config = getAuthConfig()
+        if (!config.enabled) {
+            return fail(res, 503, 'SERVICE_UNAVAILABLE', 'JWT auth not configured (set JWT_SECRET)')
+        }
+        const address = req.body?.address
+        const signature = req.body?.signature
+        if (!address || typeof address !== 'string' || !address.trim()) {
+            return fail(res, 400, 'VALIDATION_ERROR', 'address is required')
+        }
+        if (!signature || typeof signature !== 'string' || !signature.trim()) {
+            return fail(res, 400, 'VALIDATION_ERROR', 'signature is required — request a challenge first via POST /auth/challenge')
+        }
         const trimmed = address.trim()
+        const valid = verifyWalletSignature(trimmed, signature.trim())
+        if (!valid) {
+            return fail(res, 401, 'UNAUTHORIZED', 'Invalid or expired signature — request a new challenge and sign it with your wallet')
+        }
         const tokens = await issueTokens(trimmed)
         return ok(res, {
             accessToken: tokens.accessToken,

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -993,7 +993,19 @@ router.get('/portfolio/:id/performance-summary', async (req: Request, res: Respo
 // Subscribe to notifications
 router.post('/notifications/subscribe', requireJwtWhenEnabled, ...protectedWriteLimiter, idempotencyMiddleware, async (req: Request, res: Response) => {
     try {
-        const userId = req.user?.address ?? req.body?.userId
+        // Issue #178: when auth is enabled, derive userId from the token only.
+        // Reject requests that try to subscribe on behalf of a different address.
+        let userId: string | undefined
+        if (getAuthConfig().enabled) {
+            userId = req.user!.address
+            const bodyId = req.body?.userId as string | undefined
+            if (bodyId && bodyId !== userId) {
+                return fail(res, 403, 'FORBIDDEN', 'Cannot manage notification preferences for another user')
+            }
+        } else {
+            userId = req.body?.userId
+        }
+
         const { emailEnabled, webhookEnabled, webhookUrl, events, emailAddress } = req.body ?? {}
 
         // Validation
@@ -1050,7 +1062,17 @@ router.post('/notifications/subscribe', requireJwtWhenEnabled, ...protectedWrite
 // Get notification preferences
 router.get('/notifications/preferences', requireJwtWhenEnabled, async (req: Request, res: Response) => {
     try {
-        const userId = req.user?.address ?? (req.query.userId as string)
+        // Issue #178: when auth is enabled, only allow reading own preferences.
+        let userId: string | undefined
+        if (getAuthConfig().enabled) {
+            userId = req.user!.address
+            const queryId = req.query.userId as string | undefined
+            if (queryId && queryId !== userId) {
+                return fail(res, 403, 'FORBIDDEN', 'Cannot read notification preferences for another user')
+            }
+        } else {
+            userId = req.query.userId as string | undefined
+        }
 
         if (!userId) {
             return fail(res, 400, 'VALIDATION_ERROR', 'userId query parameter is required')
@@ -1072,7 +1094,17 @@ router.get('/notifications/preferences', requireJwtWhenEnabled, async (req: Requ
 // Unsubscribe from notifications
 router.delete('/notifications/unsubscribe', requireJwtWhenEnabled, writeRateLimiter, async (req: Request, res: Response) => {
     try {
-        const userId = req.user?.address ?? (req.query.userId as string)
+        // Issue #178: when auth is enabled, only allow unsubscribing own preferences.
+        let userId: string | undefined
+        if (getAuthConfig().enabled) {
+            userId = req.user!.address
+            const queryId = req.query.userId as string | undefined
+            if (queryId && queryId !== userId) {
+                return fail(res, 403, 'FORBIDDEN', 'Cannot unsubscribe notification preferences for another user')
+            }
+        } else {
+            userId = req.query.userId as string | undefined
+        }
 
         if (!userId) {
             return fail(res, 400, 'VALIDATION_ERROR', 'userId query parameter is required')

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken'
 import { randomBytes } from 'node:crypto'
+import { Keypair } from '@stellar/stellar-sdk'
 import {
     createRefreshToken,
     findRefreshToken,
@@ -84,6 +85,57 @@ export async function refreshTokens(refreshToken: string): Promise<AuthTokens | 
     }
     await deleteRefreshTokenById(row.id)
     return issueTokens(row.user_address)
+}
+
+// ── Issue #171: wallet-signed challenge authentication ────────────────────
+
+const CHALLENGE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+
+interface ChallengeEntry {
+    nonce: string
+    expiresAt: number
+}
+
+/** In-memory store: address → pending challenge */
+const challengeStore = new Map<string, ChallengeEntry>()
+
+/**
+ * Generate a one-time challenge nonce for the given Stellar address.
+ * The client must sign this exact string (UTF-8 bytes) with the wallet
+ * private key and return it to `POST /auth/login`.
+ */
+export function issueChallenge(address: string): string {
+    // Purge any stale entry for this address
+    challengeStore.delete(address)
+    const nonce = randomBytes(32).toString('hex')
+    const message = `stellar-rebalancer:auth:${nonce}`
+    challengeStore.set(address, { nonce: message, expiresAt: Date.now() + CHALLENGE_TTL_MS })
+    logger.info('Auth challenge issued', { address })
+    return message
+}
+
+/**
+ * Verify a base64-encoded Ed25519 signature over the previously issued
+ * challenge nonce for `address`.  Consumes the challenge on success so it
+ * cannot be replayed.
+ */
+export function verifyWalletSignature(address: string, signatureB64: string): boolean {
+    const entry = challengeStore.get(address)
+    if (!entry) return false
+    if (Date.now() > entry.expiresAt) {
+        challengeStore.delete(address)
+        return false
+    }
+    // Consume the challenge regardless of outcome to prevent brute-force.
+    challengeStore.delete(address)
+    try {
+        const keypair = Keypair.fromPublicKey(address)
+        const messageBuffer = Buffer.from(entry.nonce, 'utf8')
+        const sigBuffer = Buffer.from(signatureB64, 'base64')
+        return keypair.verify(messageBuffer, sigBuffer)
+    } catch {
+        return false
+    }
 }
 
 export async function logout(refreshToken: string | undefined, address: string | undefined): Promise<boolean> {


### PR DESCRIPTION
## Summary

Resolves #171 and #178.

- **#171 — Replace address-only login with wallet-signed challenge authentication**
  - `POST /api/auth/challenge` (new): accepts `{ address }`, returns a one-time challenge string the client must sign with their Stellar wallet private key. Challenge expires in 5 minutes and is consumed on first use.
  - `POST /api/auth/login` (updated): now requires `{ address, signature }` — base64-encoded Ed25519 signature over the challenge string. Tokens are only issued after the signature is verified against the address using `@stellar/stellar-sdk` `Keypair.verify`. Submitting an address alone is no longer sufficient.

- **#178 — Enforce ownership checks on notification preference reads and deletes**
  - `POST /notifications/subscribe`: when JWT auth is enabled, `userId` is derived exclusively from `req.user.address` (the token subject). Returns `403 FORBIDDEN` if a different `userId` is present in the request body.
  - `GET /notifications/preferences`: same — returns `403` when the query `userId` differs from the authenticated address.
  - `DELETE /notifications/unsubscribe`: same — returns `403` when the query `userId` differs from the authenticated address.
  - When auth is disabled (dev/demo), the existing fallback to query/body `userId` is preserved.

## Auth flow for frontend / contributors

```
# 1. Request a challenge
POST /api/auth/challenge
{ "address": "G..." }
→ { "data": { "challenge": "stellar-rebalancer:auth:<hex-nonce>" } }

# 2. Sign the challenge string (UTF-8 bytes) with the wallet private key
# e.g. Freighter: signMessage(challenge) → base64 signature

# 3. Login with the signature
POST /api/auth/login
{ "address": "G...", "signature": "<base64>" }
→ { "data": { "accessToken": "...", "refreshToken": "...", ... } }
```

## Test plan

- [x] `POST /auth/challenge` returns a challenge for a valid address
- [x] `POST /auth/login` with a valid signature issues tokens
- [x] `POST /auth/login` with no signature returns 400
- [x] `POST /auth/login` with a wrong/forged signature returns 401
- [x] `POST /auth/login` with an expired challenge (after 5 min) returns 401
- [x] `GET /notifications/preferences` with a mismatched `userId` query param returns 403 when auth is enabled
- [x] `DELETE /notifications/unsubscribe` with a mismatched `userId` returns 403 when auth is enabled
- [x] `POST /notifications/subscribe` with a mismatched body `userId` returns 403 when auth is enabled
- [x] All three notification routes work normally when auth is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)