### PR TITLE
Unit tests for reflector

### DIFF
--- a/backend/src/services/reflector.ts
+++ b/backend/src/services/reflector.ts
@@ -18,6 +18,8 @@ export class ReflectorService {
     private coinGeckoApiKey: string
     private coinGeckoIds: Record<string, string>
     private priceCache: Map<string, { data: PriceData; cachedAtMs: number }>
+    private reflectorApiUrl: string
+    private readonly PRICE_DATA_MAX_AGE = Number.parseInt(process.env.PRICE_DATA_MAX_AGE || '600', 10)
     private readonly CACHE_DURATION = process.env.NODE_ENV === 'production' ? 600000 : 300000 // 10 min vs 5 min
     private lastRequestTime = 0
     private readonly MIN_REQUEST_INTERVAL = 90000 // Increased to 1.5 minutes for Pro API
@@ -26,6 +28,7 @@ export class ReflectorService {
         this.coinGeckoApiKey = process.env.COINGECKO_API_KEY || ''
         this.priceCache = new Map()
         this.coinGeckoIds = { ...DEFAULT_COIN_IDS }
+        this.reflectorApiUrl = process.env.REFLECTOR_API_URL || ''
     }
 
     /** Asset list from registry; fallback to default 4 if registry empty */
@@ -71,7 +74,7 @@ export class ReflectorService {
 
     private async resolvePricesInternal(): Promise<{ map: PricesMap; hint: PriceResolutionHint }> {
         try {
-            logger.info('[DEBUG] Fetching prices from CoinGecko with smart caching')
+            logger.info('[DEBUG] Fetching prices with Reflector/CoinGecko and smart caching')
             const assets = this.getAssetList()
 
             const cachedPrices = this.getCachedPrices(assets)
@@ -92,11 +95,26 @@ export class ReflectorService {
                 throw new Error('Price request rate-limited and ALLOW_FALLBACK_PRICES is disabled')
             }
 
+            let reflectorPrices: PricesMap = {}
+            try {
+                reflectorPrices = await this.getReflectorPrices(assets)
+            } catch (reflectorError) {
+                logger.warn('[WARNING] Reflector fetch failed, falling back to CoinGecko', { reflectorError })
+            }
+
+            const missingAssets = assets.filter((asset) => reflectorPrices[asset] === undefined)
             const coinIds = this.getCoinIdMap()
-            const freshPrices = await this.getFreshPrices(assets, coinIds)
-            const merged = { ...cachedPrices, ...freshPrices } as PricesMap
+            const freshPrices = missingAssets.length > 0
+                ? await this.getFreshPrices(missingAssets, coinIds)
+                : {}
+
+            const merged = { ...cachedPrices, ...reflectorPrices, ...freshPrices } as PricesMap
+            if (Object.keys(merged).length === 0) {
+                throw new Error('No valid price data available from Reflector or CoinGecko')
+            }
+
             const hint: PriceResolutionHint =
-                Object.keys(freshPrices).length === assets.length
+                Object.keys(reflectorPrices).length + Object.keys(freshPrices).length === assets.length
                     ? 'fresh_primary'
                     : Object.keys(cachedPrices).length > 0
                       ? 'partial_merge'
@@ -166,6 +184,76 @@ export class ReflectorService {
         })
 
         return cachedPrices
+    }
+
+    private normalizeReflectorPrice(raw: string | number | bigint, decimals: number): number {
+        const numeric = typeof raw === 'bigint' ? Number(raw) : Number(raw)
+        if (!Number.isFinite(numeric)) {
+            throw new Error('Invalid Reflector price value')
+        }
+        if (decimals <= 0) return numeric
+        return numeric / (10 ** decimals)
+    }
+
+    private isPriceStale(timestamp: number): boolean {
+        const tsSec = timestamp >= 1e12 ? Math.floor(timestamp / 1000) : Math.floor(timestamp)
+        const nowSec = Math.floor(Date.now() / 1000)
+        return (nowSec - tsSec) > this.PRICE_DATA_MAX_AGE
+    }
+
+    private async getReflectorPrices(assets: string[]): Promise<PricesMap> {
+        if (!this.reflectorApiUrl) return {}
+
+        const url = `${this.reflectorApiUrl.replace(/\/$/, '')}/prices?assets=${encodeURIComponent(assets.join(','))}`
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'StellarPortfolioRebalancer/1.0'
+            }
+        })
+
+        if (!response.ok) {
+            throw new Error(`Reflector API error: ${response.status}`)
+        }
+
+        const payload = await response.json() as {
+            prices?: Record<string, { price: string | number | bigint; timestamp: number; decimals?: number; change?: number; volume?: number }>
+        } | Record<string, { price: string | number | bigint; timestamp: number; decimals?: number; change?: number; volume?: number }>
+
+        const rows = ('prices' in payload && payload.prices)
+            ? payload.prices
+            : payload
+
+        const out: PricesMap = {}
+        let staleCount = 0
+
+        assets.forEach((asset) => {
+            const row = rows?.[asset]
+            if (!row) return
+
+            if (this.isPriceStale(row.timestamp)) {
+                staleCount += 1
+                return
+            }
+
+            out[asset] = {
+                price: this.normalizeReflectorPrice(row.price, row.decimals ?? 0),
+                change: row.change ?? 0,
+                timestamp: row.timestamp,
+                source: 'reflector',
+                volume: row.volume,
+                servedFromCache: false,
+                serverFetchedAtMs: Date.now(),
+                dataTier: 'primary'
+            }
+        })
+
+        if (Object.keys(out).length === 0 && staleCount > 0) {
+            throw new Error('Reflector data is stale')
+        }
+
+        return out
     }
 
     private async getFreshPrices(assets: string[], coinIds: Record<string, string>): Promise<PricesMap> {

--- a/backend/src/test/reflector.service.test.ts
+++ b/backend/src/test/reflector.service.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ReflectorService } from '../services/reflector.js'
+import { assetRegistryService } from '../services/assetRegistryService.js'
+
+type MockFetchResponse = {
+    ok: boolean
+    status: number
+    json: () => Promise<unknown>
+    text: () => Promise<string>
+    headers: Headers
+}
+
+const response = (body: unknown, status = 200): MockFetchResponse => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    headers: new Headers()
+})
+
+describe('ReflectorService staleness and fallback', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+        vi.clearAllMocks()
+
+        vi.spyOn(assetRegistryService, 'getSymbols').mockReturnValue(['XLM'])
+        vi.spyOn(assetRegistryService, 'getCoingeckoIdMap').mockReturnValue({ XLM: 'stellar' })
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.unstubAllEnvs()
+        vi.unstubAllGlobals()
+        vi.restoreAllMocks()
+    })
+
+    it('falls back to CoinGecko when Reflector quote is stale beyond PRICE_DATA_MAX_AGE', async () => {
+        const nowSec = Math.floor(Date.now() / 1000)
+
+        vi.stubEnv('REFLECTOR_API_URL', 'https://reflector.example')
+        vi.stubEnv('PRICE_DATA_MAX_AGE', '600')
+        vi.stubEnv('ALLOW_FALLBACK_PRICES', 'false')
+
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(response({
+                prices: {
+                    XLM: {
+                        price: '3540000',
+                        decimals: 7,
+                        timestamp: nowSec - 601
+                    }
+                }
+            }))
+            .mockResolvedValueOnce(response({
+                stellar: {
+                    usd: 0.361,
+                    usd_24h_change: 0.5,
+                    last_updated_at: nowSec - 3
+                }
+            }))
+
+        vi.stubGlobal('fetch', fetchMock)
+
+        const service = new ReflectorService()
+        const prices = await service.getCurrentPrices()
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        expect(fetchMock.mock.calls[0]?.[0]).toContain('reflector.example')
+        expect(fetchMock.mock.calls[1]?.[0]).toContain('api.coingecko.com')
+        expect(prices.XLM.source).toBe('coingecko_free')
+        expect(prices.XLM.price).toBe(0.361)
+    })
+
+    it('treats quote exactly at threshold as fresh and keeps Reflector as source', async () => {
+        const nowSec = Math.floor(Date.now() / 1000)
+
+        vi.stubEnv('REFLECTOR_API_URL', 'https://reflector.example')
+        vi.stubEnv('PRICE_DATA_MAX_AGE', '600')
+
+        const fetchMock = vi.fn().mockResolvedValueOnce(response({
+            prices: {
+                XLM: {
+                    price: '3540000',
+                    decimals: 7,
+                    timestamp: nowSec - 600
+                }
+            }
+        }))
+
+        vi.stubGlobal('fetch', fetchMock)
+
+        const service = new ReflectorService()
+        const prices = await service.getCurrentPrices()
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(prices.XLM.source).toBe('reflector')
+        expect(prices.XLM.price).toBeCloseTo(0.354, 8)
+    })
+
+    it('throws explicit error when Reflector and CoinGecko are unavailable with fallback disabled', async () => {
+        const nowSec = Math.floor(Date.now() / 1000)
+
+        vi.stubEnv('REFLECTOR_API_URL', 'https://reflector.example')
+        vi.stubEnv('PRICE_DATA_MAX_AGE', '600')
+        vi.stubEnv('ALLOW_FALLBACK_PRICES', 'false')
+
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(response({
+                prices: {
+                    XLM: {
+                        price: '3540000',
+                        decimals: 7,
+                        timestamp: nowSec - 900
+                    }
+                }
+            }))
+            .mockResolvedValueOnce(response({ error: 'upstream unavailable' }, 503))
+
+        vi.stubGlobal('fetch', fetchMock)
+
+        const service = new ReflectorService()
+
+        await expect(service.getCurrentPrices()).rejects.toThrow(
+            'Price sources unavailable and ALLOW_FALLBACK_PRICES is disabled'
+        )
+    })
+
+    it('normalizes Reflector prices across mixed decimal precisions', async () => {
+        const nowSec = Math.floor(Date.now() / 1000)
+
+        vi.spyOn(assetRegistryService, 'getSymbols').mockReturnValue(['XLM', 'BTC'])
+        vi.spyOn(assetRegistryService, 'getCoingeckoIdMap').mockReturnValue({ XLM: 'stellar', BTC: 'bitcoin' })
+
+        vi.stubEnv('REFLECTOR_API_URL', 'https://reflector.example')
+        vi.stubEnv('PRICE_DATA_MAX_AGE', '600')
+
+        const fetchMock = vi.fn().mockResolvedValueOnce(response({
+            prices: {
+                XLM: {
+                    price: '3540000',
+                    decimals: 7,
+                    timestamp: nowSec - 10
+                },
+                BTC: {
+                    price: '10500000000000',
+                    decimals: 8,
+                    timestamp: nowSec - 10
+                }
+            }
+        }))
+
+        vi.stubGlobal('fetch', fetchMock)
+
+        const service = new ReflectorService()
+        const prices = await service.getCurrentPrices()
+
+        expect(prices.XLM.price).toBeCloseTo(0.354, 8)
+        expect(prices.BTC.price).toBe(105000)
+        expect(prices.XLM.source).toBe('reflector')
+        expect(prices.BTC.source).toBe('reflector')
+    })
+})


### PR DESCRIPTION
closes #311 

The `reflector.ts `service fetches oracle prices and the `test_stale_data` contract snapshot exists, but the backend service layer has no tests for staleness detection or fallback to CoinGecko.

**Implementation:**
Create `backend/src/test/reflector.service.test.ts`:

- Mock Reflector response with timestamps older than the staleness threshold
- Verify service falls back to CoinGecko API when Reflector data is stale
- Test that both sources being unavailable returns a clear error (not cached stale data)
- Test price normalization from different decimal precisions

**Acceptance Criteria:**

- Staleness threshold is enforced in tests
- CoinGecko fallback is triggered and tested
- Dual-source failure produces an explicit error, not silent zeros

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced price fetching with automatic fallback mechanism when data sources are incomplete
  * Added data freshness validation to ensure pricing accuracy

* **Bug Fixes**
  * Improved error messaging when price data is unavailable
  * Fixed decimal precision handling in price calculations

* **Tests**
  * Added comprehensive test suite for price fetching fallback scenarios and data validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->