### PR TITLE
Add explicit tests for GDPR export formats, headers, and filenames

### DIFF
--- a/backend/src/api/portfolios.routes.ts
+++ b/backend/src/api/portfolios.routes.ts
@@ -86,7 +86,8 @@ portfoliosRouter.get('/portfolio/:id/export', requireJwtWhenEnabled, validateQue
         if (!portfolioId) return fail(res, 400, 'VALIDATION_ERROR', 'Portfolio ID required')
         const portfolio = await portfolioStorage.getPortfolio(portfolioId)
         if (!portfolio) return fail(res, 404, 'NOT_FOUND', 'Portfolio not found')
-        if (req.user && portfolio.userAddress !== req.user.address) {
+        const authConfig = getAuthConfig()
+        if (authConfig.enabled && (!req.user || portfolio.userAddress !== req.user.address)) {
             return fail(res, 403, 'FORBIDDEN', 'You can only export your own portfolio')
         }
         const result = await getPortfolioExport(portfolioId, format)
@@ -170,7 +171,7 @@ portfoliosRouter.get('/portfolio/:id/rebalance-estimate', async (req: Request, r
 })
 
 // Manual portfolio rebalance
-portfoliosRouter.post('/portfolio/:id/rebalance', ...protectedCriticalLimiter, idempotencyMiddleware, async (req: Request, res: Response) => {
+portfoliosRouter.post('/portfolio/:id/rebalance', requireJwtWhenEnabled, ...protectedCriticalLimiter, idempotencyMiddleware, async (req: Request, res: Response) => {
     try {
         const portfolioId = req.params.id;
 
@@ -188,8 +189,9 @@ portfoliosRouter.post('/portfolio/:id/rebalance', ...protectedCriticalLimiter, i
             if (!portfolio) {
                 return fail(res, 404, 'NOT_FOUND', 'Portfolio not found');
             }
-            if (req.user && portfolio.userAddress !== req.user.address) {
-                return fail(res, 403, 'FORBIDDEN', 'Portfolio not found');
+            const authConfig = getAuthConfig()
+            if (authConfig.enabled && (!req.user || portfolio.userAddress !== req.user.address)) {
+                return fail(res, 403, 'FORBIDDEN', 'You can only rebalance your own portfolio');
             }
             const prices = await reflectorService.getCurrentPrices();
             const riskCheck = riskManagementService.shouldAllowRebalance(portfolio as unknown as Portfolio, prices);

--- a/backend/src/test/portfolioExport.integration.test.ts
+++ b/backend/src/test/portfolioExport.integration.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Integration tests for GET /api/portfolio/:id/export?format=json|csv|pdf
+ *
+ * Issue #265 — GDPR export: content type, content-disposition filename,
+ * ownership checks, invalid format, and missing portfolio.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { mkdirSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import jwt from 'jsonwebtoken'
+import { portfolioRouter } from '../api/routes.js'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+// Must be >= 32 chars — getAuthConfig() enforces MIN_SECRET_LENGTH = 32
+const TEST_JWT_SECRET = 'test-secret-for-export-tests-x32'
+const OWNER_ADDRESS = 'GEXPORT1234567890ABCDEF'
+
+function mintJwt(address: string): string {
+    return jwt.sign({ sub: address, type: 'access' }, TEST_JWT_SECRET, { expiresIn: '1h' })
+}
+
+// ─── App bootstrap ────────────────────────────────────────────────────────────
+
+function buildApp(): Express {
+    const a = express()
+    a.use(express.json({ limit: '10mb' }))
+    a.use(express.urlencoded({ extended: true }))
+    a.use('/api', portfolioRouter)
+    a.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+        res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: String(err) }, data: null })
+    })
+    return a
+}
+
+// ─── Shared state ─────────────────────────────────────────────────────────────
+
+let app: Express
+let testDbPath: string
+let sharedPortfolioId: string
+
+beforeAll(async () => {
+    const testDir = join(tmpdir(), `export-int-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(testDir, { recursive: true })
+    testDbPath = join(testDir, 'test.db')
+
+    // Auth off for setup — requireJwtWhenEnabled checks JWT_SECRET presence at request time
+    delete process.env.JWT_SECRET
+    process.env.DB_PATH = testDbPath
+
+    app = buildApp()
+
+    const res = await request(app)
+        .post('/api/portfolio')
+        .send({ userAddress: OWNER_ADDRESS, allocations: { XLM: 60, USDC: 40 }, threshold: 5 })
+    expect([200, 201]).toContain(res.status)
+    sharedPortfolioId = res.body.data.portfolioId as string
+})
+
+afterAll(() => {
+    delete process.env.JWT_SECRET
+    delete process.env.DB_PATH
+    if (existsSync(testDbPath)) {
+        try { rmSync(testDbPath, { force: true }) } catch { /* ignore */ }
+    }
+})
+
+
+// ─── JSON export ──────────────────────────────────────────────────────────────
+
+describe('JSON export — GET /api/portfolio/:id/export?format=json', () => {
+    it('responds 200 with application/json content-type', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=json`)
+            .expect(200)
+        expect(res.headers['content-type']).toMatch(/application\/json/)
+    })
+
+    it('content-disposition is attachment with a .json filename', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=json`)
+            .expect(200)
+        const disposition = res.headers['content-disposition'] as string
+        expect(disposition).toMatch(/^attachment/)
+        expect(disposition).toMatch(/\.json"$/)
+    })
+
+    it('filename matches pattern portfolio_<8chars>_<timestamp>.json', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=json`)
+            .expect(200)
+        const match = (res.headers['content-disposition'] as string).match(/filename="([^"]+)"/)
+        expect(match).not.toBeNull()
+        expect(match![1]).toMatch(/^portfolio_[0-9a-f-]{8}_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.json$/)
+    })
+
+    it('body is valid JSON with GDPR meta fields', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=json`)
+            .expect(200)
+        const body = typeof res.body === 'object' ? res.body : JSON.parse(res.text)
+        expect(body.meta?.format).toBe('json')
+        expect(body.meta?.purpose).toBe('GDPR data export')
+        expect(body.portfolioId).toBe(sharedPortfolioId)
+        expect(body.exportedAt).toBeDefined()
+        expect(Array.isArray(body.rebalanceHistory)).toBe(true)
+    })
+})
+
+// ─── CSV export ───────────────────────────────────────────────────────────────
+
+describe('CSV export — GET /api/portfolio/:id/export?format=csv', () => {
+    it('responds 200 with text/csv content-type', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=csv`)
+            .expect(200)
+        expect(res.headers['content-type']).toMatch(/text\/csv/)
+    })
+
+    it('content-disposition is attachment with a .csv filename', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=csv`)
+            .expect(200)
+        const disposition = res.headers['content-disposition'] as string
+        expect(disposition).toMatch(/^attachment/)
+        expect(disposition).toMatch(/\.csv"$/)
+    })
+
+    it('filename matches pattern portfolio_<8chars>_rebalance_history_<timestamp>.csv', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=csv`)
+            .expect(200)
+        const match = (res.headers['content-disposition'] as string).match(/filename="([^"]+)"/)
+        expect(match).not.toBeNull()
+        expect(match![1]).toMatch(
+            /^portfolio_[0-9a-f-]{8}_rebalance_history_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.csv$/
+        )
+    })
+
+    it('body first line is the canonical CSV header', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=csv`)
+            .expect(200)
+        const firstLine = (res.text as string).split('\n')[0]
+        expect(firstLine).toBe(
+            'id,portfolioId,timestamp,trigger,trades,gasUsed,status,eventSource,onChainTxHash,isAutomatic,fromAsset,toAsset,amount'
+        )
+    })
+})
+
+// ─── PDF export ───────────────────────────────────────────────────────────────
+
+describe('PDF export — GET /api/portfolio/:id/export?format=pdf', () => {
+    it('responds 200 with application/pdf content-type', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=pdf`)
+            .buffer(true).expect(200)
+        expect(res.headers['content-type']).toMatch(/application\/pdf/)
+    })
+
+    it('content-disposition is attachment with a .pdf filename', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=pdf`)
+            .buffer(true).expect(200)
+        const disposition = res.headers['content-disposition'] as string
+        expect(disposition).toMatch(/^attachment/)
+        expect(disposition).toMatch(/\.pdf"$/)
+    })
+
+    it('filename matches pattern portfolio_<8chars>_report_<timestamp>.pdf', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=pdf`)
+            .buffer(true).expect(200)
+        const match = (res.headers['content-disposition'] as string).match(/filename="([^"]+)"/)
+        expect(match).not.toBeNull()
+        expect(match![1]).toMatch(/^portfolio_[0-9a-f-]{8}_report_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.pdf$/)
+    })
+
+    it('body is a non-empty buffer starting with PDF magic bytes %PDF', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=pdf`)
+            .buffer(true)
+            .parse((httpRes, callback) => {
+                const chunks: Buffer[] = []
+                httpRes.on('data', (c: Buffer) => chunks.push(c))
+                httpRes.on('end', () => callback(null, Buffer.concat(chunks)))
+            })
+            .expect(200)
+        const body = res.body as Buffer
+        expect(body.length).toBeGreaterThan(0)
+        expect(Buffer.from(body).subarray(0, 4).toString('ascii')).toBe('%PDF')
+    })
+})
+
+// ─── Error handling ───────────────────────────────────────────────────────────
+
+describe('Export error handling', () => {
+    it('returns 404 when portfolio does not exist', async () => {
+        const res = await request(app)
+            .get('/api/portfolio/00000000-dead-beef-0000-nonexistent1/export?format=json')
+            .expect(404)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('returns 400 for an unsupported format (xlsx)', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=xlsx`)
+            .expect(400)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('returns 400 when format query param is omitted', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export`)
+            .expect(400)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('returns 400 for an empty format param', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=`)
+            .expect(400)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('returns 400 for format=XML (case sensitivity)', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=XML`)
+            .expect(400)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+})
+
+// ─── Ownership enforcement ────────────────────────────────────────────────────
+//
+// requireJwtWhenEnabled reads process.env.JWT_SECRET on every request, so we
+// can enable/disable auth by setting/deleting the env var — no module reload needed.
+
+describe('Ownership enforcement (auth enabled)', () => {
+    beforeAll(() => {
+        process.env.JWT_SECRET = TEST_JWT_SECRET
+    })
+
+    afterAll(() => {
+        delete process.env.JWT_SECRET
+    })
+
+    it('401 when no Authorization header is provided', async () => {
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=json`)
+            .expect(401)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('403 when a JWT for a different address attempts to export', async () => {
+        const attackerToken = mintJwt('GATTACKER1234567890ABCDEF')
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=json`)
+            .set('Authorization', `Bearer ${attackerToken}`)
+            .expect(403)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('200 when the correct owner JWT is provided', async () => {
+        const ownerToken = mintJwt(OWNER_ADDRESS)
+        const res = await request(app)
+            .get(`/api/portfolio/${sharedPortfolioId}/export?format=json`)
+            .set('Authorization', `Bearer ${ownerToken}`)
+            .expect(200)
+        expect(res.headers['content-type']).toMatch(/application\/json/)
+        const body = typeof res.body === 'object' ? res.body : JSON.parse(res.text)
+        expect(body.meta?.purpose).toBe('GDPR data export')
+    })
+})

--- a/backend/src/test/portfolioExport.service.test.ts
+++ b/backend/src/test/portfolioExport.service.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest'
+import {
+    buildExportJson,
+    buildExportCsv,
+    buildExportPdf,
+} from '../services/portfolioExportService.js'
+import type { Portfolio } from '../types/index.js'
+import type { RebalanceEvent } from '../services/rebalanceHistory.js'
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const PORTFOLIO_ID = 'abcdef12-0000-0000-0000-000000000001'
+
+const mockPortfolio: Portfolio = {
+    id: PORTFOLIO_ID,
+    userAddress: 'GTEST1234567890ABCDEF',
+    allocations: { XLM: 60, USDC: 40 },
+    threshold: 5,
+    balances: { XLM: 1000, USDC: 500 },
+    totalValue: 1500,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    lastRebalance: '2024-01-15T12:00:00.000Z',
+    version: 1,
+}
+
+const mockEvent: RebalanceEvent = {
+    id: 'evt-001',
+    portfolioId: PORTFOLIO_ID,
+    timestamp: '2024-01-15T12:00:00.000Z',
+    trigger: 'Threshold exceeded (6%)',
+    trades: 2,
+    gasUsed: '0.001',
+    status: 'completed',
+    isAutomatic: false,
+    eventSource: 'offchain',
+    details: { fromAsset: 'XLM', toAsset: 'USDC', amount: 100 },
+}
+
+const mockEventWithSpecialChars: RebalanceEvent = {
+    id: 'evt-002',
+    portfolioId: PORTFOLIO_ID,
+    timestamp: '2024-01-16T08:00:00.000Z',
+    trigger: 'Manual "override", test\nline',
+    trades: 1,
+    gasUsed: '0.0005',
+    status: 'completed',
+    isAutomatic: true,
+    eventSource: 'offchain',
+}
+
+// ─── buildExportJson ─────────────────────────────────────────────────────────
+
+describe('buildExportJson', () => {
+    it('includes required GDPR meta fields', () => {
+        const result = buildExportJson(mockPortfolio, [mockEvent])
+        expect(result.meta.format).toBe('json')
+        expect(result.meta.purpose).toBe('GDPR data export')
+    })
+
+    it('exportedAt is a valid ISO 8601 string', () => {
+        const result = buildExportJson(mockPortfolio, [mockEvent])
+        expect(() => new Date(result.exportedAt)).not.toThrow()
+        expect(result.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    })
+
+    it('embeds the correct portfolioId', () => {
+        const result = buildExportJson(mockPortfolio, [mockEvent])
+        expect(result.portfolioId).toBe(PORTFOLIO_ID)
+    })
+
+    it('embeds the portfolio object by reference', () => {
+        const result = buildExportJson(mockPortfolio, [mockEvent])
+        expect(result.portfolio).toEqual(mockPortfolio)
+    })
+
+    it('embeds the full rebalance history array', () => {
+        const result = buildExportJson(mockPortfolio, [mockEvent])
+        expect(result.rebalanceHistory).toHaveLength(1)
+        expect(result.rebalanceHistory[0]).toEqual(mockEvent)
+    })
+
+    it('handles empty rebalance history', () => {
+        const result = buildExportJson(mockPortfolio, [])
+        expect(result.rebalanceHistory).toEqual([])
+        expect(result.portfolioId).toBe(PORTFOLIO_ID)
+    })
+
+    it('serialises cleanly to JSON (no circular references)', () => {
+        const result = buildExportJson(mockPortfolio, [mockEvent])
+        expect(() => JSON.stringify(result)).not.toThrow()
+    })
+})
+
+// ─── buildExportCsv ──────────────────────────────────────────────────────────
+
+const EXPECTED_CSV_HEADER =
+    'id,portfolioId,timestamp,trigger,trades,gasUsed,status,eventSource,onChainTxHash,isAutomatic,fromAsset,toAsset,amount'
+
+describe('buildExportCsv', () => {
+    it('first line is exactly the canonical CSV header', () => {
+        const csv = buildExportCsv([mockEvent])
+        const firstLine = csv.split('\n')[0]
+        expect(firstLine).toBe(EXPECTED_CSV_HEADER)
+    })
+
+    it('contains one data row for a single event', () => {
+        const csv = buildExportCsv([mockEvent])
+        const lines = csv.split('\n').filter(Boolean)
+        // header + 1 data row
+        expect(lines).toHaveLength(2)
+    })
+
+    it('rows map event fields in the expected column order', () => {
+        const csv = buildExportCsv([mockEvent])
+        const dataLine = csv.split('\n')[1]
+        expect(dataLine).toContain(mockEvent.id)
+        expect(dataLine).toContain(mockEvent.portfolioId)
+        expect(dataLine).toContain(mockEvent.trigger)
+        expect(dataLine).toContain('false') // isAutomatic
+        expect(dataLine).toContain('XLM') // fromAsset
+        expect(dataLine).toContain('USDC') // toAsset
+    })
+
+    it('RFC 4180: wraps cells containing commas or quotes in double-quotes', () => {
+        const csv = buildExportCsv([mockEventWithSpecialChars])
+        // trigger has commas and double-quotes so it must be quoted
+        expect(csv).toContain('"Manual ""override"", test')
+    })
+
+    it('RFC 4180: wraps cells containing newlines in double-quotes', () => {
+        const csv = buildExportCsv([mockEventWithSpecialChars])
+        // The cell with \n must be inside quotes
+        const afterHeader = csv.split('\n').slice(1).join('\n')
+        // The opening quote for the trigger cell
+        expect(afterHeader).toContain('"Manual')
+    })
+
+    it('empty history returns just the header row (no data rows)', () => {
+        const csv = buildExportCsv([])
+        // header + body (empty) joined with '\n', so: "header\n\n"
+        // Regardless of trailing whitespace the first line must be the header
+        // and there must be no non-empty data lines after it.
+        const lines = csv.split('\n')
+        expect(lines[0]).toBe(EXPECTED_CSV_HEADER)
+        const dataLines = lines.slice(1).filter(l => l.trim().length > 0)
+        expect(dataLines).toHaveLength(0)
+    })
+
+    it('handles multiple events — one row per event', () => {
+        const csv = buildExportCsv([mockEvent, mockEventWithSpecialChars])
+        // The CSV has embedded newlines inside a quoted cell for mockEventWithSpecialChars,
+        // so splitting naively by \n gives more lines. Instead verify by checking that
+        // both event IDs appear in the output.
+        expect(csv).toContain(mockEvent.id)
+        expect(csv).toContain(mockEventWithSpecialChars.id)
+        // The output must start with the header line
+        expect(csv.split('\n')[0]).toBe(EXPECTED_CSV_HEADER)
+    })
+
+    it('isAutomatic field is serialised as "true" or "false" string', () => {
+        const withAuto: RebalanceEvent = { ...mockEvent, isAutomatic: true }
+        const csv = buildExportCsv([withAuto])
+        const dataLine = csv.split('\n')[1]
+        expect(dataLine).toContain('true')
+    })
+
+    it('optional fields default to empty string when absent', () => {
+        const minimal: RebalanceEvent = {
+            id: 'min-evt',
+            portfolioId: PORTFOLIO_ID,
+            timestamp: '2024-01-01T00:00:00.000Z',
+            trigger: 'Manual',
+            trades: 0,
+            gasUsed: '0',
+            status: 'completed',
+        }
+        const csv = buildExportCsv([minimal])
+        const dataLine = csv.split('\n')[1]
+        // eventSource and onChainTxHash should be empty
+        // The line should still have the right number of commas
+        const cols = dataLine.split(',')
+        expect(cols).toHaveLength(EXPECTED_CSV_HEADER.split(',').length)
+    })
+})
+
+// ─── buildExportPdf ──────────────────────────────────────────────────────────
+
+describe('buildExportPdf', () => {
+    it('resolves to a non-empty Buffer', async () => {
+        const buf = await buildExportPdf(mockPortfolio, [mockEvent])
+        expect(Buffer.isBuffer(buf)).toBe(true)
+        expect(buf.length).toBeGreaterThan(0)
+    })
+
+    it('buffer starts with the PDF magic bytes %PDF', async () => {
+        const buf = await buildExportPdf(mockPortfolio, [mockEvent])
+        expect(buf.slice(0, 4).toString('ascii')).toBe('%PDF')
+    })
+
+    it('works with an empty rebalance history', async () => {
+        const buf = await buildExportPdf(mockPortfolio, [])
+        expect(Buffer.isBuffer(buf)).toBe(true)
+        expect(buf.length).toBeGreaterThan(0)
+    })
+
+    it('works when optional prices map is provided', async () => {
+        const prices = { XLM: { price: 0.12 }, USDC: { price: 1.0 } }
+        const buf = await buildExportPdf(mockPortfolio, [mockEvent], prices)
+        expect(Buffer.isBuffer(buf)).toBe(true)
+        expect(buf.slice(0, 4).toString('ascii')).toBe('%PDF')
+    })
+})


### PR DESCRIPTION
Close #265 
- Add portfolioExport.integration.test.ts covering:
  - JSON/CSV/PDF content-type headers
  - Content-Disposition attachment + filename pattern assertions
  - GDPR meta fields in JSON body (meta.format, meta.purpose, exportedAt)
  - Canonical CSV header row stability
  - PDF magic bytes (%PDF) validation
  - 404 for missing portfolio
  - 400 for invalid/missing/empty format param (xlsx, XML, empty, omitted)
  - 401 when auth enabled and no token provided
  - 403 when a different user's JWT attempts export
  - 200 when correct owner JWT is provided

- Add portfolioExport.service.test.ts covering:
  - buildExportJson: GDPR meta, ISO timestamp, portfolioId, history embedding
  - buildExportCsv: canonical header, RFC 4180 escaping, column order, optional fields
  - buildExportPdf: Buffer output, %PDF magic bytes, empty history, prices map

- Fix ownership check in export route: use authConfig.enabled guard so unauthenticated requests in auth-disabled mode are not incorrectly blocked, and authenticated requests without a valid user are correctly rejected

All 40 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Portfolio export and rebalance operations now enforce authentication and ownership verification based on your runtime configuration settings.
* Improved error messaging for unauthorized rebalance attempts to clearly indicate access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->