### PR TITLE
test: add max asset count tests and document limit (#296)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ Contract interface reference (functions, errors, and type notes): [`contracts/CO
 - Rebalancing: Manual or automatic execution
 - History: Track past rebalances
 
+### Portfolio Asset Limit
+Each portfolio supports a maximum of **10 assets** (). This limit exists because Soroban persistent storage entries are bounded by ledger entry size constraints, and each asset adds allocation and balance map entries plus oracle lookup overhead during rebalance. Attempting to create a portfolio with more than 10 assets returns a  error.
+
 ## Safety Features
 - Cooldown Periods: Minimum 1 hour between rebalances
 - Volatility Detection: Pauses rebalancing during extreme market conditions

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -964,3 +964,118 @@ fn assert_cost_within_tolerance(cpu: u64, mem: u64, baseline_cpu: u64, baseline_
         mem_limit
     );
 }
+
+// ── #296: Maximum asset count tests ──────────────────────────────────────────
+
+/// Helper: build a portfolio allocation map with `n` assets, each equally weighted.
+/// Allocations are distributed as evenly as possible; any remainder is added to
+/// the last asset so that the sum is always exactly 100.
+fn build_equal_allocations(env: &Env, n: u32) -> Map<Address, u32> {
+    let mut allocations = Map::new(env);
+    let base = 100 / n;
+    let remainder = 100 % n;
+    for i in 0..n {
+        let asset = Address::generate(env);
+        let pct = if i == n - 1 { base + remainder } else { base };
+        allocations.set(asset, pct);
+    }
+    allocations
+}
+
+/// TC-296-01: A portfolio with exactly MAX_PORTFOLIO_ASSETS (10) assets should
+/// be created successfully.
+#[test]
+fn test_create_portfolio_at_max_asset_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    // 10 assets = MAX_PORTFOLIO_ASSETS — must succeed
+    let allocations = build_equal_allocations(&env, MAX_PORTFOLIO_ASSETS);
+    let portfolio_id = client.create_portfolio(&user, &allocations, &5, &50);
+    assert!(portfolio_id > 0, "Portfolio with {} assets (MAX) should be created", MAX_PORTFOLIO_ASSETS);
+
+    let portfolio = client.get_portfolio(&portfolio_id);
+    assert_eq!(
+        portfolio.target_allocations.len(),
+        MAX_PORTFOLIO_ASSETS,
+        "Portfolio should hold exactly MAX_PORTFOLIO_ASSETS entries"
+    );
+}
+
+/// TC-296-02: A portfolio with MAX_PORTFOLIO_ASSETS + 1 (11) assets must be
+/// rejected with Error::TooManyAssets.
+#[test]
+fn test_create_portfolio_exceeds_max_asset_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    let user = Address::generate(&env);
+
+    // 11 assets = one above the limit — must be rejected
+    let over_limit = MAX_PORTFOLIO_ASSETS + 1;
+    let allocations = build_equal_allocations(&env, over_limit);
+    let result = client.try_create_portfolio(&user, &allocations, &5, &50);
+    assert_eq!(
+        result,
+        Err(Ok(Error::TooManyAssets)),
+        "Portfolio with {} assets should be rejected with TooManyAssets",
+        over_limit
+    );
+}
+
+/// TC-296-03: A portfolio with 20 assets (significantly over limit) is also
+/// rejected with Error::TooManyAssets — the error is not bypassed for large counts.
+#[test]
+fn test_create_portfolio_twenty_assets_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    let user = Address::generate(&env);
+    let allocations = build_equal_allocations(&env, 20);
+    let result = client.try_create_portfolio(&user, &allocations, &5, &50);
+    assert_eq!(
+        result,
+        Err(Ok(Error::TooManyAssets)),
+        "Portfolio with 20 assets must be rejected with TooManyAssets"
+    );
+}
+
+/// TC-296-04: A portfolio with one asset below the limit (9) is accepted.
+/// Confirms the boundary check is strictly > MAX, not >=.
+#[test]
+fn test_create_portfolio_below_max_asset_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    let allocations = build_equal_allocations(&env, MAX_PORTFOLIO_ASSETS - 1);
+    let portfolio_id = client.create_portfolio(&user, &allocations, &5, &50);
+    assert!(portfolio_id > 0, "Portfolio with {} assets (one below MAX) should be created", MAX_PORTFOLIO_ASSETS - 1);
+}

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -3,6 +3,15 @@ use soroban_sdk::{contracterror, contracttype, Address, Map};
 // Stellar assets use 7-decimal precision where 1 XLM = 10^7 stroops.
 // 1_000_000 stroops equals 0.1 XLM, which acts as the minimum executable trade size.
 pub const MIN_TRADE_AMOUNT_STROOPS: i128 = 1_000_000;
+/// Maximum number of assets allowed in a single portfolio (#296).
+///
+/// Soroban persistent storage entries are bounded by ledger entry size limits.
+/// Each additional asset adds two `Map` entries (target allocation + current
+/// balance) plus oracle price lookup overhead during rebalance.
+/// 10 assets is the tested practical maximum that keeps all operations within
+/// Soroban CPU and memory budgets.
+///
+/// Attempting to create a portfolio with more assets returns [`Error::TooManyAssets`].
 pub const MAX_PORTFOLIO_ASSETS: u32 = 10;
 
 #[contracttype]


### PR DESCRIPTION
Fixes #296

## What changed

### `contracts/src/types.rs`
Expanded the `MAX_PORTFOLIO_ASSETS` doc comment to explain the Soroban storage rationale (ledger entry size limits, per-asset map overhead) and point readers to `Error::TooManyAssets`.

### `contracts/src/test.rs`
Added four boundary tests using a new `build_equal_allocations(env, n)` helper:

| Test | Assets | Expected |
|---|---|---|
| TC-296-01 | 10 (MAX) | ✅ Success |
| TC-296-02 | 11 (MAX+1) | ❌ `TooManyAssets` |
| TC-296-03 | 20 | ❌ `TooManyAssets` |
| TC-296-04 | 9 (MAX-1) | ✅ Success |

### `README.md`
Added **Portfolio Asset Limit** subsection under Managing Portfolios documenting the 10-asset cap and the reason for it.

## How to test
```bash
cd contracts
cargo test test_create_portfolio_at_max_asset_count
cargo test test_create_portfolio_exceeds_max_asset_count
cargo test test_create_portfolio_twenty_assets_rejected
cargo test test_create_portfolio_below_max_asset_count
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added portfolio asset limit documentation specifying a hard cap of 10 assets per portfolio, including rationale and error behavior when limits are exceeded.

* **Tests**
  * Added test cases validating asset-count limit enforcement, covering successful creation at maximum capacity, rejection of over-limit attempts, and boundary condition verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->