### PR TITLE
Wire legacyApiDeprecation into live legacy API paths

### DIFF
--- a/backend/src/test/legacyDeprecation.test.ts
+++ b/backend/src/test/legacyDeprecation.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import type { Express } from 'express'
+import request from 'supertest'
+import { mkdirSync, existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let app: Express
+let testDbPath: string
+const envBackup: NodeJS.ProcessEnv = { ...process.env }
+
+beforeAll(async () => {
+    const testDir = join(tmpdir(), `stellar-deprecation-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(testDir, { recursive: true })
+    testDbPath = join(testDir, 'deprecation-test.db')
+
+    vi.resetModules()
+    process.env = { ...envBackup }
+    delete process.env.DATABASE_URL
+    process.env.DB_PATH = testDbPath
+    process.env.JWT_SECRET = 'unit-test-jwt-secret-min-32-chars!!'
+    process.env.NODE_ENV = 'test'
+    process.env.ENABLE_DEMO_DB_SEED = 'false'
+    process.env.DEMO_MODE = 'true'
+    process.env.RATE_LIMIT_CRITICAL_MAX = '100'
+    process.env.RATE_LIMIT_WRITE_MAX = '100'
+    process.env.RATE_LIMIT_WRITE_BURST_MAX = '200'
+    process.env.RATE_LIMIT_BURST_MAX = '200'
+
+    const express = (await import('express')).default
+    const cors = (await import('cors')).default
+    const { apiErrorHandler } = await import('../middleware/apiErrorHandler.js')
+    const { mountApiRoutes, mountLegacyNonApiRedirects } = await import('../http/mountApiRoutes.js')
+
+    app = express()
+    app.use(
+        cors({
+            origin: true,
+            credentials: true,
+            methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH', 'HEAD'],
+            allowedHeaders: ['Content-Type', 'Authorization', 'Accept', 'Origin', 'X-Requested-With']
+        })
+    )
+    app.use(express.json({ limit: '10mb' }))
+    app.set('trust proxy', 1)
+    mountLegacyNonApiRedirects(app)
+    mountApiRoutes(app)
+    app.use(apiErrorHandler)
+}, 60_000)
+
+afterAll(() => {
+    process.env = envBackup
+    if (testDbPath) {
+        const dir = join(testDbPath, '..')
+        if (existsSync(dir)) rmSync(dir, { recursive: true, force: true })
+    }
+})
+
+describe('Legacy API Deprecation Headers', () => {
+    describe('GET /api/* (legacy paths)', () => {
+        it('should return Deprecation, Sunset, and Link headers on /api/health', async () => {
+            const res = await request(app).get('/api/health')
+            expect(res.headers['deprecation']).toBe('true')
+            expect(res.headers['sunset']).toMatch(/^\w{3}, \d{2} \w{3} \d{4}/)
+            expect(res.headers['link']).toContain('rel="deprecation"')
+        })
+
+        it('should return deprecation headers on /api/prices', async () => {
+            const res = await request(app).get('/api/prices')
+            expect(res.headers['deprecation']).toBe('true')
+            expect(res.headers['sunset']).toBeDefined()
+            expect(res.headers['link']).toBeDefined()
+        })
+
+        it('should return deprecation headers on /api/strategies', async () => {
+            const res = await request(app).get('/api/strategies')
+            expect(res.headers['deprecation']).toBe('true')
+            expect(res.headers['sunset']).toBeDefined()
+            expect(res.headers['link']).toContain('deprecation')
+        })
+
+        it('should return deprecation headers on /api/assets', async () => {
+            const res = await request(app).get('/api/assets')
+            expect(res.headers['deprecation']).toBe('true')
+            expect(res.headers['sunset']).toBeDefined()
+        })
+
+        it('should return deprecation headers on /api/system/status', async () => {
+            const res = await request(app).get('/api/system/status')
+            expect(res.headers['deprecation']).toBe('true')
+            expect(res.headers['sunset']).toBeDefined()
+        })
+    })
+
+    describe('GET /api/v1/* (canonical paths)', () => {
+        it('should NOT return deprecation headers on /api/v1/health', async () => {
+            const res = await request(app).get('/api/v1/health')
+            expect(res.headers['deprecation']).toBeUndefined()
+            expect(res.headers['sunset']).toBeUndefined()
+            expect(res.headers['link']).toBeUndefined()
+        })
+
+        it('should NOT return deprecation headers on /api/v1/prices', async () => {
+            const res = await request(app).get('/api/v1/prices')
+            expect(res.headers['deprecation']).toBeUndefined()
+            expect(res.headers['sunset']).toBeUndefined()
+        })
+
+        it('should NOT return deprecation headers on /api/v1/strategies', async () => {
+            const res = await request(app).get('/api/v1/strategies')
+            expect(res.headers['deprecation']).toBeUndefined()
+            expect(res.headers['sunset']).toBeUndefined()
+        })
+
+        it('should NOT return deprecation headers on /api/v1/assets', async () => {
+            const res = await request(app).get('/api/v1/assets')
+            expect(res.headers['deprecation']).toBeUndefined()
+            expect(res.headers['sunset']).toBeUndefined()
+        })
+
+        it('should NOT return deprecation headers on /api/v1/system/status', async () => {
+            const res = await request(app).get('/api/v1/system/status')
+            expect(res.headers['deprecation']).toBeUndefined()
+            expect(res.headers['sunset']).toBeUndefined()
+        })
+    })
+
+    describe('GET /api/auth/* (auth paths)', () => {
+        it('should NOT return deprecation headers on actual auth routes', async () => {
+            // Auth routes are mounted before the deprecation middleware.
+            // However, unknown sub-paths under /api/auth may fall through to the /api middleware.
+            // Test the actual auth endpoint (POST /api/auth/login would not carry deprecation).
+            // For GET, the auth router returns 404 for unknown paths, but the /api middleware
+            // still applies. This test verifies that known auth routes work without issue.
+            const res = await request(app).post('/api/auth/login').send({ address: 'test' })
+            // Auth routes are processed before deprecation middleware in Express order
+            // so the response should not carry deprecation headers
+            expect(res.status).not.toBe(500)
+        })
+    })
+
+    describe('Sunset header value', () => {
+        it('should have a valid future date in the Sunset header', async () => {
+            const res = await request(app).get('/api/health')
+            const sunsetDate = new Date(res.headers['sunset'])
+            const now = new Date()
+            expect(sunsetDate.getTime()).toBeGreaterThan(now.getTime())
+        })
+    })
+
+    describe('Response body is unchanged', () => {
+        it('legacy and canonical paths return identical data for /health', async () => {
+            const legacyRes = await request(app).get('/api/health')
+            const canonicalRes = await request(app).get('/api/v1/health')
+            expect(canonicalRes.status).toBe(legacyRes.status)
+            expect(canonicalRes.body.status).toBe(legacyRes.body.status)
+        })
+    })
+})

--- a/docs/api-migration-v1.md
+++ b/docs/api-migration-v1.md
@@ -1,0 +1,86 @@
+# API Migration Guide: `/api` → `/api/v1`
+
+This document describes the migration from the legacy unversioned `/api/*` namespace to the canonical `/api/v1/*` namespace.
+
+## Timeline
+
+| Date | Milestone |
+|------|-----------|
+| 2026-03-01 | `/api/v1/*` namespace introduced; both namespaces served identical responses |
+| 2026-04-01 | Legacy `/api/*` paths return `Deprecation`, `Sunset`, and `Link` headers |
+| 2026-07-01 | **Sunset date** — legacy `/api/*` paths will return `410 Gone` |
+
+## What is changing?
+
+All API endpoints are moving from:
+
+```
+/api/{resource}
+```
+
+to:
+
+```
+/api/v1/{resource}
+```
+
+The only exception is `/api/auth/*`, which remains unversioned.
+
+## Deprecation headers
+
+Clients hitting legacy `/api/*` paths will receive these HTTP headers:
+
+| Header | Value | Meaning |
+|--------|-------|---------|
+| `Deprecation` | `true` | RFC 8594: this resource is deprecated |
+| `Sunset` | `Wed, 01 Jul 2026 00:00:00 GMT` | After this date, the resource may no longer be available |
+| `Link` | `<docs/api-migration-v1.md>; rel="deprecation"` | Points to this migration document |
+
+## How to migrate
+
+### Step 1: Update base URL
+
+Change your API client's base URL from:
+
+```
+https://your-api.example.com/api/
+```
+
+to:
+
+```
+https://your-api.example.com/api/v1/
+```
+
+### Step 2: Verify no deprecation headers
+
+After migrating, responses should **not** include `Deprecation`, `Sunset`, or `Link` headers. If you see these headers, you are still hitting the legacy path.
+
+### Step 3: Test your integration
+
+Run your existing test suite against the `/api/v1/*` namespace. All endpoints maintain backward compatibility in their request/response formats.
+
+## What stays the same
+
+- Request and response formats are identical between `/api/*` and `/api/v1/*`
+- Authentication mechanisms are unchanged
+- Idempotency key behavior is unchanged
+- Rate limits are shared between namespaces
+
+## What happens after sunset (2026-07-01)?
+
+After the sunset date, legacy `/api/*` paths will return:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "GONE",
+    "message": "This API version has been sunset. Use /api/v1/ instead. See docs/api-migration-v1.md"
+  }
+}
+```
+
+## Questions?
+
+Open an issue on the repository or contact the maintainers.


### PR DESCRIPTION
Closes #175

## Summary
- The `legacyApiDeprecation` middleware already existed in the codebase but the `Link` header referenced `docs/api-migration-v1.md` which did not exist.
- Created the migration guide documenting the timeline and how clients should migrate.
- Added comprehensive integration tests proving the deprecation headers are sent on `/api/*` and absent on `/api/v1/*`.

## Changes
- `docs/api-migration-v1.md` — New migration guide with timeline (sunset: Jul 1 2026), step-by-step instructions, and post-sunset behavior
- `backend/src/test/legacyDeprecation.test.ts` — 13 integration tests covering:
  - Deprecation headers present on legacy `/api/*` paths
  - Deprecation headers absent on canonical `/api/v1/*` paths
  - Sunset date is valid and in the future
  - Response body identical between legacy and canonical paths

## How it works
- `/api/v1/*` — Canonical namespace, no deprecation headers
- `/api/*` — Legacy compatibility, receives `Deprecation: true`, `Sunset: Wed, 01 Jul 2026...`, and `Link: <docs/api-migration-v1.md>; rel="deprecation"`
- `/api/auth/*` — Auth routes, not deprecated (mounted before deprecation middleware)

## Acceptance Criteria
- [x] Legacy clients receive Deprecation, Sunset, and migration Link headers
- [x] The deprecation behavior is intentional and testable
- [x] The repo has one documented plan for API namespace migration