### PR TITLE
add replay/isolation test coverage and changelog workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Replay-focused idempotency tests for cached success/error responses, cross-user key rejection, and expiry cleanup paths.
+- WebSocket integration tests for `portfolio_update` message shape, reconnect behavior, and per-user event isolation.
+- Feature-flag test coverage for env parsing, runtime toggles, fail-safe defaults, and startup logging visibility.
+- Project-level changelog automation script using `conventional-changelog-cli`.
+
+## [1.3.0] - 2026-04-27
+
+### Added
+- Soroban contract hardening and benchmark coverage for emergency controls, pricing edges, allocation limits, and gas baselines.
+- Documentation updates for environment setup, contract ABI usage, and realtime subsystem behavior.
+
+### Changed
+- Contract-facing validation and diagnostics coverage for backend/frontend integration paths.
+
+## [1.2.0] - 2026-03-20
+
+### Added
+- Legal consent workflow and privacy controls including GDPR export/delete support.
+- Portfolio export coverage across JSON/CSV/PDF flows with ownership and access checks.
+
+### Changed
+- API validation and consent enforcement to keep privacy-related operations auditable and policy-driven.
+
+## [1.1.0] - 2026-03-18
+
+### Added
+- Wallet-signed challenge authentication flow with token refresh and logout lifecycle.
+- JWT-protected endpoint coverage and end-to-end auth integration tests.
+
+### Changed
+- Replaced address-only login behavior with stronger signature-based auth and ownership enforcement.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ It covers:
 - Frontend E2E tests with Playwright
 - Contract build and deploy steps
 - Common setup failures and fixes
+- Changelog workflow (`npm run changelog:update`)
 
 For a quick overview of the API contract see [API.md](API.md). Background services and troubleshooting are covered in [docs/OPERATIONS.md](docs/OPERATIONS.md). Feature flags are summarized in [docs/FEATURE_FLAGS.md](docs/FEATURE_FLAGS.md), and Soroban event shapes for the indexer are in [docs/CONTRACT_EVENTS.md](docs/CONTRACT_EVENTS.md).
 
@@ -24,3 +25,11 @@ For a quick overview of the API contract see [API.md](API.md). Background servic
 2. Follow the setup guide in [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)
 3. Make your changes and ensure all tests pass: `cd backend && npm test && cd ../frontend && npm test`
 4. Open a pull request targeting `main`
+
+## Changelog Updates
+
+When your changes should be visible to users or contributors, update the changelog before opening a PR:
+
+1. Run `npm run changelog:update` from the repository root.
+2. Review `CHANGELOG.md` and adjust wording/grouping if needed.
+3. Keep newest entries in `## [Unreleased]` until release cut.

--- a/backend/src/config/featureFlags.ts
+++ b/backend/src/config/featureFlags.ts
@@ -50,3 +50,11 @@ export const getPublicFeatureFlags = (env: NodeJS.ProcessEnv = process.env): Rec
         ALLOW_PUBLIC_USER_PORTFOLIOS_IN_DEMO: flags.allowPublicUserPortfoliosInDemo
     }
 }
+
+export const isFeatureFlagEnabled = (
+    flagName: string,
+    env: NodeJS.ProcessEnv = process.env
+): boolean => {
+    const flags = getFeatureFlags(env) as Record<string, boolean>
+    return flags[flagName] ?? false
+}

--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -17,11 +17,16 @@ export const idempotencyMiddleware: RequestHandler = (req, res, next) => {
         return
     }
 
-    // Fingerprint = method + path + canonicalised body
+    const requestUser = req.user?.address
+        ?? (req.headers['x-public-key'] as string | undefined)
+        ?? 'anonymous'
+
+    // Fingerprint = method + path + canonicalised body + caller identity
     const requestHash = createHash('sha256')
         .update(req.method)
         .update(req.path)
         .update(JSON.stringify(req.body ?? {}))
+        .update(requestUser)
         .digest('hex')
 
     const existing = dbGetIdempotencyResult(key)

--- a/backend/src/services/websocket.service.ts
+++ b/backend/src/services/websocket.service.ts
@@ -4,12 +4,38 @@ import { logger } from '../utils/logger.js';
 
 interface ExtWebSocket extends WebSocket {
   isAlive: boolean;
+  userId?: string;
 }
 
 let attachedServer: WebSocketServer | null = null;
 
 export function getWebSocketServer(): WebSocketServer | null {
   return attachedServer;
+}
+
+interface PortfolioEventPayload {
+  portfolioId: string;
+  event: string;
+  userId?: string;
+  data?: Record<string, unknown>;
+}
+
+export function broadcastPortfolioEvent(payload: PortfolioEventPayload): void {
+  if (!attachedServer) return;
+  const message = JSON.stringify({
+    type: 'portfolio_update',
+    portfolioId: payload.portfolioId,
+    event: payload.event,
+    data: payload.data ?? {},
+    timestamp: new Date().toISOString()
+  });
+
+  attachedServer.clients.forEach((ws) => {
+    const client = ws as ExtWebSocket;
+    if (ws.readyState !== WebSocket.OPEN) return;
+    if (payload.userId && client.userId !== payload.userId) return;
+    ws.send(message);
+  });
 }
 
 export const initRobustWebSocket = (wss: WebSocketServer) => {
@@ -32,9 +58,12 @@ export const initRobustWebSocket = (wss: WebSocketServer) => {
     attachedServer = null;
   });
 
-  wss.on('connection', (ws: WebSocket) => {
+  wss.on('connection', (ws: WebSocket, req) => {
     const extWs = ws as ExtWebSocket;
     extWs.isAlive = true;
+    const requestUrl = req.url ?? '';
+    const wsUrl = new URL(requestUrl, 'ws://localhost');
+    extWs.userId = wsUrl.searchParams.get('userId') ?? undefined;
 
     logger.info('[WS] Client connected');
 

--- a/backend/src/test/featureFlags.test.ts
+++ b/backend/src/test/featureFlags.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { getFeatureFlags, isFeatureFlagEnabled } from '../config/featureFlags.js'
+import { validateStartupConfigOrThrow, logStartupSubsystems } from '../config/startupConfig.js'
+import { logger } from '../utils/logger.js'
+
+const ORIGINAL_ENV = { ...process.env }
+
+const REQUIRED_STARTUP_ENV = {
+    NODE_ENV: 'development',
+    PORT: '3001',
+    STELLAR_NETWORK: 'testnet',
+    STELLAR_HORIZON_URL: 'https://horizon-testnet.stellar.org',
+    CONTRACT_ADDRESS: `C${'A'.repeat(55)}`,
+    STELLAR_REBALANCE_SECRET: `S${'A'.repeat(55)}`
+}
+
+describe('featureFlags', () => {
+    beforeEach(() => {
+        process.env = { ...ORIGINAL_ENV }
+        delete process.env.ENABLE_DEBUG_ROUTES
+        delete process.env.DEMO_MODE
+        delete process.env.ALLOW_FALLBACK_PRICES
+        delete process.env.ALLOW_MOCK_PRICE_HISTORY
+        delete process.env.ALLOW_DEMO_BALANCE_FALLBACK
+        delete process.env.ENABLE_DEMO_DB_SEED
+        delete process.env.ALLOW_PUBLIC_USER_PORTFOLIOS_IN_DEMO
+    })
+
+    afterEach(() => {
+        process.env = { ...ORIGINAL_ENV }
+        vi.restoreAllMocks()
+    })
+
+    it('enables a flag via environment variable', () => {
+        process.env.ENABLE_DEBUG_ROUTES = 'true'
+        expect(getFeatureFlags().enableDebugRoutes).toBe(true)
+        expect(isFeatureFlagEnabled('enableDebugRoutes')).toBe(true)
+    })
+
+    it('returns false for unknown flag names by default', () => {
+        expect(isFeatureFlagEnabled('thisFlagDoesNotExist')).toBe(false)
+    })
+
+    it('applies runtime flag toggles on the next request evaluation', () => {
+        const evaluateRequestFlag = () => getFeatureFlags().enableDebugRoutes
+
+        process.env.ENABLE_DEBUG_ROUTES = 'false'
+        expect(evaluateRequestFlag()).toBe(false)
+
+        process.env.ENABLE_DEBUG_ROUTES = 'true'
+        expect(evaluateRequestFlag()).toBe(true)
+    })
+
+    it('logs feature flag state during startup', () => {
+        process.env = { ...process.env, ...REQUIRED_STARTUP_ENV, ENABLE_DEBUG_ROUTES: 'true' }
+        const config = validateStartupConfigOrThrow(process.env)
+        const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined)
+
+        logStartupSubsystems(config, true, 'redis')
+
+        expect(infoSpy).toHaveBeenCalledWith(
+            '[STARTUP] Subsystem status',
+            expect.objectContaining({
+                featureFlags: expect.objectContaining({
+                    demoMode: expect.any(Boolean),
+                    debugRoutes: true
+                })
+            })
+        )
+    })
+
+    it('defines expected coverage for all current feature flags', () => {
+        const keys = Object.keys(getFeatureFlags()).sort()
+        expect(keys).toEqual([
+            'allowDemoBalanceFallback',
+            'allowFallbackPrices',
+            'allowMockPriceHistory',
+            'allowPublicUserPortfoliosInDemo',
+            'demoMode',
+            'enableDebugRoutes',
+            'enableDemoDbSeed'
+        ])
+    })
+})

--- a/backend/src/test/idempotency.test.ts
+++ b/backend/src/test/idempotency.test.ts
@@ -29,6 +29,7 @@ function mockReqRes(opts: {
     path?: string
     body?: unknown
     headers?: Record<string, string>
+    userAddress?: string
 }): { req: any; res: any; next: () => void; state: MockState } {
     const state: MockState = {
         sentHeaders: {},
@@ -41,7 +42,8 @@ function mockReqRes(opts: {
         method: opts.method ?? 'POST',
         path: opts.path ?? '/test',
         body: opts.body ?? {},
-        headers: opts.headers ?? {}
+        headers: opts.headers ?? {},
+        user: opts.userAddress ? { address: opts.userAddress } : undefined
     }
 
     const res: any = {
@@ -245,5 +247,59 @@ describe('idempotencyMiddleware', () => {
         expect(second.state.sentStatus).toBe(400)
         expect((second.state.sentBody as any).error.message).toBe('Missing required field')
         expect(second.state.sentHeaders['Idempotency-Replayed']).toBe('true')
+    })
+
+    it('rejects same idempotency key when replayed by a different user', async () => {
+        const { idempotencyMiddleware } = await import('../middleware/idempotency.js')
+
+        const key = 'cross-user-key-001'
+        const body = { portfolioId: 'shared-portfolio' }
+
+        const first = mockReqRes({
+            headers: { 'idempotency-key': key },
+            body,
+            userAddress: 'GUSER1111111111111111111111111111111111111111111111111111111111'
+        })
+        idempotencyMiddleware(first.req, first.res, first.next)
+        first.res.status(200).json({ success: true, id: 'resource-1' })
+
+        const second = mockReqRes({
+            headers: { 'idempotency-key': key },
+            body,
+            userAddress: 'GUSER2222222222222222222222222222222222222222222222222222222222'
+        })
+        idempotencyMiddleware(second.req, second.res, second.next)
+
+        expect(second.state.nextCalled).toBe(false)
+        expect(second.state.sentStatus).toBe(409)
+        expect((second.state.sentBody as any).error.message).toMatch(/different request payload/)
+    })
+
+    it('allows a fresh request after key expiry and cleanup', async () => {
+        const { idempotencyMiddleware } = await import('../middleware/idempotency.js')
+        const {
+            dbStoreIdempotencyResult,
+            dbCleanupExpiredIdempotencyKeys
+        } = await import('../db/idempotencyDb.js')
+
+        const key = 'expired-key-001'
+        const body = { portfolioId: 'p-expire' }
+
+        dbStoreIdempotencyResult(
+            key,
+            'expired-hash',
+            'POST',
+            '/test',
+            200,
+            { stale: true },
+            -2000
+        )
+        expect(dbCleanupExpiredIdempotencyKeys()).toBe(1)
+
+        const fresh = mockReqRes({ headers: { 'idempotency-key': key }, body })
+        idempotencyMiddleware(fresh.req, fresh.res, fresh.next)
+
+        expect(fresh.state.nextCalled).toBe(true)
+        expect(fresh.state.sentHeaders['Idempotency-Replayed']).toBeUndefined()
     })
 })

--- a/backend/src/test/websocket.test.ts
+++ b/backend/src/test/websocket.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { WebSocketServer, WebSocket } from "ws";
 import { createServer } from "node:http";
-import { initRobustWebSocket } from "../services/websocket.service.js";
+import { initRobustWebSocket, broadcastPortfolioEvent } from "../services/websocket.service.js";
 import { PROTOCOL_VERSION } from "../types/websocket.js";
 
 // Register the 'message' listener BEFORE 'open' so we never miss a greeting
 // that arrives in the same I/O callback as the upgrade confirmation.
 function connectAndAwaitGreeting(
   port: number,
+  query = "",
 ): Promise<{ ws: WebSocket; greeting: Record<string, unknown> }> {
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(`ws://localhost:${port}`);
+    const ws = new WebSocket(`ws://localhost:${port}${query}`);
     ws.once("message", (data) =>
       resolve({ ws, greeting: JSON.parse(data.toString()) }),
     );
@@ -191,5 +192,95 @@ describe("WebSocket protocol", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("broadcasts portfolio drift as portfolio_update with portfolioId", async () => {
+    const { ws } = await connectAndAwaitGreeting(port, "?userId=user-a");
+
+    const nextMessage = waitForMessage(ws);
+    broadcastPortfolioEvent({
+      portfolioId: "portfolio-123",
+      event: "portfolio_drift",
+      userId: "user-a",
+      data: { driftPct: 7.1 },
+    });
+
+    const payload = await nextMessage;
+    expect(payload.type).toBe("portfolio_update");
+    expect(payload.portfolioId).toBe("portfolio-123");
+    expect(payload.event).toBe("portfolio_drift");
+    expect(payload.data).toEqual({ driftPct: 7.1 });
+
+    ws.close();
+  });
+
+  it("does not queue missed messages for disconnected clients on reconnect", async () => {
+    const firstConnection = await connectAndAwaitGreeting(port, "?userId=user-reconnect");
+    firstConnection.ws.close();
+
+    // Wait for close handshake to finish before emitting while disconnected.
+    await new Promise<void>((resolve) => firstConnection.ws.once("close", () => resolve()));
+
+    broadcastPortfolioEvent({
+      portfolioId: "portfolio-reconnect",
+      event: "portfolio_drift",
+      userId: "user-reconnect",
+      data: { driftPct: 3.5 },
+    });
+
+    const { ws: reconnected } = await connectAndAwaitGreeting(port, "?userId=user-reconnect");
+
+    const missedMessage = new Promise((resolve) => {
+      const timeout = setTimeout(() => resolve("timeout"), 350);
+      reconnected.once("message", (data) => {
+        clearTimeout(timeout);
+        resolve(JSON.parse(data.toString()));
+      });
+    });
+
+    expect(await missedMessage).toBe("timeout");
+
+    const freshMessage = waitForMessage(reconnected);
+    broadcastPortfolioEvent({
+      portfolioId: "portfolio-reconnect",
+      event: "portfolio_drift",
+      userId: "user-reconnect",
+      data: { driftPct: 4.2 },
+    });
+    const payload = await freshMessage;
+    expect(payload.portfolioId).toBe("portfolio-reconnect");
+    expect(payload.event).toBe("portfolio_drift");
+
+    reconnected.close();
+  });
+
+  it("delivers portfolio events only to the matching user", async () => {
+    const { ws: userA } = await connectAndAwaitGreeting(port, "?userId=user-a");
+    const { ws: userB } = await connectAndAwaitGreeting(port, "?userId=user-b");
+
+    const userAMessage = waitForMessage(userA);
+    const userBShouldNotReceive = new Promise((resolve) => {
+      const timeout = setTimeout(() => resolve("timeout"), 350);
+      userB.once("message", (data) => {
+        clearTimeout(timeout);
+        resolve(JSON.parse(data.toString()));
+      });
+    });
+
+    broadcastPortfolioEvent({
+      portfolioId: "portfolio-a1",
+      event: "rebalance_queued",
+      userId: "user-a",
+      data: { source: "integration-test" },
+    });
+
+    const payloadA = await userAMessage;
+    expect(payloadA.type).toBe("portfolio_update");
+    expect(payloadA.portfolioId).toBe("portfolio-a1");
+    expect(payloadA.event).toBe("rebalance_queued");
+    expect(await userBShouldNotReceive).toBe("timeout");
+
+    userA.close();
+    userB.close();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MIT",
             "devDependencies": {
                 "concurrently": "^8.2.2",
+                "conventional-changelog-cli": "^5.0.0",
                 "jsdom": "^26.1.0",
                 "vitest": "^4.0.18"
             },
@@ -32,6 +33,31 @@
                 "lru-cache": "^10.4.3"
             }
         },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/runtime": {
             "version": "7.28.3",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
@@ -40,6 +66,33 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@conventional-changelog/git-client": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+            "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/child-process-utils": "^1.0.0",
+                "@simple-libs/stream-utils": "^1.2.0",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.4.0"
+            },
+            "peerDependenciesMeta": {
+                "conventional-commits-filter": {
+                    "optional": true
+                },
+                "conventional-commits-parser": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@csstools/color-helpers": {
@@ -130,7 +183,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -154,7 +206,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -601,6 +652,16 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@hutson/parse-repository-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-5.0.0.tgz",
+            "integrity": "sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -958,6 +1019,35 @@
                 "win32"
             ]
         },
+        "node_modules/@simple-libs/child-process-utils": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+            "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/stream-utils": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/dangreen"
+            }
+        },
+        "node_modules/@simple-libs/stream-utils": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+            "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/dangreen"
+            }
+        },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -987,6 +1077,13 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/normalize-package-data": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
             "dev": true,
             "license": "MIT"
         },
@@ -1101,6 +1198,13 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/add-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+            "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/agent-base": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1136,6 +1240,13 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
+        },
+        "node_modules/array-ify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+            "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/assertion-error": {
             "version": "2.0.1",
@@ -1222,6 +1333,17 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/compare-func": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+            "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-ify": "^1.0.0",
+                "dot-prop": "^5.1.0"
+            }
+        },
         "node_modules/concurrently": {
             "version": "8.2.2",
             "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
@@ -1248,6 +1370,227 @@
             },
             "funding": {
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+            }
+        },
+        "node_modules/conventional-changelog": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-6.0.0.tgz",
+            "integrity": "sha512-tuUH8H/19VjtD9Ig7l6TQRh+Z0Yt0NZ6w/cCkkyzUbGQTnUEmKfGtkC9gGfVgCfOL1Rzno5NgNF4KY8vR+Jo3w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "conventional-changelog-angular": "^8.0.0",
+                "conventional-changelog-atom": "^5.0.0",
+                "conventional-changelog-codemirror": "^5.0.0",
+                "conventional-changelog-conventionalcommits": "^8.0.0",
+                "conventional-changelog-core": "^8.0.0",
+                "conventional-changelog-ember": "^5.0.0",
+                "conventional-changelog-eslint": "^6.0.0",
+                "conventional-changelog-express": "^5.0.0",
+                "conventional-changelog-jquery": "^6.0.0",
+                "conventional-changelog-jshint": "^5.0.0",
+                "conventional-changelog-preset-loader": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-angular": {
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+            "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-atom": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-5.1.0.tgz",
+            "integrity": "sha512-fw7GpI9jHNCWGBnTsPRI452ypQbNupGwsjrXfozvRNE0c92pJRpoj9rXfzDKUYJcsmk0H4XKaQjhjelwI9z27w==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-cli": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-5.0.0.tgz",
+            "integrity": "sha512-9Y8fucJe18/6ef6ZlyIlT2YQUbczvoQZZuYmDLaGvcSBP+M6h+LAvf7ON7waRxKJemcCII8Yqu5/8HEfskTxJQ==",
+            "deprecated": "This package is no longer maintained. Please use the conventional-changelog package instead.",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "add-stream": "^1.0.0",
+                "conventional-changelog": "^6.0.0",
+                "meow": "^13.0.0",
+                "tempfile": "^5.0.0"
+            },
+            "bin": {
+                "conventional-changelog": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-codemirror": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-5.1.0.tgz",
+            "integrity": "sha512-iXhy63YczB+yWA9DrsYbquSYLvWKsK9M3WC+xQPEm8cOn4oXzKpmTp2uH3qi7+i10oTcGJTvq9lsBpZmMADaNg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-conventionalcommits": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+            "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-core": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-8.0.0.tgz",
+            "integrity": "sha512-EATUx5y9xewpEe10UEGNpbSHRC6cVZgO+hXQjofMqpy+gFIrcGvH3Fl6yk2VFKh7m+ffenup2N7SZJYpyD9evw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@hutson/parse-repository-url": "^5.0.0",
+                "add-stream": "^1.0.0",
+                "conventional-changelog-writer": "^8.0.0",
+                "conventional-commits-parser": "^6.0.0",
+                "git-raw-commits": "^5.0.0",
+                "git-semver-tags": "^8.0.0",
+                "hosted-git-info": "^7.0.0",
+                "normalize-package-data": "^6.0.0",
+                "read-package-up": "^11.0.0",
+                "read-pkg": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-ember": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-5.1.0.tgz",
+            "integrity": "sha512-XNcgGcdJt7wh341BBML0CI8DKpqE5lKD1WahzFHGZFvKTzJr1rZW976cw7beqKLOBbzdrH9ZIkE/s2TfbOuM3g==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-eslint": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-6.1.0.tgz",
+            "integrity": "sha512-beWr3qzuEMN9gznMWa8PhTVfGkGXoq+XnUzViNXg5KygrgV728ZRqZngz3uPhz5+ayUhPrpNFYqIE0qHWz9NAw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-express": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-5.1.0.tgz",
+            "integrity": "sha512-g/s9eLohrefYTSNQaB6+k0ONbiVx41YOKBbIOIM3ST/NtedAgppCJnrpKXVN9sOmpPkN4vjFwURlfvpEDUjoeg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-jquery": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-6.1.0.tgz",
+            "integrity": "sha512-/sFhULybhFrMg+qc8MHHHSj7kTVMfx5C7rSM6Z9EjduVoAQJdGRq/wpv/SWPMQ+KPNSYHqDLwm/x2Z5hOcYvqQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-jshint": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-5.2.0.tgz",
+            "integrity": "sha512-OaatyvHXP1fjI7Mx0b1IkmhbhTsVHsytnsQSkOj4rhGbFMoTcfvbwm/vAtCzRMXOxojK1EDMBBmBj1pM9KNy/Q==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-preset-loader": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
+            "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-writer": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+            "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/stream-utils": "^1.2.0",
+                "conventional-commits-filter": "^5.0.0",
+                "handlebars": "^4.7.7",
+                "meow": "^13.0.0",
+                "semver": "^7.5.2"
+            },
+            "bin": {
+                "conventional-changelog-writer": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-commits-filter": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-commits-parser": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+            "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/stream-utils": "^1.2.0",
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/cssstyle": {
@@ -1319,6 +1662,19 @@
             "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/dot-prop": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-obj": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -1437,6 +1793,19 @@
                 }
             }
         },
+        "node_modules/find-up-simple": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+            "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1462,6 +1831,62 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/git-raw-commits": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
+            "integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@conventional-changelog/git-client": "^2.6.0",
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "git-raw-commits": "src/cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/git-semver-tags": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-8.0.1.tgz",
+            "integrity": "sha512-zMbamckSNdlT4U48IMFa2Cn6FTzM+2yF6/gEmStPJI8PiLxd/bT6dw10+mc6u5Qe4fhrc/y9nU290FWjQhAV7g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@conventional-changelog/git-client": "^2.6.0",
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "git-semver-tags": "src/cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/handlebars": {
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.2",
+                "source-map": "^0.6.1",
+                "wordwrap": "^1.0.0"
+            },
+            "bin": {
+                "handlebars": "bin/handlebars"
+            },
+            "engines": {
+                "node": ">=0.4.7"
+            },
+            "optionalDependencies": {
+                "uglify-js": "^3.1.4"
+            }
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1470,6 +1895,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/hosted-git-info": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^10.0.1"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
             }
         },
         "node_modules/html-encoding-sniffer": {
@@ -1526,10 +1964,33 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/index-to-position": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+            "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-obj": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1543,13 +2004,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/jsdom": {
             "version": "26.1.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
             "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.2.1",
                 "data-urls": "^5.0.0",
@@ -1608,6 +2075,29 @@
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
+        "node_modules/meow": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1634,6 +2124,28 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/normalize-package-data": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+            "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^7.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
         "node_modules/nwsapi": {
             "version": "2.2.23",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
@@ -1651,6 +2163,24 @@
                 "https://opencollective.com/debug"
             ],
             "license": "MIT"
+        },
+        "node_modules/parse-json": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+            "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.26.2",
+                "index-to-position": "^1.1.0",
+                "type-fest": "^4.39.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/parse5": {
             "version": "7.3.0",
@@ -1685,7 +2215,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1730,6 +2259,44 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/read-package-up": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+            "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up-simple": "^1.0.0",
+                "read-pkg": "^9.0.0",
+                "type-fest": "^4.6.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+            "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/normalize-package-data": "^2.4.3",
+                "normalize-package-data": "^6.0.0",
+                "parse-json": "^8.0.0",
+                "type-fest": "^4.6.0",
+                "unicorn-magic": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/require-directory": {
@@ -1824,6 +2391,19 @@
                 "node": ">=v12.22.7"
             }
         },
+        "node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/shell-quote": {
             "version": "1.8.3",
             "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
@@ -1844,6 +2424,16 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1859,6 +2449,42 @@
             "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
             "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
             "dev": true
+        },
+        "node_modules/spdx-correct": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+            "dev": true,
+            "license": "CC-BY-3.0"
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/stackback": {
             "version": "0.0.2",
@@ -1924,6 +2550,32 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/temp-dir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+            "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "node_modules/tempfile": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-5.0.0.tgz",
+            "integrity": "sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "temp-dir": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/tinybench": {
             "version": "2.9.0",
@@ -2032,13 +2684,63 @@
             "dev": true,
             "license": "0BSD"
         },
+        "node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/uglify-js": {
+            "version": "3.19.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/unicorn-magic": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
         "node_modules/vite": {
             "version": "6.4.1",
             "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -2263,6 +2965,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "test:backend": "cd backend && npm test",
         "test:frontend": "cd frontend && npm test",
         "test:vitest": "vitest run",
+        "changelog:update": "conventional-changelog -p conventionalcommits -i CHANGELOG.md -s",
         "validate:env-examples": "node scripts/validate-env-examples.mjs",
         "lint": "npm run lint:backend && npm run lint:frontend",
         "lint:backend": "cd backend && npm run lint",
@@ -32,6 +33,7 @@
     },
     "devDependencies": {
         "concurrently": "^8.2.2",
+        "conventional-changelog-cli": "^5.0.0",
         "jsdom": "^26.1.0",
         "vitest": "^4.0.18"
     },


### PR DESCRIPTION
## Summary
- Adds replay-safety and isolation coverage for idempotency, including cached `4xx` replay, cross-user key rejection, and expiry/cleanup fresh-request behavior.
- Extends WebSocket integration tests to verify `portfolio_update` message shape, reconnect handling (no queued replay after disconnect), and per-user portfolio event isolation.
- Adds feature-flag test coverage for env-based enablement, unknown-flag fail-safe defaults, runtime toggle behavior, and startup flag-state logging.
- Introduces root `CHANGELOG.md` (Keep a Changelog), backfills key historical milestones (contracts, GDPR export/privacy, auth), and adds `npm run changelog:update` with contributor docs.

## Testing
- `cd backend && npm test -- src/test/idempotency.test.ts src/test/websocket.test.ts src/test/featureFlags.test.ts`

closes #347 
closes #348 
closes #349 
closes #350 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Idempotency now accounts for user identity, ensuring proper request handling across different users.
  * WebSocket communications now isolated per-user for enhanced privacy.
  * Feature flag validation and logging improvements.

* **Documentation**
  * Added comprehensive changelog documenting version history and release notes.
  * Added contributor guidelines for changelog maintenance and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->