### PR TITLE
feat: implement notification delivery logging with 30-day retention a…

### DIFF
--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -47,7 +47,6 @@ import {
 import { rateLimitMonitor } from '../services/rateLimitMonitor.js'
 import { databaseService } from '../services/databaseService.js'
 import { autoRebalancer } from '../services/runtimeServices.js'
-import { getAuthConfig } from '../services/authService.js'
 
 const router = Router()
 const stellarService = new StellarService()
@@ -1099,6 +1098,40 @@ router.delete('/notifications/unsubscribe', requireJwtWhenEnabled, writeRateLimi
 // ================================
 // DEBUG ROUTES
 // ================================
+
+// Get notification delivery logs
+router.get('/notifications/logs', requireJwtWhenEnabled, validateQuery(notificationQuerySchema), async (req: Request, res: Response) => {
+    try {
+        let userId: string | undefined
+        
+        // Authorization Logic:
+        // When global authentication is explicitly enabled, we extract the context directly from the token.
+        // If the user tries passing an arbitrary ?userId=... query that does not match their own authenticated address, 
+        // we forcefully block the request to prevent exposure of other users' delivery logs.
+        // If authentication is disabled, we simply fall back to taking the userId query parameter as given.
+        if (getAuthConfig().enabled) {
+            userId = req.user!.address
+            const queryId = req.query.userId as string | undefined
+            if (queryId && queryId !== userId) {
+                return fail(res, 403, 'FORBIDDEN', 'Cannot read notification logs for another user')
+            }
+        } else {
+            userId = req.query.userId as string | undefined
+        }
+
+        if (!userId) {
+            return fail(res, 400, 'VALIDATION_ERROR', 'userId query parameter is required')
+        }
+
+        const logs = notificationService.getLogs(userId)
+
+        return ok(res, { logs })
+    } catch (error) {
+        logger.error('Failed to get notification logs', { error: getErrorObject(error) })
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
 
 /**
  * Debug-only + admin-gated endpoint for sending a single test notification.

--- a/backend/src/db/migrations/009_notification_logs.down.sql
+++ b/backend/src/db/migrations/009_notification_logs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS notification_logs;

--- a/backend/src/db/migrations/009_notification_logs.up.sql
+++ b/backend/src/db/migrations/009_notification_logs.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS notification_logs (
+    id SERIAL PRIMARY KEY,
+    user_id VARCHAR(256) NOT NULL,
+    provider VARCHAR(32) NOT NULL,
+    event_type VARCHAR(64) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_logs_user ON notification_logs(user_id);
+CREATE INDEX IF NOT EXISTS idx_notification_logs_created_at ON notification_logs(created_at DESC);

--- a/backend/src/db/notificationDb.ts
+++ b/backend/src/db/notificationDb.ts
@@ -56,6 +56,18 @@ function ensureNotificationTable() {
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
+
+        CREATE TABLE IF NOT EXISTS notification_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            status TEXT NOT NULL,
+            error_message TEXT,
+            created_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_notification_logs_user ON notification_logs(user_id);
     `)
 }
 
@@ -140,4 +152,80 @@ export function dbDeleteNotificationPreferences(userId: string): boolean {
     
     const result = db.prepare('DELETE FROM notification_preferences WHERE user_id = ?').run(userId)
     return result.changes > 0
+}
+
+/**
+ * Represents a log entry for a notification delivery attempt.
+ * Used for tracking provider success/failure and troubleshooting.
+ */
+export interface NotificationLog {
+    id: number
+    userId: string
+    provider: 'email' | 'webhook'
+    eventType: string
+    status: 'sent' | 'failed' | 'retried' | 'skipped'
+    errorMessage?: string
+    createdAt: string
+}
+
+/**
+ * Logs the outcome of a notification delivery attempt (e.g., sent, failed) 
+ * and automatically prunes any log entries older than 30 days to save space.
+ * @param userId - The user receiving the notification
+ * @param provider - 'email' or 'webhook'
+ * @param eventType - The type of event (e.g., 'rebalance', 'circuitBreaker')
+ * @param status - Success/failure state of the delivery attempt
+ * @param errorMessage - Optional error details if the delivery failed or was skipped
+ */
+export function dbLogNotificationOutcome(
+    userId: string,
+    provider: 'email' | 'webhook',
+    eventType: string,
+    status: 'sent' | 'failed' | 'retried' | 'skipped',
+    errorMessage?: string
+): void {
+    ensureNotificationTable()
+    const db = getDb()
+    const now = new Date().toISOString()
+    
+    db.prepare(`
+        INSERT INTO notification_logs 
+            (user_id, provider, event_type, status, error_message, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+    `).run(userId, provider, eventType, status, errorMessage || null, now)
+
+    // Run 30-day retention cleanup. Note: SQLite uses 'now', '-30 days' for datetime math.
+    // This effectively self-cleans old logs continuously during insertions.
+    db.prepare(`
+        DELETE FROM notification_logs 
+        WHERE created_at < datetime('now', '-30 days')
+    `).run();
+}
+
+/**
+ * Retrieves recent notification delivery logs for a given user.
+ * Useful for exposing operational visibility and debugging delivery issues.
+ * @param userId - ID of the user to fetch logs for
+ * @param limit - Max number of logs to return (default: 50)
+ */
+export function dbGetNotificationLogs(userId: string, limit: number = 50): NotificationLog[] {
+    ensureNotificationTable()
+    const db = getDb()
+
+    const rows = db.prepare<[string, number], any>(`
+        SELECT * FROM notification_logs 
+        WHERE user_id = ? 
+        ORDER BY created_at DESC 
+        LIMIT ?
+    `).all(userId, limit)
+
+    return rows.map((r: any) => ({
+        id: r.id,
+        userId: r.user_id,
+        provider: r.provider,
+        eventType: r.event_type,
+        status: r.status,
+        errorMessage: r.error_message || undefined,
+        createdAt: r.created_at
+    }))
 }

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -52,3 +52,16 @@ CREATE TABLE IF NOT EXISTS notification_preferences (
 );
 
 CREATE INDEX IF NOT EXISTS idx_notification_preferences_user ON notification_preferences(user_id);
+
+CREATE TABLE IF NOT EXISTS notification_logs (
+    id SERIAL PRIMARY KEY,
+    user_id VARCHAR(256) NOT NULL,
+    provider VARCHAR(32) NOT NULL,
+    event_type VARCHAR(64) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_logs_user ON notification_logs(user_id);
+CREATE INDEX IF NOT EXISTS idx_notification_logs_created_at ON notification_logs(created_at DESC);

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -3,7 +3,10 @@ import {
   dbSaveNotificationPreferences,
   dbGetNotificationPreferences,
   dbGetAllNotificationPreferences,
+  dbLogNotificationOutcome,
+  dbGetNotificationLogs,
   type NotificationPreferences,
+  type NotificationLog,
 } from "../db/notificationDb.js";
 import nodemailer from "nodemailer";
 
@@ -44,6 +47,8 @@ class WebhookProvider implements NotificationProvider {
     preferences: NotificationPreferences,
   ): Promise<void> {
     if (!preferences.webhookEnabled || !preferences.webhookUrl) {
+      // Log as 'skipped' since the webhook preconditions were not met
+      dbLogNotificationOutcome(payload.userId, 'webhook', payload.eventType, 'skipped', 'Webhook disabled or no URL provided');
       return;
     }
 
@@ -89,6 +94,8 @@ class WebhookProvider implements NotificationProvider {
         event: payload.event,
         userId: payload.userId,
       });
+      // Capture successful delivery outcome payload
+      dbLogNotificationOutcome(payload.userId, 'webhook', payload.event, 'sent');
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -98,11 +105,15 @@ class WebhookProvider implements NotificationProvider {
         error: errorMessage,
       });
 
-      // Retry once
+      // Retry once prior to total failure assertion
       if (attempt < this.MAX_RETRIES) {
+        // Track the intermittent failure state as 'retried'
+        dbLogNotificationOutcome(payload.userId, 'webhook', payload.event, 'retried', errorMessage);
         await new Promise((resolve) => setTimeout(resolve, 1000));
         await this.sendWithRetry(url, payload, attempt + 1);
       } else {
+        // Log final failure out to the DB if the max retries parameter is exceeded
+        dbLogNotificationOutcome(payload.userId, 'webhook', payload.event, 'failed', errorMessage);
         throw error;
       }
     }
@@ -173,6 +184,8 @@ class EmailProvider implements NotificationProvider {
         hasTransporter: !!this.transporter,
         userId: preferences.userId,
       });
+      // Record 'skipped' state if the app SMTP config or the user's config disables email sending
+      dbLogNotificationOutcome(payload.userId, 'email', payload.eventType, 'skipped', 'Email disabled or missing config');
       return;
     }
 
@@ -183,6 +196,7 @@ class EmailProvider implements NotificationProvider {
       logger.warn("No valid email address for user", {
         userId: preferences.userId,
       });
+      dbLogNotificationOutcome(payload.userId, 'email', payload.eventType, 'skipped', 'No valid email address');
       return;
     }
 
@@ -202,6 +216,7 @@ class EmailProvider implements NotificationProvider {
         userId: payload.userId,
         messageId: info.messageId,
       });
+      dbLogNotificationOutcome(payload.userId, 'email', payload.eventType, 'sent');
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -209,6 +224,8 @@ class EmailProvider implements NotificationProvider {
         to: recipientEmail,
         error: errorMessage,
       });
+      // Record failed transmission natively
+      dbLogNotificationOutcome(payload.userId, 'email', payload.eventType, 'failed', errorMessage);
       throw error;
     }
   }
@@ -383,6 +400,13 @@ export class NotificationService {
    */
   getAllPreferences(): NotificationPreferences[] {
     return dbGetAllNotificationPreferences();
+  }
+
+  /**
+   * Get delivery logs for a specific user
+   */
+  getLogs(userId: string): NotificationLog[] {
+    return dbGetNotificationLogs(userId);
   }
 }
 


### PR DESCRIPTION
### Description

Previously, the notification service dispatched webhook and email payloads without retaining any persistent record of their delivery outcomes. This made troubleshooting provider failures and disabled notifications difficult for contributors, requiring them to dig through raw application logs. 

This PR implements persistent database logging for notification deliveries and exposes an endpoint for users to query their own notification execution logs.

### Key Changes
1. **Schema Modifications (PostgreSQL & SQLite)**
   - Added a new `notification_logs` table that tracks the `user_id`, `provider` (email/webhook), `event_type`, delivery `status` (sent, skipped, retried, failed), and associative `error_messages`.
   - Built a self-cleaning continuous retention mechanism within SQLite (`dbLogNotificationOutcome`) that automatically prunes logs older than 30 days during each insertion to ensure lightweight environments don't bloat.
   - Appended proper `UP` and `DOWN` PostgreSQL migration sequences.
2. **Service Providers Instrumentation**
   - Refactored `WebhookProvider` (`backend/src/services/notificationService.ts`) to intercept network attempts, recording mid-flight `retried` statuses and terminal `failed`/`sent` statuses.
   - Refactored `EmailProvider` to enforce logging of `skipped` statuses (when a user/app disabled SMTP mapping) and tracking of successful or fatally rejected `Nodemailer` instances. 
3. **Operational Visibility API**
   - Created endpoint `GET /api/v1/notifications/logs` allowing users to retrieve delivery metadata.
   - Bound strict authorization logic to this endpoint: if the server uses `JWT_SECRET` authentication, the endpoint restricts the outputs precisely to the authenticated token’s target, explicitly protecting against arbitrary `?userId=` probing.

### Files Modified / Created
- **Created:** `backend/src/db/migrations/009_notification_logs.up.sql`
- **Created:** `backend/src/db/migrations/009_notification_logs.down.sql`
- **Modified:** `backend/src/db/schema.sql` (Appended `notification_logs` baseline schema)
- **Modified:** `backend/src/db/notificationDb.ts` (Integrated schema generation, 30-day cleanup, and log write/read methods)
- **Modified:** `backend/src/services/notificationService.ts` (Instrumented tracking bindings to Nodemailer and Fetch services)
- **Modified:** `backend/src/api/routes.ts` (Exposed GET controller and added duplicate import cleanup)

### New Endpoint Specs
**`GET /api/v1/notifications/logs`**
**Query parameters:**
- `userId` (required string): Stellar public key whose logs are being requested. Note that if authentication is enabled, this parameter must match the logged-in user context.
- Returns a normalized JSON payload mapping an array of recent `NotificationLog` structures denoting status, timestamp, provider, and error reasons.

### Testing Instructions
1. Run `npm run db:migrate` in the backend to ensure Postgres schemas mirror the update (if SQL is explicitly preferred over SQLite).
2. Register a webhook callback via `POST /api/v1/notifications/subscribe`.
3. Force a notification deployment by triggering the debug endpoint: `POST /api/v1/debug/notifications/test`.
4. Run `GET /api/v1/notifications/logs?userId=<YOUR_ADDRESS>` and verify that the `sent`, `failed`, or `skipped` payloads accurately map your previous execution variables.

Closes #180.