### PR TITLE
feat: migrate manual polling to TanStack Query hooks

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useCallback } from 'react'
 import { motion } from 'framer-motion'
 import { PieChart, Pie, Cell, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
 import { TrendingUp, AlertCircle, RefreshCw, ArrowLeft, ExternalLink, Trash2 } from 'lucide-react'
@@ -13,9 +13,10 @@ import PriceTracker from './PriceTracker'
 import { API_CONFIG } from '../config/api'
 
 // TanStack Query Hooks
-import { useUserPortfolios, usePortfolioDetails, useRebalanceEstimate } from '../hooks/queries/usePortfolioQuery'
-import { usePrices, formatPriceFeedSummary } from '../hooks/queries/usePricesQuery'
+import { useUserPortfolios, usePortfolioDetails, useRebalanceEstimate, portfolioKeys } from '../hooks/queries/usePortfolioQuery'
+import { usePrices, formatPriceFeedSummary, priceKeys } from '../hooks/queries/usePricesQuery'
 import { useExecuteRebalanceMutation } from '../hooks/mutations/usePortfolioMutations'
+import { useQueryClient } from '@tanstack/react-query'
 import { api, ENDPOINTS } from '../config/api'
 import { logout as authLogout } from '../services/authService'
 
@@ -109,11 +110,16 @@ const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
     const estimateUsd = rebalanceEstimate?.gasEstimateUsd ?? 0
     const hasHighGasWarning = rebalanceEstimate?.gasWarning || estimateXlm > 0.5
 
-    const refreshData = async () => {
-        // TanStack Query handles background refresh automatically, but we can force it
-        // by invalidating queries if needed. For now, simple manual refresh is fine.
-        window.location.reload()
-    }
+    const queryClient = useQueryClient()
+
+    const refreshData = useCallback(async () => {
+        // Invalidate all relevant queries to force a refetch without a full page reload.
+        // This leverages TanStack Query's cache invalidation instead of the naive window.location.reload().
+        await Promise.all([
+            queryClient.invalidateQueries({ queryKey: portfolioKeys.all }),
+            queryClient.invalidateQueries({ queryKey: priceKeys.all }),
+        ])
+    }, [queryClient])
 
     const disconnectWallet = async () => {
         if (publicKey) {

--- a/frontend/src/components/PriceTracker.tsx
+++ b/frontend/src/components/PriceTracker.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { Wifi, WifiOff, TrendingUp, TrendingDown } from 'lucide-react'
-import { api, ENDPOINTS } from '../config/api'
 import { usePrices, type PriceFeedClientMeta } from '../hooks/queries/usePricesQuery'
+import { useAssets } from '../hooks/queries/useAssetsQuery'
 import { useRealtimeConnection } from '../context/RealtimeConnectionContext'
 
 interface PriceTrackerProps {
@@ -81,7 +81,7 @@ function qualityMessage(meta: PriceFeedClientMeta | undefined): string | null {
 }
 
 const PriceTracker: React.FC<PriceTrackerProps> = ({ compact = false }) => {
-    const [assetList, setAssetList] = useState<string[]>(['XLM', 'BTC', 'ETH', 'USDC'])
+    const { data: assetList = ['XLM', 'BTC', 'ETH', 'USDC'] } = useAssets()
     const { data: priceBundle, isLoading, error: queryError, refetch } = usePrices()
     const { state: realtimeState } = useRealtimeConnection()
 
@@ -107,13 +107,8 @@ const PriceTracker: React.FC<PriceTrackerProps> = ({ compact = false }) => {
         void refetch()
     }
 
-    useEffect(() => {
-        api.get<{ assets: Array<{ symbol: string }> }>(ENDPOINTS.ASSETS)
-            .then((res) => {
-                if (res?.assets?.length) setAssetList(res.assets.map((a) => a.symbol))
-            })
-            .catch(() => {})
-    }, [])
+    // Assets list is now handled by useAssets() React Query hook above.
+    // This eliminates the manual useEffect fetch + setState pattern.
 
     if (loading && Object.keys(prices).length === 0) {
         return (

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -199,13 +199,6 @@ export const apiRequest = async <T>(
         try {
             const payload = await browserPriceService.getCurrentPrices()
             return payload as unknown as T
-            const prices = await browserPriceService.getCurrentPrices()
-            // Source information is embedded in each price entry via the 'source' field
-            debugLog('Price source: Browser (CoinGecko API or fallback)', {
-                assets: Object.keys(prices),
-                sourceSample: prices[Object.keys(prices)[0]]?.source
-            })
-            return prices as unknown as T
         } catch (error) {
             console.error('Browser price service failed, falling back to backend:', error)
             debugLog('Price fallback triggered: Attempting backend API')

--- a/frontend/src/hooks/queries/useAssetsQuery.ts
+++ b/frontend/src/hooks/queries/useAssetsQuery.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
+import { api, ENDPOINTS } from '../../config/api'
+
+export const assetKeys = {
+    all: ['assets'] as const,
+}
+
+interface Asset {
+    symbol: string
+}
+
+export const useAssets = () => {
+    return useQuery({
+        queryKey: assetKeys.all,
+        queryFn: async () => {
+            const res = await api.get<{ assets: Asset[] }>(ENDPOINTS.ASSETS)
+            return res?.assets?.map((a) => a.symbol) ?? ['XLM', 'BTC', 'ETH', 'USDC']
+        },
+        staleTime: 300000, // 5 minutes — asset list rarely changes
+        placeholderData: ['XLM', 'BTC', 'ETH', 'USDC'],
+    })
+}

--- a/frontend/src/hooks/queries/useReadinessQuery.ts
+++ b/frontend/src/hooks/queries/useReadinessQuery.ts
@@ -1,0 +1,78 @@
+import { useQuery } from '@tanstack/react-query'
+import { API_CONFIG } from '../../config/api'
+import type { ReadinessReport } from '../useReadinessReport'
+import { buildCapabilityNotices, type CapabilityNotice } from '../useReadinessReport'
+import { useMemo } from 'react'
+
+export const readinessKeys = {
+    all: ['readiness'] as const,
+}
+
+function isReadinessCheck(v: unknown): v is { status: string; required: boolean; message: string } {
+    if (!v || typeof v !== 'object') return false
+    const o = v as Record<string, unknown>
+    return (
+        (o.status === 'ready' || o.status === 'not_ready' || o.status === 'disabled') &&
+        typeof o.required === 'boolean' &&
+        typeof o.message === 'string'
+    )
+}
+
+function parseReadinessReport(body: unknown): ReadinessReport | null {
+    if (!body || typeof body !== 'object') return null
+    const o = body as Record<string, unknown>
+    if (o.status !== 'ready' && o.status !== 'not_ready') return null
+    const checks = o.checks
+    if (!checks || typeof checks !== 'object') return null
+    const c = checks as Record<string, unknown>
+    const keys = ['database', 'queue', 'workers', 'contractEventIndexer', 'autoRebalancer'] as const
+    for (const k of keys) {
+        if (!isReadinessCheck(c[k])) return null
+    }
+    return {
+        status: o.status as 'ready' | 'not_ready',
+        timestamp: typeof o.timestamp === 'string' ? o.timestamp : new Date().toISOString(),
+        uptimeSeconds: typeof o.uptimeSeconds === 'number' ? o.uptimeSeconds : undefined,
+        checks: c as ReadinessReport['checks'],
+    }
+}
+
+async function fetchReadinessReport(): Promise<ReadinessReport | null> {
+    const base = API_CONFIG.BASE_URL.replace(/\/$/, '')
+    const url = `${base}${API_CONFIG.ENDPOINTS.READINESS}`
+    const response = await fetch(url, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        mode: 'cors',
+        credentials: 'omit',
+    })
+    const ct = response.headers.get('content-type') || ''
+    if (!ct.includes('application/json')) {
+        return null
+    }
+    const body: unknown = await response.json()
+    return parseReadinessReport(body)
+}
+
+const POLL_MS = 45_000
+
+/**
+ * React Query version of useReadinessReport.
+ * Replaces manual setInterval polling with TanStack Query refetchInterval.
+ */
+export function useReadinessQuery() {
+    const { data: report, isLoading: loading, isError: loadError, refetch: refresh } = useQuery({
+        queryKey: readinessKeys.all,
+        queryFn: fetchReadinessReport,
+        refetchInterval: POLL_MS,
+        refetchOnWindowFocus: true,
+        staleTime: POLL_MS - 5000,
+    })
+
+    const notices: CapabilityNotice[] = useMemo(
+        () => (report ? buildCapabilityNotices(report) : []),
+        [report],
+    )
+
+    return { report: report ?? null, notices, loadError, loading, refresh }
+}

--- a/frontend/src/hooks/usePortfolio.ts
+++ b/frontend/src/hooks/usePortfolio.ts
@@ -1,3 +1,24 @@
+/**
+ * @deprecated Use `usePortfolioDetails` from `./queries/usePortfolioQuery` instead.
+ *
+ * This hook used a manual `useEffect` + `setInterval` polling pattern.
+ * It has been replaced by TanStack Query hooks that provide:
+ * - Automatic caching & deduplication
+ * - Background refetching via `refetchInterval`
+ * - Built-in loading/error states
+ * - Cache invalidation on mutations
+ *
+ * Migration:
+ * ```ts
+ * // Before:
+ * const { portfolio, loading, error, executeRebalance } = usePortfolio(id)
+ *
+ * // After:
+ * const { data: portfolio, isLoading, error } = usePortfolioDetails(id)
+ * const { mutateAsync: executeRebalance } = useExecuteRebalanceMutation(id)
+ * ```
+ */
+
 import { useState, useEffect } from 'react'
 import { api, ENDPOINTS } from '../config/api'
 
@@ -15,6 +36,13 @@ interface PortfolioData {
 }
 
 export const usePortfolio = (portfolioId?: string) => {
+    if (import.meta.env.DEV) {
+        console.warn(
+            '[usePortfolio] DEPRECATED: Use usePortfolioDetails from ./queries/usePortfolioQuery instead. ' +
+            'This hook uses manual polling that duplicates TanStack Query functionality.',
+        )
+    }
+
     const [portfolio, setPortfolio] = useState<PortfolioData | null>(null)
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)

--- a/frontend/src/hooks/useReflector.ts
+++ b/frontend/src/hooks/useReflector.ts
@@ -1,3 +1,23 @@
+/**
+ * @deprecated Use `usePrices` from `./queries/usePricesQuery` instead.
+ *
+ * This hook used a manual `useEffect` + `setInterval` polling pattern.
+ * It has been replaced by TanStack Query hooks that provide:
+ * - Automatic caching & deduplication
+ * - Background refetching via `refetchInterval`
+ * - Built-in loading/error states
+ *
+ * Migration:
+ * ```ts
+ * // Before:
+ * const { prices, loading, error } = useReflector()
+ *
+ * // After:
+ * const { data: priceBundle, isLoading, error } = usePrices()
+ * const prices = priceBundle?.prices ?? {}
+ * ```
+ */
+
 import { useState, useEffect } from 'react'
 import { api, ENDPOINTS } from '../config/api'
 import { unwrapPriceFeedPayload } from './queries/usePricesQuery'
@@ -11,6 +31,13 @@ interface PriceData {
 }
 
 export const useReflector = () => {
+    if (import.meta.env.DEV) {
+        console.warn(
+            '[useReflector] DEPRECATED: Use usePrices from ./queries/usePricesQuery instead. ' +
+            'This hook uses manual polling that duplicates TanStack Query functionality.',
+        )
+    }
+
     const [prices, setPrices] = useState<PriceData>({})
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)


### PR DESCRIPTION
## Summary

Resolves #40 — Migrate remaining manual `useEffect`/`setInterval` polling patterns to TanStack Query for centralized, deduplicated server-state management.

## What Changed

### New Hooks
- **`useAssetsQuery.ts`** — Replaces the manual `useEffect` + `api.get` pattern in PriceTracker with a React Query hook (`staleTime: 5min`, placeholder data for instant render)
- **`useReadinessQuery.ts`** — Replaces the manual `setInterval(45s)` health-check polling with `refetchInterval` + `refetchOnWindowFocus`

### Migrated Components
- **`Dashboard.tsx`** — Replaced `window.location.reload()` with `queryClient.invalidateQueries()` for proper cache-aware refresh
- **`PriceTracker.tsx`** — Replaced `useState` + `useEffect` asset fetching with the new `useAssets()` query hook

### Deprecated Hooks (backward-compatible)
- **`usePortfolio.ts`** — Added `@deprecated` JSDoc + runtime `console.warn` in dev mode. Consumers should use `usePortfolioDetails` + `useExecuteRebalanceMutation`
- **`useReflector.ts`** — Added `@deprecated` JSDoc + runtime `console.warn` in dev mode. Consumers should use `usePrices()`

### Bug Fix
- **`api.ts`** — Removed unreachable dead code after early `return` that caused a pre-existing TS7053 type error, unblocking the build

## Migration Guide

```ts
// Before (manual polling):
const { portfolio, loading, error } = usePortfolio(id)

// After (TanStack Query):
const { data: portfolio, isLoading, error } = usePortfolioDetails(id)
const { mutateAsync: rebalance } = useExecuteRebalanceMutation(id)
```

```ts
// Before (manual polling):
const { prices, loading, error } = useReflector()

// After (TanStack Query):
const { data: priceBundle, isLoading, error } = usePrices()
```

## Testing

- ✅ `tsc --noEmit` passes (0 new errors; fixed 1 pre-existing TS7053)
- ✅ `npm run build` succeeds (Vite production build)
- ✅ All changes are backward-compatible (deprecated hooks preserved)
- ✅ No secrets or credentials included