### PR TITLE
test: add dashboard, legacy api, rate limit, and asset registry coverage

### DIFF
--- a/backend/src/api/assets.routes.ts
+++ b/backend/src/api/assets.routes.ts
@@ -20,10 +20,43 @@ export const assetsRouter = Router()
 assetsRouter.get('/assets', (req: Request, res: Response) => {
     try {
         const enabledOnly = parseOptionalBoolean(req.query.enabledOnly) !== false
-        const assets = assetRegistryService.list(enabledOnly)
-        return ok(res, { assets })
+        const queryCode = typeof req.query.code === 'string' ? req.query.code.trim().toUpperCase() : ''
+        const querySearch = typeof req.query.search === 'string' ? req.query.search.trim().toUpperCase() : ''
+        const queryQ = typeof req.query.q === 'string' ? req.query.q.trim().toUpperCase() : ''
+        const term = queryCode || querySearch || queryQ
+        const page = Math.max(1, Number.parseInt(String(req.query.page ?? '1'), 10) || 1)
+        const limit = Math.min(100, Math.max(1, Number.parseInt(String(req.query.limit ?? '20'), 10) || 20))
+
+        let assets = assetRegistryService.list(enabledOnly)
+        if (term) {
+            assets = assets.filter(asset =>
+                asset.symbol.includes(term) || asset.name.toUpperCase().includes(term)
+            )
+        }
+
+        const total = assets.length
+        const start = (page - 1) * limit
+        const pagedAssets = assets.slice(start, start + limit)
+
+        return ok(res, { assets: pagedAssets, page, limit, total })
     } catch (error) {
         logger.error('[ERROR] List assets failed', { error: getErrorObject(error) })
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
+/** Public: get asset by symbol */
+assetsRouter.get('/assets/:id', (req: Request, res: Response) => {
+    try {
+        const id = req.params.id?.trim()
+        if (!id) return fail(res, 400, 'VALIDATION_ERROR', 'Asset id is required')
+
+        const asset = assetRegistryService.getBySymbol(id)
+        if (!asset || !asset.enabled) return fail(res, 404, 'NOT_FOUND', 'Asset not found')
+
+        return ok(res, { asset })
+    } catch (error) {
+        logger.error('[ERROR] Get asset failed', { error: getErrorObject(error) })
         return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
     }
 })

--- a/backend/src/middleware/legacyApiDeprecation.ts
+++ b/backend/src/middleware/legacyApiDeprecation.ts
@@ -2,10 +2,21 @@ import { Request, Response, NextFunction } from 'express'
 
 const LEGACY_API_SUNSET = 'Wed, 01 Jul 2026 00:00:00 GMT'
 const LEGACY_API_MIGRATION_DOC = '</docs/api-migration-v1.md>; rel="deprecation"'
+const LEGACY_REDIRECTS: Record<string, string> = {
+    '/portfolios': '/api/v1/portfolios'
+}
 
 export const legacyApiDeprecation = (req: Request, res: Response, next: NextFunction) => {
     res.setHeader('Deprecation', 'true')
     res.setHeader('Sunset', LEGACY_API_SUNSET)
     res.setHeader('Link', LEGACY_API_MIGRATION_DOC)
+
+    const target = LEGACY_REDIRECTS[req.path]
+    if (target) {
+        const search = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : ''
+        const status = req.method === 'GET' || req.method === 'HEAD' ? 301 : 308
+        res.redirect(status, `${target}${search}`)
+        return
+    }
     next()
 }

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -147,7 +147,7 @@ export const globalRateLimiter = rateLimit({
   keyGenerator: createKeyGenerator("global"),
   handler: createHandler(GLOBAL_WINDOW_MS, "global"),
   standardHeaders: "draft-7",
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: makeStore("global"),
   skip: skipSuccessfulRequests,
   message: "Too many requests from this IP, please try again later.",
@@ -160,7 +160,7 @@ export const burstProtectionLimiter = rateLimit({
   keyGenerator: createKeyGenerator("burst"),
   handler: createHandler(BURST_WINDOW_MS, "burst-protection"),
   standardHeaders: "draft-7",
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: makeStore("burst"),
   skip: (req) => isProbePath(req.path),
 });
@@ -172,7 +172,7 @@ export const writeRateLimiter = rateLimit({
   keyGenerator: createKeyGenerator("write"),
   handler: createHandler(GLOBAL_WINDOW_MS, "write-operations"),
   standardHeaders: "draft-7",
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: makeStore("write"),
 });
 
@@ -183,7 +183,7 @@ export const writeBurstLimiter = rateLimit({
   keyGenerator: createKeyGenerator("write-burst"),
   handler: createHandler(BURST_WINDOW_MS, "write-burst-protection"),
   standardHeaders: "draft-7",
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: makeStore("write-burst"),
   skip: (req) => isProbePath(req.path),
 });
@@ -195,7 +195,7 @@ export const authRateLimiter = rateLimit({
   keyGenerator: createKeyGenerator("auth"),
   handler: createHandler(GLOBAL_WINDOW_MS, "authentication"),
   standardHeaders: "draft-7",
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: makeStore("auth"),
   skip: () => false,
 });
@@ -207,7 +207,7 @@ export const criticalRateLimiter = rateLimit({
   keyGenerator: createKeyGenerator("critical"),
   handler: createHandler(GLOBAL_WINDOW_MS, "critical-operations"),
   standardHeaders: "draft-7",
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: makeStore("critical"),
   skip: () => false,
 });
@@ -219,7 +219,7 @@ export const adminRateLimiter = rateLimit({
   keyGenerator: createKeyGenerator("admin"),
   handler: createHandler(GLOBAL_WINDOW_MS, "admin-operations"),
   standardHeaders: "draft-7",
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: makeStore("admin"),
   skip: () => false,
 });

--- a/backend/src/test/assets.routes.integration.test.ts
+++ b/backend/src/test/assets.routes.integration.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import type { Express } from 'express'
+import request from 'supertest'
+import { mkdirSync, existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let app: Express
+let testDbPath: string
+const envBackup: NodeJS.ProcessEnv = { ...process.env }
+
+beforeAll(async () => {
+    const testDir = join(tmpdir(), `stellar-assets-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(testDir, { recursive: true })
+    testDbPath = join(testDir, 'assets-test.db')
+
+    vi.resetModules()
+    process.env = { ...envBackup }
+    delete process.env.DATABASE_URL
+    process.env.DB_PATH = testDbPath
+    process.env.JWT_SECRET = 'unit-test-jwt-secret-min-32-chars!!'
+    process.env.NODE_ENV = 'test'
+    process.env.ENABLE_DEMO_DB_SEED = 'false'
+    process.env.DEMO_MODE = 'true'
+    process.env.AUTH_ENABLED = 'false'
+
+    const express = (await import('express')).default
+    const cors = (await import('cors')).default
+    const { mountApiRoutes } = await import('../http/mountApiRoutes.js')
+    const { apiErrorHandler } = await import('../middleware/apiErrorHandler.js')
+
+    app = express()
+    app.use(cors())
+    app.use(express.json())
+    mountApiRoutes(app)
+    app.use(apiErrorHandler)
+}, 60_000)
+
+afterAll(() => {
+    process.env = envBackup
+    if (testDbPath) {
+        const dir = join(testDbPath, '..')
+        if (existsSync(dir)) rmSync(dir, { recursive: true, force: true })
+    }
+})
+
+describe('assets routes integration', () => {
+    it('GET /api/v1/assets returns paginated asset list', async () => {
+        const res = await request(app).get('/api/v1/assets?page=1&limit=2').expect(200)
+
+        expect(res.body.success).toBe(true)
+        expect(Array.isArray(res.body.data.assets)).toBe(true)
+        expect(res.body.data.assets.length).toBeLessThanOrEqual(2)
+        expect(res.body.data.page).toBe(1)
+        expect(res.body.data.limit).toBe(2)
+        expect(typeof res.body.data.total).toBe('number')
+        expect(res.body.data.total).toBeGreaterThan(0)
+    })
+
+    it('filters assets by asset code with matching and non-matching queries', async () => {
+        const match = await request(app).get('/api/v1/assets?code=XLM').expect(200)
+        expect(match.body.data.assets.length).toBeGreaterThan(0)
+        expect(match.body.data.assets.every((asset: { symbol: string }) => asset.symbol.includes('XLM'))).toBe(true)
+
+        const noMatch = await request(app).get('/api/v1/assets?code=DOES_NOT_EXIST').expect(200)
+        expect(noMatch.body.data.assets).toEqual([])
+        expect(noMatch.body.data.total).toBe(0)
+    })
+
+    it('GET /api/v1/assets/:id returns 404 for unknown asset', async () => {
+        const res = await request(app).get('/api/v1/assets/UNKNOWN_ASSET').expect(404)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('allows public browsing without Authorization header', async () => {
+        const res = await request(app).get('/api/v1/assets').expect(200)
+        expect(res.body.success).toBe(true)
+    })
+})

--- a/backend/src/test/legacyDeprecation.test.ts
+++ b/backend/src/test/legacyDeprecation.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import type { Express } from 'express'
 import request from 'supertest'
+import express from 'express'
 import { mkdirSync, existsSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { legacyApiDeprecation } from '../middleware/legacyApiDeprecation.js'
 
 let app: Express
 let testDbPath: string
@@ -155,5 +157,51 @@ describe('Legacy API Deprecation Headers', () => {
             expect(canonicalRes.status).toBe(legacyRes.status)
             expect(canonicalRes.body.status).toBe(legacyRes.body.status)
         })
+    })
+})
+
+describe('legacyApiDeprecation redirect compatibility', () => {
+    const redirectApp = express()
+    redirectApp.use(express.json())
+    redirectApp.use('/api', legacyApiDeprecation)
+
+    redirectApp.get('/api/v1/portfolios', (_req, res) => {
+        res.status(200).json({ ok: true })
+    })
+    redirectApp.post('/api/v1/portfolios', (req, res) => {
+        res.status(200).json({ body: req.body })
+    })
+    redirectApp.use('/api/*', (_req, res) => {
+        res.status(404).json({ code: 'NOT_FOUND' })
+    })
+
+    it('redirects GET /api/portfolios to /api/v1/portfolios with 301', async () => {
+        const res = await request(redirectApp).get('/api/portfolios')
+        expect(res.status).toBe(301)
+        expect(res.headers.location).toBe('/api/v1/portfolios')
+    })
+
+    it('includes RFC 8594 deprecation headers on legacy redirects', async () => {
+        const res = await request(redirectApp).get('/api/portfolios')
+        expect(res.headers['deprecation']).toBe('true')
+        expect(res.headers['sunset']).toMatch(/^\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} GMT$/)
+        expect(res.headers['link']).toContain('rel="deprecation"')
+    })
+
+    it('preserves POST body through redirect', async () => {
+        const payload = { userAddress: 'GTEST', allocations: { XLM: 100 } }
+        const res = await request(redirectApp)
+            .post('/api/portfolios')
+            .send(payload)
+            .redirects(1)
+
+        expect(res.status).toBe(200)
+        expect(res.body.body).toEqual(payload)
+    })
+
+    it('returns 404 for unknown legacy paths without misdirecting', async () => {
+        const res = await request(redirectApp).get('/api/unknown-legacy-path')
+        expect(res.status).toBe(404)
+        expect(res.headers.location).toBeUndefined()
     })
 })

--- a/backend/src/test/rateLimit.test.ts
+++ b/backend/src/test/rateLimit.test.ts
@@ -8,9 +8,34 @@ vi.mock('../utils/apiResponse.js', async () => {
 })
 
 describe('rateLimit middleware', () => {
-    it('returns standardized RATE_LIMITED response with retry metadata', async () => {
+    it('sets X-RateLimit-Limit on v1 responses and decrements remaining', async () => {
         vi.stubEnv('RATE_LIMIT_WINDOW_MS', '60000')
-        vi.stubEnv('RATE_LIMIT_MAX', '1')
+        vi.stubEnv('RATE_LIMIT_WRITE_MAX', '2')
+        vi.resetModules()
+
+        const { writeRateLimiter } = await import('../middleware/rateLimit.js')
+        const app = express()
+        app.use(express.json())
+        app.post('/api/v1/test', writeRateLimiter, (_req, res) => {
+            res.json({ ok: true })
+        })
+
+        const first = await request(app).post('/api/v1/test').send({ ok: true }).expect(200)
+        const second = await request(app).post('/api/v1/test').send({ ok: true }).expect(200)
+
+        const firstLimit = Number(first.headers['x-ratelimit-limit'])
+        const firstRemaining = Number(first.headers['x-ratelimit-remaining'])
+        const secondRemaining = Number(second.headers['x-ratelimit-remaining'])
+
+        expect(Number.isInteger(firstLimit)).toBe(true)
+        expect(firstLimit).toBeGreaterThan(0)
+        expect(Number.isInteger(firstRemaining)).toBe(true)
+        expect(Number.isInteger(secondRemaining)).toBe(true)
+        expect(secondRemaining).toBeLessThan(firstRemaining)
+    })
+
+    it('returns Retry-After with a valid integer on 429 responses', async () => {
+        vi.stubEnv('RATE_LIMIT_WINDOW_MS', '60000')
         vi.stubEnv('RATE_LIMIT_WRITE_MAX', '1')
         vi.resetModules()
 
@@ -28,6 +53,37 @@ describe('rateLimit middleware', () => {
         expect(second.body.success).toBe(false)
         expect(second.body.error.code).toBe('RATE_LIMITED')
         expect(second.body.meta.retryAfter).toBeDefined()
-        expect(second.headers['retry-after']).toBeDefined()
+        expect(second.headers['x-ratelimit-limit']).toBeDefined()
+        expect(second.headers['x-ratelimit-remaining']).toBeDefined()
+        expect(Number.isInteger(Number(second.headers['retry-after']))).toBe(true)
+        expect(Number(second.headers['retry-after'])).toBeGreaterThan(0)
+    })
+
+    it('reports redis store type when redis is available', async () => {
+        vi.resetModules()
+        vi.doMock('../queue/connection.js', async () => {
+            const actual = await vi.importActual<typeof import('../queue/connection.js')>('../queue/connection.js')
+            return {
+                ...actual,
+                getCachedRedisAvailability: () => true
+            }
+        })
+
+        const { getRateLimitStoreType } = await import('../middleware/rateLimit.js')
+        expect(getRateLimitStoreType()).toBe('redis')
+    })
+
+    it('reports memory store type when redis is unavailable', async () => {
+        vi.resetModules()
+        vi.doMock('../queue/connection.js', async () => {
+            const actual = await vi.importActual<typeof import('../queue/connection.js')>('../queue/connection.js')
+            return {
+                ...actual,
+                getCachedRedisAvailability: () => false
+            }
+        })
+
+        const { getRateLimitStoreType } = await import('../middleware/rateLimit.js')
+        expect(getRateLimitStoreType()).toBe('memory')
     })
 })

--- a/frontend/src/components/Dashboard.test.tsx
+++ b/frontend/src/components/Dashboard.test.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import Dashboard from './Dashboard'
+
+const queryMocks = vi.hoisted(() => ({
+    useUserPortfolios: vi.fn(),
+    usePortfolioDetails: vi.fn(),
+    useRebalanceEstimate: vi.fn(),
+    usePrices: vi.fn(),
+    useExecuteRebalanceMutation: vi.fn(),
+}))
+
+vi.mock('../hooks/queries/usePortfolioQuery', () => ({
+    useUserPortfolios: queryMocks.useUserPortfolios,
+    usePortfolioDetails: queryMocks.usePortfolioDetails,
+    useRebalanceEstimate: queryMocks.useRebalanceEstimate,
+}))
+
+vi.mock('../hooks/queries/usePricesQuery', () => ({
+    usePrices: queryMocks.usePrices,
+    formatPriceFeedSummary: vi.fn(() => 'Live prices'),
+}))
+
+vi.mock('../hooks/mutations/usePortfolioMutations', () => ({
+    useExecuteRebalanceMutation: queryMocks.useExecuteRebalanceMutation,
+}))
+
+vi.mock('../context/ThemeContext', () => ({
+    useTheme: vi.fn(() => ({ isDark: false })),
+}))
+
+vi.mock('./ThemeToggle', () => ({ default: () => <div>Theme Toggle</div> }))
+vi.mock('recharts', () => ({
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    PieChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    Pie: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    Cell: () => <div />,
+    LineChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    Line: () => <div />,
+    XAxis: () => <div />,
+    YAxis: () => <div />,
+    CartesianGrid: () => <div />,
+    Tooltip: () => <div />,
+}))
+vi.mock('./AssetCard', () => ({
+    default: ({ asset, isLoading }: { asset?: { name?: string }; isLoading?: boolean }) =>
+        isLoading ? <div>Asset Card Skeleton</div> : <div>Asset Card {asset?.name ?? 'Unknown'}</div>
+}))
+vi.mock('./RebalanceHistory', () => ({ default: () => <div>Rebalance History</div> }))
+vi.mock('./PerformanceChart', () => ({ default: () => <div>Performance Chart</div> }))
+vi.mock('./NotificationPreferences', () => ({ default: () => <div>Notification Preferences</div> }))
+vi.mock('./PriceTracker', () => ({ default: () => <div>Price Tracker</div> }))
+
+vi.mock('../utils/stellar', () => ({
+    StellarWallet: {
+        getWalletType: vi.fn(() => 'freighter'),
+        disconnect: vi.fn(),
+    }
+}))
+
+vi.mock('../services/authService', () => ({
+    logout: vi.fn(async () => undefined),
+}))
+
+vi.mock('../utils/export', () => ({
+    downloadCSV: vi.fn(),
+    downloadJSON: vi.fn(),
+    toCSV: vi.fn(() => 'csv'),
+}))
+
+vi.mock('../config/api', async () => {
+    const actual = await vi.importActual<typeof import('../config/api')>('../config/api')
+    return {
+        ...actual,
+        API_CONFIG: { ...actual.API_CONFIG, USE_BROWSER_PRICES: false },
+        api: { delete: vi.fn(async () => undefined) },
+        downloadPortfolioExport: vi.fn(async () => undefined),
+    }
+})
+
+class TestErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
+    constructor(props: { children: React.ReactNode }) {
+        super(props)
+        this.state = { hasError: false }
+    }
+
+    static getDerivedStateFromError() {
+        return { hasError: true }
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return <div>Dashboard failed to load</div>
+        }
+        return this.props.children
+    }
+}
+
+describe('Dashboard', () => {
+    beforeEach(() => {
+        cleanup()
+        vi.restoreAllMocks()
+
+        queryMocks.useUserPortfolios.mockReturnValue({ data: [], isLoading: false })
+        queryMocks.usePortfolioDetails.mockReturnValue({ data: null, isLoading: false })
+        queryMocks.useRebalanceEstimate.mockReturnValue({ data: null, isLoading: false })
+        queryMocks.usePrices.mockReturnValue({ data: { prices: {}, feedMeta: null }, isLoading: false })
+        queryMocks.useExecuteRebalanceMutation.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    })
+
+    it('renders onboarding CTA for an empty portfolio', async () => {
+        render(<Dashboard onNavigate={vi.fn()} publicKey="GABC1234TEST" />)
+
+        expect(await screen.findByRole('button', { name: /create portfolio/i })).toBeTruthy()
+        expect(screen.getByText(/portfolio dashboard/i)).toBeTruthy()
+    })
+
+    it('renders asset cards when portfolio data is populated', async () => {
+        queryMocks.useUserPortfolios.mockReturnValue({
+            data: [{
+                id: 'p-1',
+                totalValue: 5000,
+                dayChange: 1.2,
+                allocations: [
+                    { asset: 'XLM', target: 60, amount: 3000 },
+                    { asset: 'USDC', target: 40, amount: 2000 },
+                ]
+            }],
+            isLoading: false
+        })
+        queryMocks.usePrices.mockReturnValue({
+            data: {
+                prices: { XLM: { price: 0.12, change: 1.1 }, USDC: { price: 1, change: 0 } },
+                feedMeta: null
+            },
+            isLoading: false
+        })
+
+        render(<Dashboard onNavigate={vi.fn()} publicKey="GABC1234TEST" />)
+
+        expect(await screen.findByText('Asset Card XLM')).toBeTruthy()
+        expect(screen.getByText('Asset Card USDC')).toBeTruthy()
+    })
+
+    it('renders loading state while portfolio data is fetching', async () => {
+        queryMocks.useUserPortfolios.mockReturnValue({ data: undefined, isLoading: true })
+        queryMocks.usePrices.mockReturnValue({ data: undefined, isLoading: true })
+
+        render(<Dashboard onNavigate={vi.fn()} publicKey="GABC1234TEST" />)
+
+        expect(await screen.findByText(/loading portfolio data/i)).toBeTruthy()
+    })
+
+    it('renders error fallback when portfolio fetching throws', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+        queryMocks.useUserPortfolios.mockImplementation(() => {
+            throw new Error('portfolio fetch failed')
+        })
+
+        render(
+            <TestErrorBoundary>
+                <Dashboard onNavigate={vi.fn()} publicKey="GABC1234TEST" />
+            </TestErrorBoundary>
+        )
+
+        expect(await screen.findByText(/dashboard failed to load/i)).toBeTruthy()
+        consoleError.mockRestore()
+    })
+})


### PR DESCRIPTION
closes #319 
closes #318 
closes #317 
closes #316 
## Summary

This PR completes four assigned open-source test contributions in a single branch by adding targeted coverage for critical frontend and backend behaviors, plus minimal backend support needed for the new tests to validate real behavior.

### 1) Dashboard unit tests (`frontend/src/components/Dashboard.test.tsx`)
- Added coverage for empty portfolio state to verify onboarding CTA renders correctly.
- Added coverage for populated portfolio state to verify asset cards render.
- Added coverage for loading state to verify loading UI appears during fetch.
- Added error-boundary coverage to verify fetch failures are safely handled without unhandled UI crashes.

### 2) Legacy API deprecation tests (`backend/src/test/legacyDeprecation.test.ts`)
- Added redirect test: `/api/portfolios` -> `/api/v1/portfolios` with expected redirect behavior.
- Added deprecation header validation for legacy responses (`Deprecation`, `Sunset`, `Link`).
- Added POST body-preservation test through redirect flow.
- Added unknown legacy path test to ensure 404 (no incorrect redirect target).

### 3) Rate limit header tests (`backend/src/test/rateLimit.test.ts`)
- Added assertions for `X-RateLimit-Limit` on responses.
- Added assertions that `X-RateLimit-Remaining` decreases across requests.
- Added assertions that `Retry-After` is present and numeric on 429 responses.
- Added coverage for both Redis-available and in-memory store reporting behavior.

### 4) Asset registry integration tests (`backend/src/test/assets.routes.integration.test.ts`)
- Added integration coverage for paginated asset listing (`page`, `limit`, `total` metadata).
- Added filter/search coverage for matching and non-matching asset code queries.
- Added unknown asset lookup coverage (`GET /api/v1/assets/:id` -> 404).
- Added public access coverage (no Authorization header required).

## Implementation Notes

To satisfy the requested acceptance criteria with executable behavior:
- `backend/src/api/assets.routes.ts`
  - Added pagination and filter support to `GET /assets`.
  - Added `GET /assets/:id` public lookup endpoint with 404 handling for unknown/disabled assets.
- `backend/src/middleware/legacyApiDeprecation.ts`
  - Added explicit redirect mapping for legacy `/portfolios`.
- `backend/src/middleware/rateLimit.ts`
  - Enabled legacy rate-limit headers so clients and tests can assert `X-RateLimit-*`.

## Test Plan

### Frontend
- [x] Run `npx vitest run frontend/src/components/Dashboard.test.tsx`
- [x] Confirm all new Dashboard tests pass.

### Backend (targeted)
- [x] Added tests for:
  - `backend/src/test/legacyDeprecation.test.ts`
  - `backend/src/test/rateLimit.test.ts`
  - `backend/src/test/assets.routes.integration.test.ts`
- [ ] Run full targeted backend test execution once existing repo parse error is resolved (`backend/src/services/contractEventIndexer.ts`).

## Acceptance Criteria Mapping

- [x] Empty state renders onboarding CTA without errors.
- [x] Loading state renders correctly.
- [x] Error state is rendered via boundary fallback (no unhandled UI failure).
- [x] Legacy redirect behavior and deprecation headers are explicitly tested.
- [x] POST redirect body behavior is explicitly verified.
- [x] Unknown legacy paths are verified as 404.
- [x] Rate limit headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `Retry-After`) are validated.
- [x] Header values are asserted as numeric in relevant cases.
- [x] Asset pagination metadata is verified.
- [x] Asset filter matching and non-matching queries are tested.
- [x] Unknown asset lookup returns 404.
- [x] Public asset browsing is tested without auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assets list endpoint now supports pagination with `page` and `limit` parameters; responses include total asset count
  * New endpoint to retrieve individual asset details by asset ID

* **Chores**
  * Legacy API paths now automatically redirect to their modern equivalents with appropriate status codes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->