### PR TITLE
test: add comprehensive unit tests for calculate_rebalance_trades

### DIFF
--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -528,6 +528,10 @@ fn test_calculate_rebalance_trades_excludes_below_minimum_stroops() {
     let trades = crate::portfolio::calculate_rebalance_trades(&env, &portfolio, &prices);
     assert!(!trades.contains_key(asset1));
     assert!(!trades.contains_key(asset2));
+    assert_eq!(
+        trades.get(asset3).unwrap(),
+        MIN_TRADE_AMOUNT_STROOPS + 1
+    );
 }
 
 #[test]

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -528,11 +528,212 @@ fn test_calculate_rebalance_trades_excludes_below_minimum_stroops() {
     let trades = crate::portfolio::calculate_rebalance_trades(&env, &portfolio, &prices);
     assert!(!trades.contains_key(asset1));
     assert!(!trades.contains_key(asset2));
-    assert_eq!(
-        trades.get(asset3).unwrap(),
-        MIN_TRADE_AMOUNT_STROOPS + 1
-    );
 }
+
+#[test]
+fn test_calculate_rebalance_trades_2_asset() {
+    let env = Env::default();
+    let asset1 = Address::generate(&env);
+    let asset2 = Address::generate(&env);
+
+    let mut allocations = Map::new(&env);
+    allocations.set(asset1.clone(), 50);
+    allocations.set(asset2.clone(), 50);
+
+    let mut balances = Map::new(&env);
+    balances.set(asset1.clone(), 150 * 10i128.pow(14));
+    balances.set(asset2.clone(), 50 * 10i128.pow(14));
+
+    let portfolio = Portfolio {
+        user: Address::generate(&env),
+        target_allocations: allocations,
+        current_balances: balances,
+        rebalance_threshold: 5,
+        slippage_tolerance: 50,
+        last_rebalance: 0,
+        total_value: 200 * 10i128.pow(14),
+        is_active: true,
+    };
+
+    let mut prices = Map::new(&env);
+    prices.set(asset1.clone(), 10i128.pow(14));
+    prices.set(asset2.clone(), 10i128.pow(14));
+
+    let trades = crate::portfolio::calculate_rebalance_trades(&env, &portfolio, &prices);
+    
+    assert_eq!(trades.get(asset1.clone()).unwrap(), -50 * 10i128.pow(14));
+    assert_eq!(trades.get(asset2.clone()).unwrap(), 50 * 10i128.pow(14));
+}
+
+#[test]
+fn test_calculate_rebalance_trades_5_asset() {
+    let env = Env::default();
+    let a1 = Address::generate(&env);
+    let a2 = Address::generate(&env);
+    let a3 = Address::generate(&env);
+    let a4 = Address::generate(&env);
+    let a5 = Address::generate(&env);
+
+    let mut allocations = Map::new(&env);
+    allocations.set(a1.clone(), 20);
+    allocations.set(a2.clone(), 20);
+    allocations.set(a3.clone(), 20);
+    allocations.set(a4.clone(), 20);
+    allocations.set(a5.clone(), 20);
+
+    let mut balances = Map::new(&env);
+    balances.set(a1.clone(), 50 * 10i128.pow(14));
+    balances.set(a2.clone(), 150 * 10i128.pow(14));
+    balances.set(a3.clone(), 100 * 10i128.pow(14));
+    balances.set(a4.clone(), 20 * 10i128.pow(14));
+    balances.set(a5.clone(), 180 * 10i128.pow(14));
+
+    let portfolio = Portfolio {
+        user: Address::generate(&env),
+        target_allocations: allocations,
+        current_balances: balances,
+        rebalance_threshold: 5,
+        slippage_tolerance: 50,
+        last_rebalance: 0,
+        total_value: 500 * 10i128.pow(14),
+        is_active: true,
+    };
+
+    let mut prices = Map::new(&env);
+    prices.set(a1.clone(), 10i128.pow(14));
+    prices.set(a2.clone(), 10i128.pow(14));
+    prices.set(a3.clone(), 10i128.pow(14));
+    prices.set(a4.clone(), 10i128.pow(14));
+    prices.set(a5.clone(), 10i128.pow(14));
+
+    let trades = crate::portfolio::calculate_rebalance_trades(&env, &portfolio, &prices);
+    
+    assert_eq!(trades.get(a1).unwrap(), 50 * 10i128.pow(14));
+    assert_eq!(trades.get(a2).unwrap(), -50 * 10i128.pow(14));
+    assert!(!trades.contains_key(a3));
+    assert_eq!(trades.get(a4).unwrap(), 80 * 10i128.pow(14));
+    assert_eq!(trades.get(a5).unwrap(), -80 * 10i128.pow(14));
+}
+
+#[test]
+fn test_calculate_rebalance_trades_direction_buy_sell() {
+    let env = Env::default();
+    let asset1 = Address::generate(&env);
+    let asset2 = Address::generate(&env);
+
+    let mut allocations = Map::new(&env);
+    allocations.set(asset1.clone(), 50);
+    allocations.set(asset2.clone(), 50);
+
+    let mut balances = Map::new(&env);
+    balances.set(asset1.clone(), 120 * 10i128.pow(14)); // overweight
+    balances.set(asset2.clone(), 80 * 10i128.pow(14));  // underweight
+
+    let portfolio = Portfolio {
+        user: Address::generate(&env),
+        target_allocations: allocations,
+        current_balances: balances,
+        rebalance_threshold: 5,
+        slippage_tolerance: 50,
+        last_rebalance: 0,
+        total_value: 200 * 10i128.pow(14),
+        is_active: true,
+    };
+
+    let mut prices = Map::new(&env);
+    prices.set(asset1.clone(), 10i128.pow(14));
+    prices.set(asset2.clone(), 10i128.pow(14));
+
+    let trades = crate::portfolio::calculate_rebalance_trades(&env, &portfolio, &prices);
+    
+    let trade_a1 = trades.get(asset1).unwrap();
+    let trade_a2 = trades.get(asset2).unwrap();
+    
+    assert!(trade_a1 < 0, "Overweight asset should result in a sell (negative) trade");
+    assert!(trade_a2 > 0, "Underweight asset should result in a buy (positive) trade");
+    assert_eq!(trade_a1, -20 * 10i128.pow(14));
+    assert_eq!(trade_a2, 20 * 10i128.pow(14));
+}
+
+#[test]
+fn test_calculate_rebalance_trades_price_precision() {
+    let env = Env::default();
+    let asset1 = Address::generate(&env);
+    let asset2 = Address::generate(&env);
+
+    let mut allocations = Map::new(&env);
+    allocations.set(asset1.clone(), 60);
+    allocations.set(asset2.clone(), 40);
+
+    let mut balances = Map::new(&env);
+    balances.set(asset1.clone(), 150 * 10i128.pow(14));
+    balances.set(asset2.clone(), 125 * 10i128.pow(13)); // 12.5 units
+
+    let portfolio = Portfolio {
+        user: Address::generate(&env),
+        target_allocations: allocations,
+        current_balances: balances,
+        rebalance_threshold: 5,
+        slippage_tolerance: 50,
+        last_rebalance: 0,
+        total_value: 100 * 10i128.pow(14),
+        is_active: true,
+    };
+
+    let mut prices = Map::new(&env);
+    prices.set(asset1.clone(), 50_000_000_000_000); // 0.5 * 10^14
+    prices.set(asset2.clone(), 200_000_000_000_000); // 2.0 * 10^14
+
+    let trades = crate::portfolio::calculate_rebalance_trades(&env, &portfolio, &prices);
+    
+    assert_eq!(trades.get(asset1).unwrap(), -30 * 10i128.pow(14));
+    assert_eq!(trades.get(asset2).unwrap(), 75 * 10i128.pow(13)); // 7.5 * 10^14
+}
+
+#[test]
+fn test_calculate_rebalance_trades_exact_boundary() {
+    let env = Env::default();
+    let asset1 = Address::generate(&env);
+    let asset2 = Address::generate(&env);
+    let asset3 = Address::generate(&env);
+
+    let mut allocations = Map::new(&env);
+    allocations.set(asset1.clone(), 40);
+    allocations.set(asset2.clone(), 30);
+    allocations.set(asset3.clone(), 30);
+
+    let mut balances = Map::new(&env);
+    let target1 = 40_000_000i128;
+    let target2 = 30_000_000i128;
+    let target3 = 30_000_000i128;
+
+    balances.set(asset1.clone(), target1 - MIN_TRADE_AMOUNT_STROOPS);
+    balances.set(asset2.clone(), target2 - (MIN_TRADE_AMOUNT_STROOPS - 1));
+    balances.set(asset3.clone(), target3 - (MIN_TRADE_AMOUNT_STROOPS + 1));
+
+    let portfolio = Portfolio {
+        user: Address::generate(&env),
+        target_allocations: allocations,
+        current_balances: balances,
+        rebalance_threshold: 5,
+        slippage_tolerance: 50,
+        last_rebalance: 0,
+        total_value: 100_000_000i128,
+        is_active: true,
+    };
+
+    let mut prices = Map::new(&env);
+    prices.set(asset1.clone(), 10i128.pow(14));
+    prices.set(asset2.clone(), 10i128.pow(14));
+    prices.set(asset3.clone(), 10i128.pow(14));
+
+    let trades = crate::portfolio::calculate_rebalance_trades(&env, &portfolio, &prices);
+    
+    assert!(!trades.contains_key(asset1));
+    assert!(!trades.contains_key(asset2));
+    assert_eq!(trades.get(asset3).unwrap(), MIN_TRADE_AMOUNT_STROOPS + 1);
+}
+
 
 #[test]
 #[should_panic]


### PR DESCRIPTION
Closes #291 

Description: This PR introduces dedicated test coverage for the calculate_rebalance_trades function in the portfolio module. Because this function is a core calculation path for on-chain rebalancing, these test cases validate its correctness across various multi-asset scenarios and numerical boundaries.

Test Cases Added:

test_calculate_rebalance_trades_2_asset: Validates exact trade amounts across a 2-asset portfolio.
test_calculate_rebalance_trades_5_asset: Validates exact trade amounts across a 5-asset portfolio, including scenarios where an asset's trade is exactly zero.
test_calculate_rebalance_trades_direction_buy_sell: Confirms trade direction correctness (positive for buy, negative for sell).
test_calculate_rebalance_trades_price_precision: Ensures accurate calculations with different 14-decimal Reflector prices (e.g., 0.5 and 2.0 representations).
test_calculate_rebalance_trades_exact_boundary: Uses a 3-asset setup to test the explicit minimum trade boundary logic, verifying that trade amounts strictly less than or equal to MIN_TRADE_AMOUNT_STROOPS are skipped while those above are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added five unit tests for trading logic: validate correct trade direction and values between overweight/underweight assets; cover multiple asset counts including assets with no trades; verify numeric precision with scaled balances and large prices; and assert exact boundary behavior around the minimum trade threshold to prevent sub-threshold trades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->