### PR TITLE
feat(queue): expand operational endpoints with worker status and last-run metadata

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2002,14 +2002,34 @@
                         "redisConnected": {
                           "type": "boolean"
                         },
-                        "portfolioCheck": {
-                          "type": "object"
+                        "queues": {
+                          "type": "object",
+                          "properties": {
+                            "portfolioCheck": {
+                              "type": "object"
+                            },
+                            "rebalance": {
+                              "type": "object"
+                            },
+                            "analyticsSnapshot": {
+                              "type": "object"
+                            }
+                          }
                         },
-                        "rebalance": {
-                          "type": "object"
-                        },
-                        "analyticsSnapshot": {
-                          "type": "object"
+                        "workers": {
+                          "type": "object",
+                          "description": "Per-worker runtime status including lifecycle state, last-run timestamps, and scheduler registration",
+                          "properties": {
+                            "portfolioCheck": {
+                              "type": "object"
+                            },
+                            "rebalance": {
+                              "type": "object"
+                            },
+                            "analyticsSnapshot": {
+                              "type": "object"
+                            }
+                          }
                         }
                       }
                     },

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -17,6 +17,9 @@ import { writeRateLimiter, protectedWriteLimiter, protectedCriticalLimiter, admi
 import { blockDebugInProduction } from '../middleware/debugGate.js'
 import { getFeatureFlags, getPublicFeatureFlags } from '../config/featureFlags.js'
 import { getQueueMetrics } from '../queue/queueMetrics.js'
+import { getPortfolioCheckWorkerStatus } from '../queue/workers/portfolioCheckWorker.js'
+import { getRebalanceWorkerStatus } from '../queue/workers/rebalanceWorker.js'
+import { getAnalyticsSnapshotWorkerStatus } from '../queue/workers/analyticsSnapshotWorker.js'
 import { getErrorMessage, getErrorObject, parseOptionalBoolean } from '../utils/helpers.js'
 import { createPortfolioSchema } from './validation.js'
 import { rebalanceLockService } from '../services/rebalanceLock.js'
@@ -1327,10 +1330,16 @@ router.get('/debug/auto-rebalancer-test', blockDebugInProduction, async (req: Re
 router.get('/queue/health', async (req: Request, res: Response) => {
     try {
         const metrics = await getQueueMetrics()
-        if (metrics.redisConnected) {
-            return ok(res, metrics)
+        const workers = {
+            portfolioCheck: getPortfolioCheckWorkerStatus(),
+            rebalance: getRebalanceWorkerStatus(),
+            analyticsSnapshot: getAnalyticsSnapshotWorkerStatus(),
         }
-        return fail(res, 503, 'SERVICE_UNAVAILABLE', 'Redis unavailable', metrics)
+        const payload = { ...metrics, workers }
+        if (metrics.redisConnected) {
+            return ok(res, payload)
+        }
+        return fail(res, 503, 'SERVICE_UNAVAILABLE', 'Redis unavailable', payload)
     } catch (error) {
         return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error), {
             redisConnected: false

--- a/backend/src/openapi/spec.ts
+++ b/backend/src/openapi/spec.ts
@@ -856,9 +856,23 @@ const spec: Record<string, any> = {
                                             type: 'object',
                                             properties: {
                                                 redisConnected: { type: 'boolean' },
-                                                portfolioCheck: { type: 'object' },
-                                                rebalance: { type: 'object' },
-                                                analyticsSnapshot: { type: 'object' },
+                                                queues: {
+                                                    type: 'object',
+                                                    properties: {
+                                                        portfolioCheck: { type: 'object' },
+                                                        rebalance: { type: 'object' },
+                                                        analyticsSnapshot: { type: 'object' },
+                                                    },
+                                                },
+                                                workers: {
+                                                    type: 'object',
+                                                    description: 'Per-worker runtime status including lifecycle state, last-run timestamps, and scheduler registration',
+                                                    properties: {
+                                                        portfolioCheck: { type: 'object' },
+                                                        rebalance: { type: 'object' },
+                                                        analyticsSnapshot: { type: 'object' },
+                                                    },
+                                                },
                                             },
                                         },
                                         error: { type: 'object', nullable: true },

--- a/backend/src/queue/scheduler.ts
+++ b/backend/src/queue/scheduler.ts
@@ -1,5 +1,7 @@
 import { getPortfolioCheckQueue, getAnalyticsSnapshotQueue } from './queues.js'
 import { logger } from '../utils/logger.js'
+import { setPortfolioCheckSchedulerRegistered } from './workers/portfolioCheckWorker.js'
+import { setAnalyticsSnapshotSchedulerRegistered } from './workers/analyticsSnapshotWorker.js'
 
 const PORTFOLIO_CHECK_CRON = '*/30 * * * *'    // every 30 minutes
 const ANALYTICS_SNAPSHOT_CRON = '0 * * * *'    // every 60 minutes (top of hour)
@@ -51,6 +53,9 @@ export async function startQueueScheduler(): Promise<void> {
         { priority: 1 }
     )
 
+    setPortfolioCheckSchedulerRegistered(true)
+    setAnalyticsSnapshotSchedulerRegistered(true)
+
     logger.info('[SCHEDULER] Repeatable jobs registered', {
         portfolioCheck: PORTFOLIO_CHECK_CRON,
         analyticsSnapshot: ANALYTICS_SNAPSHOT_CRON,
@@ -77,6 +82,9 @@ export async function stopQueueScheduler(): Promise<void> {
             await analyticsSnapshotQueue.removeRepeatableByKey(job.key)
         }
     }
+
+    setPortfolioCheckSchedulerRegistered(false)
+    setAnalyticsSnapshotSchedulerRegistered(false)
 
     logger.info('[SCHEDULER] Repeatable jobs removed')
 }

--- a/backend/src/queue/workers/analyticsSnapshotWorker.ts
+++ b/backend/src/queue/workers/analyticsSnapshotWorker.ts
@@ -6,11 +6,13 @@ import type { AnalyticsSnapshotJobData } from '../queues.js'
 import {
     createWorkerRuntimeStatus,
     markWorkerFailed,
+    markWorkerJobCompleted,
+    markWorkerJobFailed,
     markWorkerReady,
     markWorkerStarting,
     markWorkerStopped,
     snapshotWorkerRuntimeStatus,
-    type WorkerRuntimeStatus
+    type WorkerRuntimeStatus,
 } from './workerRuntime.js'
 
 let worker: Worker | null = null
@@ -72,16 +74,18 @@ export function startAnalyticsSnapshotWorker(): Worker | null {
         })
 
     worker.on('completed', (job) => {
+        markWorkerJobCompleted(runtimeStatus)
         logger.info('[WORKER:analytics-snapshot] Job completed', { jobId: job.id })
     })
 
-  worker.on("failed", (job, err) => {
-    logger.error("[WORKER:analytics-snapshot] Job failed", {
-      jobId: job?.id,
-      error: err.message,
-      attemptsMade: job?.attemptsMade,
-    });
-  });
+    worker.on('failed', (job, err) => {
+        markWorkerJobFailed(runtimeStatus, err)
+        logger.error('[WORKER:analytics-snapshot] Job failed', {
+            jobId: job?.id,
+            error: err.message,
+            attemptsMade: job?.attemptsMade,
+        })
+    })
 
   logger.info("[WORKER:analytics-snapshot] Worker started");
   return worker;
@@ -98,4 +102,8 @@ export async function stopAnalyticsSnapshotWorker(): Promise<void> {
 
 export function getAnalyticsSnapshotWorkerStatus(): WorkerRuntimeStatus {
     return snapshotWorkerRuntimeStatus(runtimeStatus)
+}
+
+export function setAnalyticsSnapshotSchedulerRegistered(registered: boolean): void {
+    runtimeStatus.schedulerRegistered = registered
 }

--- a/backend/src/queue/workers/portfolioCheckWorker.ts
+++ b/backend/src/queue/workers/portfolioCheckWorker.ts
@@ -8,10 +8,22 @@ import { getRebalanceQueue } from '../queues.js'
 import type { PortfolioCheckJobData } from '../queues.js'
 import { getConnectionOptions } from '../connection.js'
 import { logger } from '../../utils/logger.js'
+import {
+    createWorkerRuntimeStatus,
+    markWorkerFailed,
+    markWorkerJobCompleted,
+    markWorkerJobFailed,
+    markWorkerReady,
+    markWorkerStarting,
+    markWorkerStopped,
+    snapshotWorkerRuntimeStatus,
+    type WorkerRuntimeStatus,
+} from './workerRuntime.js'
 
 const DEMO_PORTFOLIO_IDS = new Set(['demo', 'demo-portfolio-1'])
 
 let worker: Worker | null = null
+const runtimeStatus = createWorkerRuntimeStatus('portfolio-check', 1)
 
 export async function processPortfolioCheckJob(job: Job<PortfolioCheckJobData>): Promise<void> {
     const triggeredBy = job.data.triggeredBy ?? 'scheduler'
@@ -59,23 +71,40 @@ export async function processPortfolioCheckJob(job: Job<PortfolioCheckJobData>):
 
 export function startPortfolioCheckWorker(): Worker | null {
     if (worker) return worker
+
     try {
+        markWorkerStarting(runtimeStatus)
         worker = new Worker('portfolio-check', processPortfolioCheckJob, {
             connection: getConnectionOptions(),
             concurrency: 1
         })
     } catch (err) {
-        logger.warn('[WORKER:portfolio-check] Failed to start – Redis may be unavailable', {
+        markWorkerFailed(runtimeStatus, err)
+        logger.warn('[WORKER:portfolio-check] Failed to start - Redis may be unavailable', {
             error: err instanceof Error ? err.message : String(err)
         })
         return null
     }
 
+    void worker.waitUntilReady()
+        .then(() => {
+            markWorkerReady(runtimeStatus)
+            logger.info('[WORKER:portfolio-check] Worker ready')
+        })
+        .catch((err) => {
+            markWorkerFailed(runtimeStatus, err)
+            logger.error('[WORKER:portfolio-check] Worker failed readiness check', {
+                error: err instanceof Error ? err.message : String(err),
+            })
+        })
+
     worker.on('completed', (j) => {
+        markWorkerJobCompleted(runtimeStatus)
         logger.info('[WORKER:portfolio-check] Job completed', { jobId: j.id })
     })
 
     worker.on('failed', (j, err) => {
+        markWorkerJobFailed(runtimeStatus, err)
         logger.error('[WORKER:portfolio-check] Job failed', {
             jobId: j?.id,
             error: err.message,
@@ -91,10 +120,19 @@ export async function stopPortfolioCheckWorker(): Promise<void> {
     if (worker) {
         await worker.close()
         worker = null
+        markWorkerStopped(runtimeStatus)
         logger.info('[WORKER:portfolio-check] Worker stopped')
     }
 }
 
 export function isPortfolioCheckWorkerRunning(): boolean {
     return worker !== null
+}
+
+export function getPortfolioCheckWorkerStatus(): WorkerRuntimeStatus {
+    return snapshotWorkerRuntimeStatus(runtimeStatus)
+}
+
+export function setPortfolioCheckSchedulerRegistered(registered: boolean): void {
+    runtimeStatus.schedulerRegistered = registered
 }

--- a/backend/src/queue/workers/rebalanceWorker.ts
+++ b/backend/src/queue/workers/rebalanceWorker.ts
@@ -7,8 +7,20 @@ import { rebalanceHistoryService } from '../../services/serviceContainer.js'
 import { notificationService } from '../../services/notificationService.js'
 import { getConnectionOptions } from '../connection.js'
 import type { RebalanceJobData } from '../queues.js'
+import {
+    createWorkerRuntimeStatus,
+    markWorkerFailed,
+    markWorkerJobCompleted,
+    markWorkerJobFailed,
+    markWorkerReady,
+    markWorkerStarting,
+    markWorkerStopped,
+    snapshotWorkerRuntimeStatus,
+    type WorkerRuntimeStatus,
+} from './workerRuntime.js'
 
 let worker: Worker | null = null
+const runtimeStatus = createWorkerRuntimeStatus('rebalance', 3)
 
 /**
  * Core processor: executes a single portfolio rebalance.
@@ -128,18 +140,33 @@ export function startRebalanceWorker(): Worker | null {
     if (worker) return worker
 
     try {
+        markWorkerStarting(runtimeStatus)
         worker = new Worker('rebalance', processRebalanceJob, {
             connection: getConnectionOptions(),
             concurrency: 3
         })
     } catch (err) {
-        logger.warn('[WORKER:rebalance] Failed to start – Redis may be unavailable', {
+        markWorkerFailed(runtimeStatus, err)
+        logger.warn('[WORKER:rebalance] Failed to start - Redis may be unavailable', {
             error: err instanceof Error ? err.message : String(err)
         })
         return null
     }
 
+    void worker.waitUntilReady()
+        .then(() => {
+            markWorkerReady(runtimeStatus)
+            logger.info('[WORKER:rebalance] Worker ready')
+        })
+        .catch((err) => {
+            markWorkerFailed(runtimeStatus, err)
+            logger.error('[WORKER:rebalance] Worker failed readiness check', {
+                error: err instanceof Error ? err.message : String(err),
+            })
+        })
+
     worker.on('completed', (j: Job) => {
+        markWorkerJobCompleted(runtimeStatus)
         logger.info('[WORKER:rebalance] Job completed', {
             jobId: j.id,
             portfolioId: j.data.portfolioId
@@ -147,6 +174,7 @@ export function startRebalanceWorker(): Worker | null {
     })
 
     worker.on('failed', (j: Job | undefined, err: Error) => {
+        markWorkerJobFailed(runtimeStatus, err)
         logger.error('[WORKER:rebalance] Job failed', {
             jobId: j?.id,
             portfolioId: j?.data.portfolioId,
@@ -163,10 +191,15 @@ export async function stopRebalanceWorker(): Promise<void> {
     if (worker) {
         await worker.close()
         worker = null
+        markWorkerStopped(runtimeStatus)
         logger.info('[WORKER:rebalance] Worker stopped')
     }
 }
 
 export function isRebalanceWorkerRunning(): boolean {
     return worker !== null
+}
+
+export function getRebalanceWorkerStatus(): WorkerRuntimeStatus {
+    return snapshotWorkerRuntimeStatus(runtimeStatus)
 }

--- a/backend/src/queue/workers/workerRuntime.ts
+++ b/backend/src/queue/workers/workerRuntime.ts
@@ -7,6 +7,9 @@ export interface WorkerRuntimeStatus {
     lastReadyAt?: string
     lastStoppedAt?: string
     lastError?: string
+    lastSuccessfulRunAt?: string
+    lastErrorAt?: string
+    schedulerRegistered: boolean
 }
 
 export function createWorkerRuntimeStatus(name: string, concurrency: number): WorkerRuntimeStatus {
@@ -15,6 +18,7 @@ export function createWorkerRuntimeStatus(name: string, concurrency: number): Wo
         concurrency,
         started: false,
         ready: false,
+        schedulerRegistered: false,
     }
 }
 
@@ -41,6 +45,19 @@ export function markWorkerStopped(status: WorkerRuntimeStatus): void {
     status.started = false
     status.ready = false
     status.lastStoppedAt = new Date().toISOString()
+}
+
+export function markWorkerJobCompleted(status: WorkerRuntimeStatus): void {
+    status.lastSuccessfulRunAt = new Date().toISOString()
+}
+
+export function markWorkerJobFailed(status: WorkerRuntimeStatus, error: unknown): void {
+    status.lastErrorAt = new Date().toISOString()
+    status.lastError = error instanceof Error ? error.message : String(error)
+}
+
+export function setSchedulerRegistered(status: WorkerRuntimeStatus, registered: boolean): void {
+    status.schedulerRegistered = registered
 }
 
 export function snapshotWorkerRuntimeStatus(status: WorkerRuntimeStatus): WorkerRuntimeStatus {

--- a/backend/src/test/readiness.test.ts
+++ b/backend/src/test/readiness.test.ts
@@ -68,6 +68,7 @@ function readyWorker(name: string) {
         concurrency: 1,
         started: true,
         ready: true,
+        schedulerRegistered: false,
     }
 }
 


### PR DESCRIPTION
## What
Extends operational health and queue endpoints with per-worker runtime status, last-run timestamps, error tracking, and scheduler registration state.

## Issues Resolved
Closes #196

## Changes

### #196 - Expand operational endpoints with worker-specific status and last-run metadata

- Extended `WorkerRuntimeStatus` interface with `lastSuccessfulRunAt`, `lastErrorAt`, and `schedulerRegistered` fields
- Integrated runtime status tracking into `portfolioCheckWorker` and `rebalanceWorker` (matching the existing pattern in `analyticsSnapshotWorker`)
- All three workers now track job completion and failure timestamps via BullMQ event handlers
- Scheduler marks registration status on workers when repeatable jobs are added or removed
- Expanded `/api/queue/health` endpoint to return per-worker runtime status alongside queue depth metrics
- Updated OpenAPI spec and exported `openapi.json` to reflect the new response shape
- Updated readiness test to include the new `schedulerRegistered` field

Contributors can now determine whether workers are alive and productive, when they last ran successfully, their last error timestamp and message, and whether the scheduler has registered recurring jobs for them.

## Testing
- `npm test` (queue.test.ts, readiness.test.ts): 8/8 passing
- `npm run api:validate`: API documentation synchronized
- `tsc --noEmit`: No new type errors introduced (pre-existing errors in unrelated files only)
- All 4 pre-existing test failures are in unrelated files (websocket, apiPathCompatibility, assetRegistryValidation, consentPrivacy)