### PR TITLE
Harden JWT rotation, CORS origin checks, and security test coverage.

### DIFF
--- a/backend/src/http/corsSecurity.ts
+++ b/backend/src/http/corsSecurity.ts
@@ -1,0 +1,44 @@
+import type { CorsOptions } from 'cors'
+import type { Request, Response, NextFunction } from 'express'
+
+const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH', 'HEAD'] as const
+const ALLOWED_HEADERS = [
+    'Content-Type',
+    'Authorization',
+    'Accept',
+    'Origin',
+    'X-Requested-With',
+    'X-Request-Id',
+] as const
+
+export function buildCorsOptions(corsOrigins: string[]): CorsOptions {
+    return {
+        origin: corsOrigins.length > 0 ? corsOrigins : true,
+        credentials: true,
+        methods: [...ALLOWED_METHODS],
+        allowedHeaders: [...ALLOWED_HEADERS],
+    }
+}
+
+export function enforceCorsOriginAllowlist(corsOrigins: string[]) {
+    const hasAllowlist = corsOrigins.length > 0
+    const allowedOrigins = new Set(corsOrigins)
+
+    return (req: Request, res: Response, next: NextFunction): void => {
+        const origin = req.headers.origin
+        if (!origin || !hasAllowlist || allowedOrigins.has(origin)) {
+            next()
+            return
+        }
+
+        res.status(403).json({
+            success: false,
+            data: null,
+            error: {
+                code: 'CORS_FORBIDDEN_ORIGIN',
+                message: 'Origin is not allowed by CORS policy',
+            },
+            timestamp: new Date().toISOString(),
+        })
+    }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import { initializeSentry, setupProcessErrorHandlers, captureException } from '.
 import { metricsMiddleware, getMetricsPayload, getMetricsContentType } from './observability/metrics.js'
 import { buildReadinessReport } from './monitoring/readiness.js'
 import { mountApiRoutes, mountLegacyNonApiRedirects } from './http/mountApiRoutes.js'
+import { buildCorsOptions, enforceCorsOriginAllowlist } from './http/corsSecurity.js'
 import spec from './openapi/spec.js'
 import { initRobustWebSocket } from './services/websocket.service.js'
 
@@ -29,20 +30,9 @@ async function main() {
 
     const app = express()
 
-    const corsOptions: cors.CorsOptions = {
-        origin: config.corsOrigins.length > 0 ? config.corsOrigins : true,
-        credentials: true,
-        methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH', 'HEAD'],
-        allowedHeaders: [
-            'Content-Type',
-            'Authorization',
-            'Accept',
-            'Origin',
-            'X-Requested-With',
-            'X-Request-Id',
-        ],
-    }
+    const corsOptions: cors.CorsOptions = buildCorsOptions(config.corsOrigins)
 
+    app.use(enforceCorsOriginAllowlist(config.corsOrigins))
     app.use(cors(corsOptions))
     app.options('*', cors(corsOptions))
     app.use(requestContextMiddleware)

--- a/backend/src/middleware/requireJwt.ts
+++ b/backend/src/middleware/requireJwt.ts
@@ -1,10 +1,15 @@
 import { Request, Response, NextFunction } from 'express'
-import { verifyAccessToken } from '../services/authService.js'
+import jwt from 'jsonwebtoken'
 import { getAuthConfig } from '../services/authService.js'
 import { fail } from '../utils/apiResponse.js'
 
 export interface JwtUser {
     address: string
+}
+
+interface AccessJwtPayload extends jwt.JwtPayload {
+    sub: string
+    type: 'access'
 }
 
 declare global {
@@ -22,16 +27,79 @@ export function requireJwt(req: Request, res: Response, next: NextFunction): voi
         fail(res, 401, 'UNAUTHORIZED', 'Missing or invalid Authorization header')
         return
     }
-    const payload = verifyAccessToken(token)
-    if (!payload) {
-        fail(res, 401, 'UNAUTHORIZED', 'Invalid or expired token')
+
+    const verification = verifyAccessTokenWithRotation(token)
+    if (!verification.ok) {
+        const isExpired = verification.reason === 'expired'
+        fail(
+            res,
+            401,
+            isExpired ? 'TOKEN_EXPIRED' : 'UNAUTHORIZED',
+            isExpired ? 'Access token expired' : 'Invalid access token'
+        )
         return
     }
-    req.user = { address: payload.sub }
+
+    req.user = { address: verification.payload.sub }
     next()
 }
 
 export function requireJwtWhenEnabled(req: Request, res: Response, next: NextFunction): void {
     if (!getAuthConfig().enabled) return next()
     requireJwt(req, res, next)
+}
+
+function verifyAccessTokenWithRotation(token: string):
+    | { ok: true; payload: AccessJwtPayload }
+    | { ok: false; reason: 'expired' | 'invalid' } {
+    const currentSecret = process.env.JWT_SECRET
+    if (!currentSecret || currentSecret.length < 32) {
+        return { ok: false, reason: 'invalid' }
+    }
+
+    const currentResult = verifyWithSecret(token, currentSecret)
+    if (currentResult.ok) return currentResult
+    if (currentResult.reason === 'expired') return currentResult
+
+    const previousSecret = process.env.JWT_PREVIOUS_SECRET
+    if (!isPreviousSecretWithinGracePeriod(previousSecret)) {
+        return currentResult
+    }
+
+    return verifyWithSecret(token, previousSecret as string)
+}
+
+function verifyWithSecret(token: string, secret: string):
+    | { ok: true; payload: AccessJwtPayload }
+    | { ok: false; reason: 'expired' | 'invalid' } {
+    try {
+        const decoded = jwt.verify(token, secret)
+        if (!isAccessPayload(decoded)) {
+            return { ok: false, reason: 'invalid' }
+        }
+        return { ok: true, payload: decoded }
+    } catch (error) {
+        if (error instanceof jwt.TokenExpiredError) {
+            return { ok: false, reason: 'expired' }
+        }
+        return { ok: false, reason: 'invalid' }
+    }
+}
+
+function isAccessPayload(payload: string | jwt.JwtPayload): payload is AccessJwtPayload {
+    return (
+        typeof payload === 'object' &&
+        payload !== null &&
+        typeof payload.sub === 'string' &&
+        payload.type === 'access'
+    )
+}
+
+function isPreviousSecretWithinGracePeriod(previousSecret: string | undefined): boolean {
+    if (!previousSecret || previousSecret.length < 32) return false
+    const graceUntilRaw = process.env.JWT_PREVIOUS_SECRET_GRACE_UNTIL
+    if (!graceUntilRaw) return false
+    const graceUntilMs = Date.parse(graceUntilRaw)
+    if (Number.isNaN(graceUntilMs)) return false
+    return Date.now() <= graceUntilMs
 }

--- a/backend/src/test/cors.security.test.ts
+++ b/backend/src/test/cors.security.test.ts
@@ -1,0 +1,62 @@
+import express from 'express'
+import cors from 'cors'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+import { buildCorsOptions, enforceCorsOriginAllowlist } from '../http/corsSecurity.js'
+
+function createCorsApp(corsOrigins: string[]) {
+    const app = express()
+    const corsOptions = buildCorsOptions(corsOrigins)
+    app.use(enforceCorsOriginAllowlist(corsOrigins))
+    app.use(cors(corsOptions))
+    app.options('*', cors(corsOptions))
+    app.get('/secure', (_req, res) => {
+        res.status(200).json({ ok: true })
+    })
+    return app
+}
+
+describe('CORS security policy', () => {
+    it('allows configured origin requests with credentials', async () => {
+        const app = createCorsApp(['https://app.example.com'])
+        const res = await request(app)
+            .get('/secure')
+            .set('Origin', 'https://app.example.com')
+            .expect(200)
+
+        expect(res.headers['access-control-allow-origin']).toBe('https://app.example.com')
+        expect(res.headers['access-control-allow-credentials']).toBe('true')
+    })
+
+    it('rejects unlisted origins with 403', async () => {
+        const app = createCorsApp(['https://app.example.com'])
+        const res = await request(app)
+            .get('/secure')
+            .set('Origin', 'https://evil.example.com')
+            .expect(403)
+
+        expect(res.body.error?.code).toBe('CORS_FORBIDDEN_ORIGIN')
+    })
+
+    it('blocks preflight OPTIONS from unlisted origins', async () => {
+        const app = createCorsApp(['https://app.example.com'])
+        const res = await request(app)
+            .options('/secure')
+            .set('Origin', 'https://evil.example.com')
+            .set('Access-Control-Request-Method', 'POST')
+            .expect(403)
+
+        expect(res.body.error?.code).toBe('CORS_FORBIDDEN_ORIGIN')
+    })
+
+    it('never emits wildcard origin when credentials are enabled', async () => {
+        const app = createCorsApp(['https://app.example.com'])
+        const res = await request(app)
+            .get('/secure')
+            .set('Origin', 'https://app.example.com')
+            .expect(200)
+
+        expect(res.headers['access-control-allow-credentials']).toBe('true')
+        expect(res.headers['access-control-allow-origin']).not.toBe('*')
+    })
+})

--- a/backend/src/test/requireJwt.test.ts
+++ b/backend/src/test/requireJwt.test.ts
@@ -1,0 +1,120 @@
+import express from 'express'
+import jwt from 'jsonwebtoken'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { requireJwt } from '../middleware/requireJwt.js'
+
+const CURRENT_SECRET = 'c'.repeat(32)
+const PREVIOUS_SECRET = 'p'.repeat(32)
+
+function createApp() {
+    const app = express()
+    app.get('/protected', requireJwt, (req, res) => {
+        res.status(200).json({
+            ok: true,
+            user: req.user ?? null,
+        })
+    })
+    return app
+}
+
+describe('requireJwt middleware', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+        vi.stubEnv('JWT_SECRET', CURRENT_SECRET)
+        vi.stubEnv('JWT_PREVIOUS_SECRET', '')
+        vi.stubEnv('JWT_PREVIOUS_SECRET_GRACE_UNTIL', '')
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.unstubAllEnvs()
+    })
+
+    it('passes valid token and attaches user to request context', async () => {
+        const token = jwt.sign({ sub: 'GVALID123', type: 'access' }, CURRENT_SECRET, { expiresIn: '15m' })
+        const app = createApp()
+
+        const res = await request(app)
+            .get('/protected')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200)
+
+        expect(res.body.ok).toBe(true)
+        expect(res.body.user).toEqual({ address: 'GVALID123' })
+    })
+
+    it('returns 401 with TOKEN_EXPIRED for expired token', async () => {
+        const token = jwt.sign({ sub: 'GEXPIRED', type: 'access' }, CURRENT_SECRET, { expiresIn: -1 })
+        const app = createApp()
+
+        const res = await request(app)
+            .get('/protected')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(401)
+
+        expect(res.body.error?.code).toBe('TOKEN_EXPIRED')
+    })
+
+    it('returns 401 for malformed token input', async () => {
+        const app = createApp()
+        const malformed = 'not-base64-token'
+        const res = await request(app)
+            .get('/protected')
+            .set('Authorization', `Bearer ${malformed}`)
+            .expect(401)
+
+        expect(res.body.error?.code).toBe('UNAUTHORIZED')
+    })
+
+    it('returns 401 for token signed with wrong secret', async () => {
+        const wrongSecretToken = jwt.sign({ sub: 'GWRONG', type: 'access' }, 'w'.repeat(32), { expiresIn: '15m' })
+        const app = createApp()
+
+        const res = await request(app)
+            .get('/protected')
+            .set('Authorization', `Bearer ${wrongSecretToken}`)
+            .expect(401)
+
+        expect(res.body.error?.code).toBe('UNAUTHORIZED')
+    })
+
+    it('returns 401 for missing Authorization header', async () => {
+        const app = createApp()
+
+        const res = await request(app)
+            .get('/protected')
+            .expect(401)
+
+        expect(res.body.error?.code).toBe('UNAUTHORIZED')
+    })
+
+    it('accepts tokens signed with previous secret within grace period', async () => {
+        vi.stubEnv('JWT_PREVIOUS_SECRET', PREVIOUS_SECRET)
+        vi.stubEnv('JWT_PREVIOUS_SECRET_GRACE_UNTIL', '2026-01-01T01:00:00.000Z')
+        const oldToken = jwt.sign({ sub: 'GOLDSECRET', type: 'access' }, PREVIOUS_SECRET, { expiresIn: '15m' })
+        const app = createApp()
+
+        const res = await request(app)
+            .get('/protected')
+            .set('Authorization', `Bearer ${oldToken}`)
+            .expect(200)
+
+        expect(res.body.user).toEqual({ address: 'GOLDSECRET' })
+    })
+
+    it('rejects tokens signed with previous secret after grace period', async () => {
+        vi.stubEnv('JWT_PREVIOUS_SECRET', PREVIOUS_SECRET)
+        vi.stubEnv('JWT_PREVIOUS_SECRET_GRACE_UNTIL', '2025-12-31T23:59:59.000Z')
+        const oldToken = jwt.sign({ sub: 'GOLDREJECTED', type: 'access' }, PREVIOUS_SECRET, { expiresIn: '15m' })
+        const app = createApp()
+
+        const res = await request(app)
+            .get('/protected')
+            .set('Authorization', `Bearer ${oldToken}`)
+            .expect(401)
+
+        expect(res.body.error?.code).toBe('UNAUTHORIZED')
+    })
+})

--- a/backend/src/test/secretRedactor.test.ts
+++ b/backend/src/test/secretRedactor.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { redactObject } from '../utils/secretRedactor.js'
+
+describe('secretRedactor', () => {
+    it('redacts authorization header values', () => {
+        const input = {
+            headers: {
+                authorization: 'Bearer very-sensitive-token',
+                'content-type': 'application/json',
+            },
+        }
+
+        const output = redactObject(input)
+
+        expect(output.headers.authorization).toBe('[REDACTED]')
+        expect(output.headers['content-type']).toBe('application/json')
+    })
+
+    it('redacts privateKey, secret, and apiKey fields', () => {
+        const input = {
+            privateKey: 'super-private-key',
+            secret: 'my-secret',
+            apiKey: 'api-key-value',
+            normalField: 'safe',
+        }
+
+        const output = redactObject(input)
+
+        expect(output.privateKey).toBe('[REDACTED]')
+        expect(output.secret).toBe('[REDACTED]')
+        expect(output.apiKey).toBe('[REDACTED]')
+        expect(output.normalField).toBe('safe')
+    })
+
+    it('keeps non-sensitive fields unchanged', () => {
+        const input = {
+            level: 'info',
+            route: '/api/v1/portfolio',
+            statusCode: 200,
+            message: 'request complete',
+        }
+
+        const output = redactObject(input)
+
+        expect(output).toEqual(input)
+    })
+
+    it('redacts nested secret fields deeply', () => {
+        const input = {
+            request: {
+                meta: {
+                    retries: 2,
+                    credentials: {
+                        jwtSecret: 'jwt-secret-value',
+                        wallet: {
+                            privateKey: 'wallet-private-key',
+                        },
+                    },
+                },
+            },
+            arrayValues: [
+                { api_key: 'coingecko-key' },
+                { asset: 'XLM' },
+            ],
+        }
+
+        const output = redactObject(input)
+
+        expect(output.request.meta.credentials.jwtSecret).toBe('[REDACTED]')
+        expect(output.request.meta.credentials.wallet.privateKey).toBe('[REDACTED]')
+        expect(output.arrayValues[0].api_key).toBe('[REDACTED]')
+        expect(output.arrayValues[1].asset).toBe('XLM')
+        expect(output.request.meta.retries).toBe(2)
+    })
+})

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -77,6 +77,32 @@ Use `/health` for load balancer liveness. Use `/ready` before traffic shifts in 
 - **Redis restart:** Queues and repeatable job metadata live in Redis. After Redis comes back, restart the API so `probeRedis()` and `startQueueScheduler()` run again; workers must reconnect via `getConnectionOptions()`.
 - **Database:** SQLite (`DB_PATH`) or PostgreSQL (`DATABASE_URL`) holds application data and indexer cursors. Deleting the DB resets consent and portfolios; indexer cursors reset to bootstrap behavior on next start.
 
+## JWT signing secret rotation
+
+The backend supports a dual-secret validation window so access tokens signed with the previous secret remain valid for a controlled grace period.
+
+### Environment variables
+
+- `JWT_SECRET`: active signing secret (required for issuing new access/refresh tokens).
+- `JWT_PREVIOUS_SECRET`: prior signing secret used before rotation.
+- `JWT_PREVIOUS_SECRET_GRACE_UNTIL`: ISO-8601 UTC timestamp. Old-secret access tokens are accepted only until this time.
+
+### Rotation runbook
+
+1. Generate a new `JWT_SECRET` value (minimum 32 chars).
+2. Set `JWT_PREVIOUS_SECRET` to the currently active secret.
+3. Set `JWT_PREVIOUS_SECRET_GRACE_UNTIL` to a future UTC timestamp that covers your rollout window (for example, 30-60 minutes).
+4. Deploy all API instances with all three variables (`JWT_SECRET`, `JWT_PREVIOUS_SECRET`, `JWT_PREVIOUS_SECRET_GRACE_UNTIL`) at the same time.
+5. Verify protected routes accept newly issued tokens and still accept tokens signed before deployment during the grace period.
+6. After the grace period has ended, remove `JWT_PREVIOUS_SECRET` and `JWT_PREVIOUS_SECRET_GRACE_UNTIL` from the environment.
+7. Perform a final deploy with only the new `JWT_SECRET` configured.
+
+### Expected behavior
+
+- Tokens signed with `JWT_SECRET` always validate normally.
+- Tokens signed with `JWT_PREVIOUS_SECRET` validate only while `Date.now() <= JWT_PREVIOUS_SECRET_GRACE_UNTIL`.
+- After grace expiry, old-secret tokens are rejected with `401`.
+
 ## Related docs
 
 - Contributor setup: [docs/CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary

- Harden JWT authentication by adding dual-secret validation in `requireJwt` to support safe secret rotation (`JWT_SECRET` + `JWT_PREVIOUS_SECRET`) during a bounded grace window (`JWT_PREVIOUS_SECRET_GRACE_UNTIL`).
- Add security-focused regression tests for JWT middleware, secret redaction, and CORS allowlist behavior to prevent token handling, logging, and origin-policy regressions.
- Document the JWT secret rotation runbook in `docs/OPERATIONS.md` with explicit rollout and cleanup steps.

## Changes Included

- Updated `backend/src/middleware/requireJwt.ts`:
  - Added dual-secret verification path for access tokens.
  - Added grace-period expiry enforcement for old-secret validation.
  - Added explicit unauthorized behavior for malformed/tampered/wrong-secret tokens.
  - Added explicit expired-token behavior (`TOKEN_EXPIRED`).

- Added `backend/src/http/corsSecurity.ts`:
  - `buildCorsOptions(corsOrigins)` for centralized CORS option construction.
  - `enforceCorsOriginAllowlist(corsOrigins)` middleware to reject unlisted origins with `403`.

- Updated `backend/src/index.ts`:
  - Switched to `buildCorsOptions`.
  - Added `enforceCorsOriginAllowlist` before CORS middleware.

- Added tests:
  - `backend/src/test/requireJwt.test.ts`
  - `backend/src/test/secretRedactor.test.ts`
  - `backend/src/test/cors.security.test.ts`

- Updated docs:
  - `docs/OPERATIONS.md` with JWT signing secret rotation procedure and expected runtime behavior.

## Acceptance Criteria Mapping

### JWT secret rotation (dual-secret + grace period)

- ✅ Dual-secret validation is implemented and tested.
- ✅ Old-secret tokens are accepted during grace period.
- ✅ Old-secret tokens are rejected after grace period.
- ✅ Rotation procedure is documented step-by-step.

### `secretRedactor` coverage

- ✅ Authorization header redaction tested.
- ✅ `privateKey`, `secret`, and `apiKey` redaction tested.
- ✅ Non-sensitive fields preserved.
- ✅ Deeply nested secret redaction tested.

### `requireJwt` malformed/expired/tampered coverage

- ✅ Valid token attaches user context and passes.
- ✅ Expired token returns `401` with `TOKEN_EXPIRED`.
- ✅ Malformed token returns `401`.
- ✅ Wrong-secret token returns `401`.
- ✅ Missing Authorization header returns `401`.
- ✅ No `500` responses for malformed token inputs.

### CORS security coverage

- ✅ Allowed origin succeeds with credentials.
- ✅ Unlisted origin is rejected with `403`.
- ✅ Unlisted-origin preflight (`OPTIONS`) is blocked.
- ✅ Wildcard origin (`*`) is not emitted when credentials are enabled.

## Test Plan

- [x] `cd backend && npm test -- src/test/requireJwt.test.ts src/test/secretRedactor.test.ts src/test/cors.security.test.ts`
- [ ] (Optional) `cd backend && npm test` for full backend suite before merge.

## Notes for Reviewers

- JWT rotation support is intentionally scoped to middleware validation so in-flight access tokens can survive deployment while new tokens are signed with the active secret.
- Old-secret validation is strictly time-bounded via `JWT_PREVIOUS_SECRET_GRACE_UNTIL`; once expired, tokens signed by old secret are rejected.
- CORS allowlist enforcement now returns explicit `403` for unlisted origins to avoid accidental exposure from misconfiguration.


closes #343 
closes #344 
closes #346 
closes #345 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CORS origin allowlist enforcement with structured error responses for forbidden origins.
  * Implemented JWT token rotation with grace period support for seamless secret transitions.

* **Tests**
  * Added comprehensive test coverage for CORS security, JWT authentication, and secret redaction.

* **Documentation**
  * Added JWT secret rotation runbook in operations handbook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->