### PR TITLE
test(ci): add optimistic consent coverage and deployment smoke checks

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -51,3 +51,67 @@ jobs:
           name: backend-coverage-${{ matrix.node-version }}
           path: backend/coverage/
           if-no-files-found: warn
+
+  migration-dry-run:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        db: [sqlite, postgres]
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpassword
+          POSTGRES_DB: migration_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect migration changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            migrations:
+              - 'backend/src/db/migrations/**'
+
+      - name: Setup Node.js
+        if: steps.changes.outputs.migrations == 'true' || github.event_name != 'pull_request'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        if: steps.changes.outputs.migrations == 'true' || github.event_name != 'pull_request'
+        working-directory: ./backend
+        run: npm ci
+
+      - name: Dry-run migrations (SQLite)
+        if: (steps.changes.outputs.migrations == 'true' || github.event_name != 'pull_request') && matrix.db == 'sqlite'
+        working-directory: ./backend
+        env:
+          DB_PATH: /tmp/stellar-migration-dryrun.sqlite
+        run: npm run db:migrate -- --dry-run
+
+      - name: Dry-run migrations (PostgreSQL)
+        if: (steps.changes.outputs.migrations == 'true' || github.event_name != 'pull_request') && matrix.db == 'postgres'
+        working-directory: ./backend
+        env:
+          DATABASE_URL: postgresql://testuser:testpassword@localhost:5432/migration_ci
+          PGUSER: testuser
+          PGPASSWORD: testpassword
+          PGHOST: localhost
+          PGPORT: '5432'
+          PGDATABASE: migration_ci
+        run: npm run db:migrate -- --dry-run

--- a/.github/workflows/contract-smoke.yml
+++ b/.github/workflows/contract-smoke.yml
@@ -1,0 +1,87 @@
+name: Contract Smoke Test
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  pull_request:
+    paths:
+      - 'contracts/**'
+      - '.github/workflows/contract-smoke.yml'
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'contracts/**'
+      - '.github/workflows/contract-smoke.yml'
+
+jobs:
+  soroban-testnet-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      STELLAR_SECRET_KEY: ${{ secrets.STELLAR_TESTNET_SECRET_KEY }}
+      SOROBAN_RPC_URL: https://soroban-testnet.stellar.org
+      SOROBAN_NETWORK_PASSPHRASE: Test SDF Network ; September 2015
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure testnet secret exists
+        run: |
+          if [ -z "${STELLAR_SECRET_KEY}" ]; then
+            echo "::error::Missing STELLAR_TESTNET_SECRET_KEY repository secret"
+            exit 1
+          fi
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo and Soroban
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.soroban
+            contracts/target
+          key: contract-smoke-${{ runner.os }}-${{ hashFiles('contracts/Cargo.lock', 'contracts/Cargo.toml') }}
+          restore-keys: |
+            contract-smoke-${{ runner.os }}-
+
+      - name: Install Soroban CLI
+        run: cargo install --locked soroban-cli
+
+      - name: Build contract wasm
+        working-directory: ./contracts
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Deploy and initialize on testnet
+        working-directory: ./contracts
+        run: |
+          soroban network add testnet --global \
+            --rpc-url "${SOROBAN_RPC_URL}" \
+            --network-passphrase "${SOROBAN_NETWORK_PASSPHRASE}" || true
+
+          soroban keys add ci-deployer --global --secret-key "${STELLAR_SECRET_KEY}" || true
+          ADMIN_ADDRESS="$(soroban keys address ci-deployer --global)"
+
+          CONTRACT_ID="$(soroban contract deploy \
+            --wasm target/wasm32-unknown-unknown/release/portfolio_rebalancer.wasm \
+            --source ci-deployer \
+            --network testnet)"
+
+          if [ -z "${CONTRACT_ID}" ]; then
+            echo "::error::Contract deployment did not return a contract ID"
+            exit 1
+          fi
+
+          soroban contract invoke \
+            --id "${CONTRACT_ID}" \
+            --source ci-deployer \
+            --network testnet \
+            -- initialize \
+            --admin "${ADMIN_ADDRESS}" \
+            --reflector_address "${ADMIN_ADDRESS}"

--- a/frontend/src/app/walletBoot.test.ts
+++ b/frontend/src/app/walletBoot.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 import { WalletError } from '../utils/walletAdapters'
 import {
     isAuthServiceUnavailable,
+    runWalletConnectBoot,
     resolveConsentAcceptedNavigation,
     runWalletReconnectBoot,
+    type WalletConnectBootState,
 } from './walletBoot'
 
 describe('isAuthServiceUnavailable', () => {
@@ -85,6 +87,74 @@ describe('runWalletReconnectBoot', () => {
         if (result.outcome === 'reconnect_failed') {
             expect(result.message).toMatch(/declined/i)
         }
+    })
+})
+
+describe('runWalletConnectBoot', () => {
+    it('returns connected state with wallet address on successful boot sequence', async () => {
+        const result = await runWalletConnectBoot({
+            checkExtension: () => true,
+            connect: async () => undefined,
+            getAddress: async () => 'GBOOTSUCCESS',
+        })
+        expect(result).toEqual({ status: 'connected', publicKey: 'GBOOTSUCCESS' })
+    })
+
+    it('returns not_installed when extension detection fails', async () => {
+        const result = await runWalletConnectBoot({
+            checkExtension: () => false,
+            connect: async () => undefined,
+            getAddress: async () => 'GIGNORED',
+        })
+        expect(result.status).toBe('not_installed')
+    })
+
+    it('returns rejected when wallet connection is declined', async () => {
+        const result = await runWalletConnectBoot({
+            checkExtension: () => true,
+            connect: async () => {
+                throw new WalletError('declined', 'USER_DECLINED', 'freighter')
+            },
+            getAddress: async () => 'GIGNORED',
+        })
+        expect(result.status).toBe('rejected')
+    })
+
+    it('exposes boot state as discriminated union for UI reactions', async () => {
+        const result = await runWalletConnectBoot({
+            checkExtension: () => true,
+            connect: async () => undefined,
+            getAddress: async () => null,
+        })
+
+        const toUiLabel = (state: WalletConnectBootState): string => {
+            switch (state.status) {
+                case 'loading':
+                    return 'loading'
+                case 'connected':
+                    return `connected:${state.publicKey}`
+                case 'not_installed':
+                    return state.message
+                case 'rejected':
+                    return state.message
+                case 'failed':
+                    return state.message
+            }
+        }
+
+        expect(toUiLabel(result)).toMatch(/wallet connected but no address was returned/i)
+    })
+
+    it('never leaves the boot flow in loading after failures', async () => {
+        const result = await runWalletConnectBoot({
+            checkExtension: () => {
+                throw new Error('extension detection failed')
+            },
+            connect: async () => undefined,
+            getAddress: async () => 'GIGNORED',
+        })
+        expect(result.status).not.toBe('loading')
+        expect(result.status).toBe('not_installed')
     })
 })
 

--- a/frontend/src/app/walletBoot.ts
+++ b/frontend/src/app/walletBoot.ts
@@ -22,6 +22,70 @@ export type WalletReconnectBootResult =
     | { outcome: 'auth_failed'; message: string }
     | { outcome: 'reconnect_failed'; message: string; walletErrorCode?: string }
 
+export type WalletConnectBootState =
+    | { status: 'loading' }
+    | { status: 'connected'; publicKey: string }
+    | { status: 'not_installed'; message: string }
+    | { status: 'rejected'; message: string }
+    | { status: 'failed'; message: string }
+
+export type WalletConnectBootDeps = {
+    checkExtension: () => Promise<boolean> | boolean
+    connect: () => Promise<void>
+    getAddress: () => Promise<string | null>
+}
+
+export async function runWalletConnectBoot(
+    deps: WalletConnectBootDeps,
+): Promise<WalletConnectBootState> {
+    try {
+        const hasExtension = await deps.checkExtension()
+        if (!hasExtension) {
+            return {
+                status: 'not_installed',
+                message: 'Wallet extension is not installed.',
+            }
+        }
+    } catch {
+        return {
+            status: 'not_installed',
+            message: 'Wallet extension is not installed.',
+        }
+    }
+
+    try {
+        await deps.connect()
+    } catch (err: unknown) {
+        const walletErr = err instanceof WalletError ? err : null
+        if (walletErr?.code === 'USER_DECLINED') {
+            return {
+                status: 'rejected',
+                message: 'Wallet connection was rejected by the user.',
+            }
+        }
+        return {
+            status: 'failed',
+            message: 'Wallet connection failed. Please try again.',
+        }
+    }
+
+    try {
+        const publicKey = await deps.getAddress()
+        if (!publicKey) {
+            return {
+                status: 'failed',
+                message: 'Wallet connected but no address was returned.',
+            }
+        }
+        return { status: 'connected', publicKey }
+    } catch {
+        return {
+            status: 'failed',
+            message: 'Unable to read wallet address after connecting.',
+        }
+    }
+}
+
 export async function runWalletReconnectBoot(
     deps: WalletReconnectBootDeps,
 ): Promise<WalletReconnectBootResult> {

--- a/frontend/src/hooks/mutations/useConsentMutation.test.tsx
+++ b/frontend/src/hooks/mutations/useConsentMutation.test.tsx
@@ -3,7 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { api } from '../../config/api'
-import { useRecordConsentMutation, consentKeys } from './useConsentMutation'
+import {
+    useRecordConsentMutation,
+    useRevokeConsentMutation,
+    consentKeys,
+} from './useConsentMutation'
 
 function createTestClient() {
     return new QueryClient({
@@ -40,5 +44,136 @@ describe('useRecordConsentMutation', () => {
         })
 
         expect(spy).toHaveBeenCalledWith({ queryKey: consentKeys.status(userId) })
+    })
+
+    it('optimistically sets consent to granted on mutate start', async () => {
+        const qc = createTestClient()
+        const userId = 'GCONSENT2'
+        qc.setQueryData(consentKeys.status(userId), { accepted: false })
+
+        let resolveRequest!: (value: unknown) => void
+        vi.spyOn(api, 'post').mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveRequest = resolve
+                }) as Promise<any>,
+        )
+
+        const { result } = renderHook(() => useRecordConsentMutation(userId), {
+            wrapper: withClient(qc),
+        })
+
+        const mutationPromise = act(async () => {
+            await result.current.mutateAsync()
+        })
+
+        await vi.waitFor(() => {
+            expect(qc.getQueryData<{ accepted: boolean }>(consentKeys.status(userId))).toEqual({
+                accepted: true,
+            })
+        })
+
+        await act(async () => {
+            resolveRequest({ recorded: true })
+            await mutationPromise
+        })
+    })
+
+    it('rolls back optimistic grant when mutation fails', async () => {
+        const qc = createTestClient()
+        const userId = 'GCONSENT3'
+        qc.setQueryData(consentKeys.status(userId), { accepted: false })
+        vi.spyOn(api, 'post').mockRejectedValue(new Error('network down'))
+
+        const { result } = renderHook(() => useRecordConsentMutation(userId), {
+            wrapper: withClient(qc),
+        })
+
+        await expect(result.current.mutateAsync()).rejects.toThrow(/network down/i)
+        expect(qc.getQueryData(consentKeys.status(userId))).toEqual({ accepted: false })
+    })
+
+    it('keeps optimistic success stable without flicker or double-update', async () => {
+        const qc = createTestClient()
+        const userId = 'GCONSENT4'
+        qc.setQueryData(consentKeys.status(userId), { accepted: false })
+        vi.spyOn(api, 'post').mockResolvedValue({ recorded: true })
+
+        const timeline: boolean[] = []
+        const unsubscribe = qc.getQueryCache().subscribe((event) => {
+            const key = event.query.queryKey
+            if (JSON.stringify(key) !== JSON.stringify(consentKeys.status(userId))) return
+            const current = qc.getQueryData<{ accepted: boolean }>(consentKeys.status(userId))
+            if (typeof current?.accepted === 'boolean') {
+                timeline.push(current.accepted)
+            }
+        })
+
+        const { result } = renderHook(() => useRecordConsentMutation(userId), {
+            wrapper: withClient(qc),
+        })
+
+        await act(async () => {
+            await result.current.mutateAsync()
+        })
+        unsubscribe()
+
+        expect(qc.getQueryData(consentKeys.status(userId))).toEqual({ accepted: true })
+        expect(timeline).toContain(true)
+        expect(timeline).not.toContain(false)
+    })
+})
+
+describe('useRevokeConsentMutation', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('optimistically sets consent to revoked and rolls back on failure', async () => {
+        const qc = createTestClient()
+        const userId = 'GCONSENT5'
+        qc.setQueryData(consentKeys.status(userId), { accepted: true })
+        vi.spyOn(api, 'delete').mockRejectedValue(new Error('delete failed'))
+
+        const { result } = renderHook(() => useRevokeConsentMutation(userId), {
+            wrapper: withClient(qc),
+        })
+
+        const pending = result.current.mutateAsync()
+        await vi.waitFor(() => {
+            expect(qc.getQueryData(consentKeys.status(userId))).toEqual({ accepted: false })
+        })
+        await expect(pending).rejects.toThrow(/delete failed/i)
+        expect(qc.getQueryData(consentKeys.status(userId))).toEqual({ accepted: true })
+    })
+
+    it('keeps optimistic revoke stable on success without flicker', async () => {
+        const qc = createTestClient()
+        const userId = 'GCONSENT6'
+        qc.setQueryData(consentKeys.status(userId), { accepted: true })
+        vi.spyOn(api, 'delete').mockResolvedValue({ ok: true })
+
+        const timeline: boolean[] = []
+        const unsubscribe = qc.getQueryCache().subscribe((event) => {
+            const key = event.query.queryKey
+            if (JSON.stringify(key) !== JSON.stringify(consentKeys.status(userId))) return
+            const current = qc.getQueryData<{ accepted: boolean }>(consentKeys.status(userId))
+            if (typeof current?.accepted === 'boolean') {
+                timeline.push(current.accepted)
+            }
+        })
+
+        const { result } = renderHook(() => useRevokeConsentMutation(userId), {
+            wrapper: withClient(qc),
+        })
+
+        await act(async () => {
+            await result.current.mutateAsync()
+        })
+        unsubscribe()
+
+        expect(qc.getQueryData(consentKeys.status(userId))).toEqual({ accepted: false })
+        expect(timeline).toContain(false)
+        expect(timeline).not.toContain(true)
     })
 })

--- a/frontend/src/hooks/mutations/useConsentMutation.ts
+++ b/frontend/src/hooks/mutations/useConsentMutation.ts
@@ -6,6 +6,14 @@ export const consentKeys = {
     status: (userId: string) => [...consentKeys.all, 'status', userId] as const,
 }
 
+type ConsentStatus = {
+    accepted: boolean
+}
+
+type ConsentMutationContext = {
+    previous: ConsentStatus | undefined
+}
+
 export function useRecordConsentMutation(userId: string) {
     const queryClient = useQueryClient()
 
@@ -17,6 +25,35 @@ export function useRecordConsentMutation(userId: string) {
                 privacy: true,
                 cookies: true,
             }),
+        onMutate: async (): Promise<ConsentMutationContext> => {
+            await queryClient.cancelQueries({ queryKey: consentKeys.status(userId) })
+            const previous = queryClient.getQueryData<ConsentStatus>(consentKeys.status(userId))
+            queryClient.setQueryData<ConsentStatus>(consentKeys.status(userId), { accepted: true })
+            return { previous }
+        },
+        onError: (_error, _variables, context) => {
+            queryClient.setQueryData(consentKeys.status(userId), context?.previous)
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: consentKeys.status(userId) })
+        },
+    })
+}
+
+export function useRevokeConsentMutation(userId: string) {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: () => api.delete(ENDPOINTS.USER_DATA_DELETE(userId)),
+        onMutate: async (): Promise<ConsentMutationContext> => {
+            await queryClient.cancelQueries({ queryKey: consentKeys.status(userId) })
+            const previous = queryClient.getQueryData<ConsentStatus>(consentKeys.status(userId))
+            queryClient.setQueryData<ConsentStatus>(consentKeys.status(userId), { accepted: false })
+            return { previous }
+        },
+        onError: (_error, _variables, context) => {
+            queryClient.setQueryData(consentKeys.status(userId), context?.previous)
+        },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: consentKeys.status(userId) })
         },


### PR DESCRIPTION
## Summary

This PR delivers four assigned OSS contributions in one branch, covering frontend test reliability and CI hardening for backend migrations + Soroban deploy smoke checks.

### 1) Consent mutation optimistic UI tests (`frontend/src/hooks/mutations/useConsentMutation.test.tsx`)

- Added explicit coverage for optimistic consent grant:
  - state is set to granted immediately when mutation starts
  - failed mutation rolls back to the previous consent state
  - successful mutation keeps optimistic state stable (no flicker / no double-update)
- Added equivalent optimistic coverage for consent revoke:
  - optimistic revoke state is applied immediately
  - failed revoke rolls back correctly
  - successful revoke remains stable without flicker

### 2) Backend migration dry-run in CI (`.github/workflows/backend-tests.yml`)

- Added a dedicated `migration-dry-run` CI job that runs:
  - against **SQLite**
  - against **PostgreSQL** (via service container)
- Executes `npm run db:migrate -- --dry-run` and fails the check on non-zero exit.
- Configured path filtering so migration dry-run runs on PRs touching:
  - `backend/src/db/migrations/**`

### 3) Soroban contract smoke workflow (`.github/workflows/contract-smoke.yml`)

- Added a new workflow to:
  - build contract WASM
  - deploy to Stellar Testnet using Soroban CLI
  - invoke `initialize` and fail loudly if rejected
- Triggered on:
  - nightly schedule
  - changes under `contracts/**`
- Added caching for:
  - `~/.cargo`
  - `~/.soroban`
  - `contracts/target`
- Set timeout to keep the workflow within a 10-minute budget.

### 4) Wallet boot initialization error-recovery tests (`frontend/src/app/walletBoot.test.ts`)

- Added tests for all required outcomes:
  - successful boot sequence returns connected wallet address
  - extension detection failure returns `not_installed`
  - connection rejection returns `rejected`
- Added verification that boot state is represented as a **discriminated union** and exposed for UI handling.
- Added check that failure paths do not leave the app stuck in loading state.

---

## Why this change

- Prevent regressions in optimistic consent UX and ensure rollback behavior is explicit and test-verified.
- Catch broken SQL migrations before merge/deploy.
- Detect Soroban deploy/initialize breakages early via automated smoke checks.
- Improve wallet boot robustness and confidence in UI recovery behavior.

---

## Test Plan

### Frontend (targeted)
- `frontend/src/hooks/mutations/useConsentMutation.test.tsx`
- `frontend/src/app/walletBoot.test.ts`

### CI workflows
- `backend-tests.yml` migration dry-run matrix validates:
  - SQLite dry-run
  - PostgreSQL dry-run (service container)

### Contract smoke
- `contract-smoke.yml` validates:
  - contract deploy to testnet
  - successful `initialize` invocation

---

## Notes

- Contract smoke workflow expects repository secret:
  - `STELLAR_TESTNET_SECRET_KEY`
- If that secret is missing, the smoke workflow fails early with a clear error.





closes #335 
closes #336 
closes #337 
closes #338 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet connection boot flow to improve wallet setup and connection handling
  * Consent revocation capability allowing users to withdraw previously granted consent
  * Optimistic state updates for consent changes with automatic rollback on failure

* **Chores**
  * Enhanced continuous integration pipeline with database migration validation and contract deployment testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->