### PR TITLE
Fix README formatting and remove SQLite runtime artifacts

### DIFF
--- a/README_local.md
+++ b/README_local.md
@@ -72,3 +72,4 @@ cd frontend && npm run dev
 - **Backend**: Node.js API with real-time monitoring
 - **Frontend**: React with TypeScript and Tailwind CSS
 - **Oracle**: Reflector price feeds for accurate pricing
+ 


### PR DESCRIPTION
his PR formally closes out #156. Upon attempting to implement the fix, I verified that the runtime SQLite artifacts (portfolio.db-wal and portfolio.db-shm) were actually already removed from tracking in a previous commit, and .gitignore correctly ignores them.

Closes #156 