### PR TITLE
Fix/portfolio rebalance consent tests

### DIFF
--- a/backend/src/api/consent.routes.ts
+++ b/backend/src/api/consent.routes.ts
@@ -3,13 +3,30 @@ import { databaseService } from '../services/databaseService.js'
 import { ok, fail } from '../utils/apiResponse.js'
 import { logger } from '../utils/logger.js'
 import { getErrorObject, getErrorMessage } from '../utils/helpers.js'
-import { consentStatusQuerySchema, recordConsentSchema } from './validation.js'
+import {
+    consentAuditQuerySchema,
+    consentGrantSchema,
+    consentStatusQuerySchema,
+    consentRevokeSchema,
+    recordConsentSchema
+} from './validation.js'
 import { validateRequest, validateQuery } from '../middleware/validate.js'
 import { protectedWriteLimiter, protectedCriticalLimiter } from '../middleware/rateLimit.js'
 import { idempotencyMiddleware } from '../middleware/idempotency.js'
 import { requireJwtWhenEnabled } from '../middleware/requireJwt.js'
 
 export const consentRouter = Router()
+
+function consentRequestMeta(req: Request): { ipAddress?: string; userAgent?: string } {
+    return {
+        ipAddress: req.ip ?? req.socket?.remoteAddress,
+        userAgent: req.get('user-agent')
+    }
+}
+
+function resolveConsentUserId(req: Request, candidate?: string): string | undefined {
+    return req.user?.address ?? candidate
+}
 
 /** Get consent status for a user. Required before using the app. */
 consentRouter.get('/consent/status', validateQuery(consentStatusQuerySchema), (req: Request, res: Response) => {
@@ -21,10 +38,78 @@ consentRouter.get('/consent/status', validateQuery(consentStatusQuerySchema), (r
             accepted,
             termsAcceptedAt: consent?.termsAcceptedAt ?? null,
             privacyAcceptedAt: consent?.privacyAcceptedAt ?? null,
-            cookieAcceptedAt: consent?.cookieAcceptedAt ?? null
+            cookieAcceptedAt: consent?.cookieAcceptedAt ?? null,
+            revokedAt: consent?.revokedAt ?? null,
+            active: consent?.active ?? false
         })
     } catch (error) {
         logger.error('[ERROR] Consent status failed', { error: getErrorObject(error) })
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
+/** GDPR: Grant active consent and append an immutable audit event. */
+consentRouter.post('/consent/grant', requireJwtWhenEnabled, ...protectedWriteLimiter, idempotencyMiddleware, validateRequest(consentGrantSchema), (req: Request, res: Response) => {
+    try {
+        const userId = resolveConsentUserId(req, req.body.userId)
+        if (!userId) return fail(res, 400, 'VALIDATION_ERROR', 'userId is required')
+        const meta = consentRequestMeta(req)
+        databaseService.recordConsent(userId, {
+            terms: req.body.terms,
+            privacy: req.body.privacy,
+            cookies: req.body.cookies,
+            ...meta
+        })
+        const consent = databaseService.getConsent(userId)
+        return ok(res, {
+            message: 'Consent granted',
+            accepted: databaseService.hasFullConsent(userId),
+            userId,
+            termsAcceptedAt: consent?.termsAcceptedAt ?? null,
+            privacyAcceptedAt: consent?.privacyAcceptedAt ?? null,
+            cookieAcceptedAt: consent?.cookieAcceptedAt ?? null,
+            revokedAt: consent?.revokedAt ?? null,
+            active: consent?.active ?? false,
+            ipAddress: meta.ipAddress ?? null
+        })
+    } catch (error) {
+        logger.error('[ERROR] Grant consent failed', { error: getErrorObject(error) })
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
+/** GDPR: Revoke active consent and append an immutable audit event. */
+consentRouter.post('/consent/revoke', requireJwtWhenEnabled, ...protectedCriticalLimiter, idempotencyMiddleware, validateRequest(consentRevokeSchema), (req: Request, res: Response) => {
+    try {
+        const userId = resolveConsentUserId(req, req.body.userId)
+        if (!userId) return fail(res, 400, 'VALIDATION_ERROR', 'userId is required')
+        const meta = consentRequestMeta(req)
+        databaseService.revokeConsent(userId, meta)
+        const consent = databaseService.getConsent(userId)
+        return ok(res, {
+            message: 'Consent revoked',
+            accepted: false,
+            userId,
+            revokedAt: consent?.revokedAt ?? null,
+            active: consent?.active ?? false
+        })
+    } catch (error) {
+        logger.error('[ERROR] Revoke consent failed', { error: getErrorObject(error) })
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
+/** GDPR: Return append-only grant/revoke audit events for a user. */
+consentRouter.get('/consent/audit', requireJwtWhenEnabled, validateQuery(consentAuditQuerySchema), (req: Request, res: Response) => {
+    try {
+        const userId = resolveConsentUserId(req, (req.query.userId ?? req.query.user_id) as string | undefined)
+        if (!userId) return fail(res, 400, 'VALIDATION_ERROR', 'userId is required')
+        return ok(res, {
+            userId,
+            events: databaseService.getConsentAudit(userId)
+        })
+    } catch (error) {
+        logger.error('[ERROR] Consent audit failed', { error: getErrorObject(error) })
         return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
     }
 })
@@ -33,9 +118,7 @@ consentRouter.get('/consent/status', validateQuery(consentStatusQuerySchema), (r
 consentRouter.post('/consent', ...protectedWriteLimiter, idempotencyMiddleware, validateRequest(recordConsentSchema), (req: Request, res: Response) => {
     try {
         const { userId, terms, privacy, cookies } = req.body
-        const ipAddress = req.ip ?? req.socket?.remoteAddress
-        const userAgent = req.get('user-agent')
-        databaseService.recordConsent(userId, { terms, privacy, cookies, ipAddress, userAgent })
+        databaseService.recordConsent(userId, { terms, privacy, cookies, ...consentRequestMeta(req) })
         return ok(res, { message: 'Consent recorded', accepted: true })
     } catch (error) {
         logger.error('[ERROR] Record consent failed', { error: getErrorObject(error) })
@@ -63,4 +146,3 @@ consentRouter.delete('/user/:address/data', requireJwtWhenEnabled, ...protectedC
         return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
     }
 })
-

--- a/backend/src/api/portfolios.routes.ts
+++ b/backend/src/api/portfolios.routes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express'
 import { StellarService } from '../services/stellar.js'
 import { ReflectorService } from '../services/reflector.js'
+import { databaseService } from '../services/databaseService.js'
 import { portfolioStorage } from '../services/portfolioStorage.js'
 import { analyticsService } from '../services/analyticsService.js'
 import { rebalanceLockService } from '../services/rebalanceLock.js'
@@ -89,6 +90,9 @@ portfoliosRouter.get('/portfolio/:id/export', requireJwtWhenEnabled, validateQue
         const authConfig = getAuthConfig()
         if (authConfig.enabled && (!req.user || portfolio.userAddress !== req.user.address)) {
             return fail(res, 403, 'FORBIDDEN', 'You can only export your own portfolio')
+        }
+        if (!databaseService.hasFullConsent(portfolio.userAddress)) {
+            return fail(res, 403, 'FORBIDDEN', 'Active consent is required before exporting portfolio data')
         }
         const result = await getPortfolioExport(portfolioId, format)
         if (!result) return fail(res, 404, 'NOT_FOUND', 'Portfolio not found')

--- a/backend/src/api/validation.ts
+++ b/backend/src/api/validation.ts
@@ -98,6 +98,25 @@ export const recordConsentSchema = z.object({
     cookies: z.boolean().refine((v) => v === true, { message: 'You must accept Cookie Policy' })
 }).strict();
 
+export const consentGrantSchema = z.object({
+    userId: z.string().min(1, 'userId is required').optional(),
+    terms: z.boolean().default(true),
+    privacy: z.boolean().default(true),
+    cookies: z.boolean().default(true)
+}).strict().refine(
+    (data) => data.terms && data.privacy && data.cookies,
+    { message: 'All consent flags must be accepted', path: ['terms'] }
+);
+
+export const consentRevokeSchema = z.object({
+    userId: z.string().min(1, 'userId is required').optional()
+}).strict();
+
+export const consentAuditQuerySchema = z.object({
+    userId: z.string().min(1, 'userId is required').optional(),
+    user_id: z.string().min(1).optional()
+});
+
 // ─── Notification schemas ─────────────────────────────────────────────────────
 export { notificationEventsSchema };
 export const notificationSubscribeSchema = notificationPreferencesSchema;

--- a/backend/src/db/migrations/010_consent_audit_lifecycle.down.sql
+++ b/backend/src/db/migrations/010_consent_audit_lifecycle.down.sql
@@ -1,0 +1,10 @@
+-- Migration: 010_consent_audit_lifecycle (down)
+
+DROP INDEX IF EXISTS idx_consent_audit_events_user_timestamp;
+DROP TABLE IF EXISTS consent_audit_events;
+
+ALTER TABLE legal_consent
+    DROP COLUMN IF EXISTS is_active;
+
+ALTER TABLE legal_consent
+    DROP COLUMN IF EXISTS revoked_at;

--- a/backend/src/db/migrations/010_consent_audit_lifecycle.up.sql
+++ b/backend/src/db/migrations/010_consent_audit_lifecycle.up.sql
@@ -1,0 +1,20 @@
+-- Migration: 010_consent_audit_lifecycle (up)
+-- Description: Track active consent state and append-only grant/revoke audit events.
+
+ALTER TABLE legal_consent
+    ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMPTZ;
+
+ALTER TABLE legal_consent
+    ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE TABLE IF NOT EXISTS consent_audit_events (
+    id          VARCHAR(64) PRIMARY KEY,
+    user_id     VARCHAR(256) NOT NULL,
+    action      VARCHAR(16) NOT NULL CHECK (action IN ('grant', 'revoke')),
+    timestamp   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ip_address  VARCHAR(64),
+    user_agent  VARCHAR(512)
+);
+
+CREATE INDEX IF NOT EXISTS idx_consent_audit_events_user_timestamp
+    ON consent_audit_events(user_id, timestamp);

--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -61,6 +61,32 @@ interface RebalanceHistoryRow {
   details: string | null;
 }
 
+interface ConsentAuditRow {
+  id: string;
+  user_id: string;
+  action: "grant" | "revoke";
+  timestamp: string;
+  ip_address: string | null;
+  user_agent: string | null;
+}
+
+export interface ConsentRecord {
+  termsAcceptedAt: string | null;
+  privacyAcceptedAt: string | null;
+  cookieAcceptedAt: string | null;
+  revokedAt: string | null;
+  active: boolean;
+}
+
+export interface ConsentAuditEvent {
+  id: string;
+  userId: string;
+  action: "grant" | "revoke";
+  timestamp: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+}
+
 // ─────────────────────────────────────────────
 // Schema SQL
 // ─────────────────────────────────────────────
@@ -134,11 +160,25 @@ CREATE TABLE IF NOT EXISTS legal_consent (
     terms_accepted_at   TEXT,
     privacy_accepted_at TEXT,
     cookie_accepted_at  TEXT,
+    revoked_at          TEXT,
+    is_active           INTEGER NOT NULL DEFAULT 1,
     ip_address          TEXT,
     user_agent          TEXT,
     created_at          TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS consent_audit_events (
+    id          TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL,
+    action      TEXT NOT NULL CHECK (action IN ('grant', 'revoke')),
+    timestamp   TEXT NOT NULL,
+    ip_address  TEXT,
+    user_agent  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_consent_audit_events_user_timestamp
+    ON consent_audit_events (user_id, timestamp);
 `;
 
 // ─────────────────────────────────────────────
@@ -403,6 +443,32 @@ export class DatabaseService {
       );
       logger.info("[DB] Migration: added strategy_config column to portfolios");
     }
+
+    const consentCols = this.db
+      .prepare("PRAGMA table_info(legal_consent)")
+      .all() as Array<{ name: string }>;
+    if (!consentCols.some((c) => c.name === "revoked_at")) {
+      this.db.exec("ALTER TABLE legal_consent ADD COLUMN revoked_at TEXT");
+      logger.info("[DB] Migration: added revoked_at column to legal_consent");
+    }
+    if (!consentCols.some((c) => c.name === "is_active")) {
+      this.db.exec(
+        "ALTER TABLE legal_consent ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1",
+      );
+      logger.info("[DB] Migration: added is_active column to legal_consent");
+    }
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS consent_audit_events (
+          id          TEXT PRIMARY KEY,
+          user_id     TEXT NOT NULL,
+          action      TEXT NOT NULL CHECK (action IN ('grant', 'revoke')),
+          timestamp   TEXT NOT NULL,
+          ip_address  TEXT,
+          user_agent  TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_consent_audit_events_user_timestamp
+          ON consent_audit_events (user_id, timestamp);
+    `);
   }
 
   private _seedDefaultAssets(): void {
@@ -843,38 +909,68 @@ export class DatabaseService {
     },
   ): void {
     const now = new Date().toISOString();
-    this.db
-      .prepare(
-        `INSERT INTO legal_consent (user_id, terms_accepted_at, privacy_accepted_at, cookie_accepted_at, ip_address, user_agent, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(user_id) DO UPDATE SET
-               terms_accepted_at = COALESCE(excluded.terms_accepted_at, terms_accepted_at),
-               privacy_accepted_at = COALESCE(excluded.privacy_accepted_at, privacy_accepted_at),
-               cookie_accepted_at = COALESCE(excluded.cookie_accepted_at, cookie_accepted_at),
-               ip_address = excluded.ip_address,
-               user_agent = excluded.user_agent,
-               updated_at = excluded.updated_at`,
-      )
-      .run(
-        userId,
-        opts.terms ? now : null,
-        opts.privacy ? now : null,
-        opts.cookies ? now : null,
-        opts.ipAddress ?? null,
-        opts.userAgent ?? null,
-        now,
-      );
+    const grant = this.db.transaction(() => {
+      this.db
+        .prepare(
+          `INSERT INTO legal_consent (user_id, terms_accepted_at, privacy_accepted_at, cookie_accepted_at, revoked_at, is_active, ip_address, user_agent, updated_at)
+               VALUES (?, ?, ?, ?, NULL, 1, ?, ?, ?)
+               ON CONFLICT(user_id) DO UPDATE SET
+                 terms_accepted_at = COALESCE(excluded.terms_accepted_at, terms_accepted_at),
+                 privacy_accepted_at = COALESCE(excluded.privacy_accepted_at, privacy_accepted_at),
+                 cookie_accepted_at = COALESCE(excluded.cookie_accepted_at, cookie_accepted_at),
+                 revoked_at = NULL,
+                 is_active = 1,
+                 ip_address = excluded.ip_address,
+                 user_agent = excluded.user_agent,
+                 updated_at = excluded.updated_at`,
+        )
+        .run(
+          userId,
+          opts.terms ? now : null,
+          opts.privacy ? now : null,
+          opts.cookies ? now : null,
+          opts.ipAddress ?? null,
+          opts.userAgent ?? null,
+          now,
+        );
+      this.insertConsentAuditEvent(userId, "grant", now, opts.ipAddress, opts.userAgent);
+    });
+    grant();
   }
 
-  getConsent(
+  revokeConsent(
     userId: string,
-  ):
-    | {
-        termsAcceptedAt: string | null;
-        privacyAcceptedAt: string | null;
-        cookieAcceptedAt: string | null;
-      }
-    | undefined {
+    opts: {
+      ipAddress?: string;
+      userAgent?: string;
+    } = {},
+  ): void {
+    const now = new Date().toISOString();
+    const revoke = this.db.transaction(() => {
+      this.db
+        .prepare(
+          `INSERT INTO legal_consent (user_id, revoked_at, is_active, ip_address, user_agent, updated_at)
+               VALUES (?, ?, 0, ?, ?, ?)
+               ON CONFLICT(user_id) DO UPDATE SET
+                 revoked_at = excluded.revoked_at,
+                 is_active = 0,
+                 ip_address = excluded.ip_address,
+                 user_agent = excluded.user_agent,
+                 updated_at = excluded.updated_at`,
+        )
+        .run(
+          userId,
+          now,
+          opts.ipAddress ?? null,
+          opts.userAgent ?? null,
+          now,
+        );
+      this.insertConsentAuditEvent(userId, "revoke", now, opts.ipAddress, opts.userAgent);
+    });
+    revoke();
+  }
+
+  getConsent(userId: string): ConsentRecord | undefined {
     const row = this.db
       .prepare<
         [string],
@@ -882,26 +978,72 @@ export class DatabaseService {
           terms_accepted_at: string | null;
           privacy_accepted_at: string | null;
           cookie_accepted_at: string | null;
+          revoked_at: string | null;
+          is_active: number;
         }
-      >("SELECT terms_accepted_at, privacy_accepted_at, cookie_accepted_at FROM legal_consent WHERE user_id = ?")
+      >("SELECT terms_accepted_at, privacy_accepted_at, cookie_accepted_at, revoked_at, is_active FROM legal_consent WHERE user_id = ?")
       .get(userId);
     if (!row) return undefined;
     return {
       termsAcceptedAt: row.terms_accepted_at,
       privacyAcceptedAt: row.privacy_accepted_at,
       cookieAcceptedAt: row.cookie_accepted_at,
+      revokedAt: row.revoked_at,
+      active: row.is_active === 1,
     };
   }
 
   hasFullConsent(userId: string): boolean {
     const c = this.getConsent(userId);
     return Boolean(
-      c?.termsAcceptedAt && c?.privacyAcceptedAt && c?.cookieAcceptedAt,
+      c?.active && c.termsAcceptedAt && c.privacyAcceptedAt && c.cookieAcceptedAt,
     );
+  }
+
+  getConsentAudit(userId: string): ConsentAuditEvent[] {
+    const rows = this.db
+      .prepare<[string], ConsentAuditRow>(
+        `SELECT id, user_id, action, timestamp, ip_address, user_agent
+         FROM consent_audit_events
+         WHERE user_id = ?
+         ORDER BY timestamp ASC, id ASC`,
+      )
+      .all(userId);
+    return rows.map((row) => ({
+      id: row.id,
+      userId: row.user_id,
+      action: row.action,
+      timestamp: row.timestamp,
+      ipAddress: row.ip_address,
+      userAgent: row.user_agent,
+    }));
+  }
+
+  private insertConsentAuditEvent(
+    userId: string,
+    action: "grant" | "revoke",
+    timestamp: string,
+    ipAddress?: string,
+    userAgent?: string,
+  ): void {
+    this.db
+      .prepare(
+        `INSERT INTO consent_audit_events (id, user_id, action, timestamp, ip_address, user_agent)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        generateId(),
+        userId,
+        action,
+        timestamp,
+        ipAddress ?? null,
+        userAgent ?? null,
+      );
   }
 
   deleteUserData(userId: string): void {
     this.db.prepare("DELETE FROM legal_consent WHERE user_id = ?").run(userId);
+    this.db.prepare("DELETE FROM consent_audit_events WHERE user_id = ?").run(userId);
     const portfolios = this.db
       .prepare<
         [string],

--- a/backend/src/test/consent.routes.integration.test.ts
+++ b/backend/src/test/consent.routes.integration.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import type { Express } from 'express'
+import request from 'supertest'
+import { mkdirSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let app: Express
+let testDbPath: string
+let generateAccessToken: (address: string) => string
+let databaseService: typeof import('../services/databaseService.js').databaseService
+const envBackup: NodeJS.ProcessEnv = { ...process.env }
+
+const testUser = (prefix: string) => `G${prefix}${Math.random().toString(36).slice(2, 12).toUpperCase()}`
+
+beforeAll(async () => {
+    const testDir = join(tmpdir(), `stellar-consent-routes-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(testDir, { recursive: true })
+    testDbPath = join(testDir, 'consent-routes.db')
+
+    vi.resetModules()
+    process.env = { ...envBackup }
+    delete process.env.DATABASE_URL
+    process.env.DB_PATH = testDbPath
+    process.env.JWT_SECRET = 'unit-test-jwt-secret-min-32-chars!!'
+    process.env.NODE_ENV = 'test'
+    process.env.ENABLE_DEMO_DB_SEED = 'false'
+    process.env.DEMO_MODE = 'true'
+    process.env.RATE_LIMIT_CRITICAL_MAX = '100'
+    process.env.RATE_LIMIT_WRITE_MAX = '100'
+    process.env.RATE_LIMIT_WRITE_BURST_MAX = '200'
+    process.env.RATE_LIMIT_BURST_MAX = '200'
+    process.env.RATE_LIMIT_AUTH_MAX = '100'
+
+    const express = (await import('express')).default
+    const { mountApiRoutes } = await import('../http/mountApiRoutes.js')
+    ;({ generateAccessToken } = await import('../services/authService.js'))
+    ;({ databaseService } = await import('../services/databaseService.js'))
+
+    app = express()
+    app.use(express.json({ limit: '10mb' }))
+    app.set('trust proxy', 1)
+    mountApiRoutes(app)
+})
+
+afterAll(() => {
+    process.env = { ...envBackup }
+    if (existsSync(testDbPath)) {
+        rmSync(testDbPath, { force: true })
+    }
+    vi.restoreAllMocks()
+})
+
+describe('consent routes integration', () => {
+    it('POST /api/v1/consent/grant persists consent with timestamp and IP', async () => {
+        const userId = testUser('GRANT')
+        const token = generateAccessToken(userId)
+
+        const grant = await request(app)
+            .post('/api/v1/consent/grant')
+            .set('Authorization', `Bearer ${token}`)
+            .set('User-Agent', 'consent-route-test')
+            .set('X-Forwarded-For', '203.0.113.44')
+            .send({})
+            .expect(200)
+
+        expect(grant.body.data.accepted).toBe(true)
+        expect(grant.body.data.userId).toBe(userId)
+        expect(grant.body.data.termsAcceptedAt).toBeTruthy()
+        expect(grant.body.data.privacyAcceptedAt).toBeTruthy()
+        expect(grant.body.data.cookieAcceptedAt).toBeTruthy()
+        expect(grant.body.data.active).toBe(true)
+        expect(grant.body.data.ipAddress).toBe('203.0.113.44')
+
+        const status = await request(app)
+            .get('/api/v1/consent/status')
+            .query({ userId })
+            .expect(200)
+
+        expect(status.body.data.accepted).toBe(true)
+        expect(status.body.data.active).toBe(true)
+    })
+
+    it('POST /api/v1/consent/revoke marks consent as revoked and blocks future exports', async () => {
+        const userId = testUser('REVOKE')
+        const token = generateAccessToken(userId)
+        const portfolioId = databaseService.createPortfolioWithBalances(
+            userId,
+            { XLM: 60, USDC: 40 },
+            5,
+            { XLM: 100, USDC: 100 }
+        )
+
+        await request(app)
+            .post('/api/v1/consent/grant')
+            .set('Authorization', `Bearer ${token}`)
+            .send({})
+            .expect(200)
+
+        const revoke = await request(app)
+            .post('/api/v1/consent/revoke')
+            .set('Authorization', `Bearer ${token}`)
+            .send({})
+            .expect(200)
+
+        expect(revoke.body.data.accepted).toBe(false)
+        expect(revoke.body.data.active).toBe(false)
+        expect(revoke.body.data.revokedAt).toBeTruthy()
+
+        const blocked = await request(app)
+            .get(`/api/v1/portfolio/${portfolioId}/export`)
+            .query({ format: 'json' })
+            .set('Authorization', `Bearer ${token}`)
+            .expect(403)
+
+        expect(blocked.body.error?.code).toBe('FORBIDDEN')
+    })
+
+    it('GET /api/v1/consent/audit returns an append-only log of all consent events', async () => {
+        const userId = testUser('AUDIT')
+        const token = generateAccessToken(userId)
+
+        await request(app)
+            .post('/api/v1/consent/grant')
+            .set('Authorization', `Bearer ${token}`)
+            .send({})
+            .expect(200)
+
+        await request(app)
+            .post('/api/v1/consent/revoke')
+            .set('Authorization', `Bearer ${token}`)
+            .send({})
+            .expect(200)
+
+        const audit = await request(app)
+            .get('/api/v1/consent/audit')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200)
+
+        expect(audit.body.data.userId).toBe(userId)
+        expect(audit.body.data.events).toHaveLength(2)
+        expect(audit.body.data.events.map((event: { action: string }) => event.action)).toEqual(['grant', 'revoke'])
+        expect(audit.body.data.events[0].timestamp).toBeTruthy()
+        expect(audit.body.data.events[1].timestamp).toBeTruthy()
+    })
+
+    it('blocks data export without active consent', async () => {
+        const userId = testUser('NOCONSENT')
+        const token = generateAccessToken(userId)
+        const portfolioId = databaseService.createPortfolioWithBalances(
+            userId,
+            { XLM: 50, USDC: 50 },
+            5,
+            { XLM: 100, USDC: 100 }
+        )
+
+        const blocked = await request(app)
+            .get(`/api/v1/portfolio/${portfolioId}/export`)
+            .query({ format: 'json' })
+            .set('Authorization', `Bearer ${token}`)
+            .expect(403)
+
+        expect(blocked.body.error?.code).toBe('FORBIDDEN')
+    })
+})

--- a/backend/src/test/consentPrivacy.integration.test.ts
+++ b/backend/src/test/consentPrivacy.integration.test.ts
@@ -275,6 +275,11 @@ describe('consent and privacy API', () => {
         const portfolioId = (createRes.body?.data?.portfolioId ?? createRes.body?.portfolioId) as string
         expect(portfolioId).toBeTruthy()
 
+        await request(app)
+            .post('/api/consent')
+            .send({ userId: owner, terms: true, privacy: true, cookies: true })
+            .expect(200)
+
         const token = generateAccessToken(owner)
         const exportRes = await request(app)
             .get(`/api/portfolio/${portfolioId}/export`)

--- a/backend/src/test/portfolioExport.integration.test.ts
+++ b/backend/src/test/portfolioExport.integration.test.ts
@@ -59,6 +59,11 @@ beforeAll(async () => {
         .send({ userAddress: OWNER_ADDRESS, allocations: { XLM: 60, USDC: 40 }, threshold: 5 })
     expect([200, 201]).toContain(res.status)
     sharedPortfolioId = res.body.data.portfolioId as string
+
+    await request(app)
+        .post('/api/consent')
+        .send({ userId: OWNER_ADDRESS, terms: true, privacy: true, cookies: true })
+        .expect(200)
 })
 
 afterAll(() => {

--- a/backend/src/test/riskManagements.test.ts
+++ b/backend/src/test/riskManagements.test.ts
@@ -155,6 +155,21 @@ describe('RiskManagementService statistical model', () => {
         expect(risk.drawdownBand).toBe('normal')
     })
 
+    it('classifies overall risk levels as low, medium, high, and critical', () => {
+        const service = new RiskManagementService()
+        const latest: PricesMap = {
+            BTC: { price: 100, change: 0, timestamp: 1, source: 'external' },
+            ETH: { price: 100, change: 0, timestamp: 1, source: 'external' },
+            XLM: { price: 1, change: 0, timestamp: 1, source: 'external' },
+            USDC: { price: 1, change: 0, timestamp: 1, source: 'external' }
+        }
+
+        expect(service.analyzePortfolioRisk({ BTC: 25, ETH: 25, XLM: 25, USDC: 25 }, latest).overallRiskLevel).toBe('low')
+        expect(service.analyzePortfolioRisk({ BTC: 40, ETH: 30, XLM: 20, USDC: 10 }, latest).overallRiskLevel).toBe('medium')
+        expect(service.analyzePortfolioRisk({ BTC: 50, ETH: 25, XLM: 15, USDC: 10 }, latest).overallRiskLevel).toBe('high')
+        expect(service.analyzePortfolioRisk({ BTC: 65, ETH: 15, XLM: 10, USDC: 10 }, latest).overallRiskLevel).toBe('critical')
+    })
+
     it('classifies drawdown bands as normal, elevated, and critical', () => {
         const service = new RiskManagementService()
         const latest = feedSeries(service, {

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -493,15 +493,21 @@ fn test_calculate_rebalance_trades_excludes_below_minimum_stroops() {
     let env = Env::default();
     let asset1 = Address::generate(&env);
     let asset2 = Address::generate(&env);
+    let asset3 = Address::generate(&env);
 
     let mut allocations = Map::new(&env);
-    allocations.set(asset1.clone(), 50);
-    allocations.set(asset2.clone(), 50);
+    allocations.set(asset1.clone(), 100);
+    allocations.set(asset2.clone(), 100);
+    allocations.set(asset3.clone(), 100);
 
     let target_balance = 50_000_000i128;
     let mut balances = Map::new(&env);
     balances.set(asset1.clone(), target_balance - (MIN_TRADE_AMOUNT_STROOPS / 2));
-    balances.set(asset2.clone(), target_balance);
+    balances.set(asset2.clone(), target_balance - MIN_TRADE_AMOUNT_STROOPS);
+    balances.set(
+        asset3.clone(),
+        target_balance - (MIN_TRADE_AMOUNT_STROOPS + 1),
+    );
 
     let portfolio = Portfolio {
         user: Address::generate(&env),
@@ -510,17 +516,22 @@ fn test_calculate_rebalance_trades_excludes_below_minimum_stroops() {
         rebalance_threshold: 5,
         slippage_tolerance: 50,
         last_rebalance: 0,
-        total_value: 100_000_000,
+        total_value: target_balance,
         is_active: true,
     };
 
     let mut prices = Map::new(&env);
     prices.set(asset1.clone(), 10i128.pow(14));
     prices.set(asset2.clone(), 10i128.pow(14));
+    prices.set(asset3.clone(), 10i128.pow(14));
 
     let trades = crate::portfolio::calculate_rebalance_trades(&env, &portfolio, &prices);
     assert!(!trades.contains_key(asset1));
     assert!(!trades.contains_key(asset2));
+    assert_eq!(
+        trades.get(asset3).unwrap(),
+        MIN_TRADE_AMOUNT_STROOPS + 1
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #297 
Closes #298 
Closes #299 
Closes #315 

- Tightened Stellar stroop trade threshold boundary coverage
- Added /api/v1/consent/grant, /api/v1/consent/revoke, and /api/v1/consent/audit (Issue 315 )
- Added active/revoked consent state plus append-only consent audit events.
- Blocked portfolio export unless the owner has active full consent.
- added backend tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now explicitly grant and revoke consent for data usage
  * Added consent audit logs capturing all grant/revoke actions with request details and timestamps
  * Portfolio exports now enforce verified active consent requirements

* **Tests**
  * Added integration tests validating consent grant, revoke, and audit workflows
  * Enhanced portfolio export tests to verify consent prerequisites

<!-- end of auto-generated comment: release notes by coderabbit.ai -->