### PR TITLE
docs: add curl recipe examples folder for common API tasks

### DIFF
--- a/docs/curl-recipes/README.md
+++ b/docs/curl-recipes/README.md
@@ -1,0 +1,65 @@
+# cURL Recipe Examples
+
+This folder contains ready-to-run `curl` commands for every API route in the Stellar Portfolio Rebalancer.
+
+Use these recipes to:
+
+- Quickly test the API during development
+- Debug authentication and token flows
+- Automate health checks or monitoring
+- Understand request/response shapes without reading the full spec
+
+> **Prerequisites:** `curl` 7.68+ with `-w` / `--write-out` support (default on Ubuntu 20.04+, macOS).
+
+---
+
+## Setup
+
+```bash
+# Replace with your backend URL
+export BASE_URL=http://localhost:3001
+
+# Login to obtain a JWT (see recipes/auth/)
+```
+
+---
+
+## Recipe index
+
+| Category            | Folder / file                    | Description                             |
+| ------------------- | -------------------------------- | --------------------------------------- |
+| **Auth**            | `recipes/auth/`                  | Login, refresh, logout                  |
+| **Portfolios**      | `recipes/portfolios/`            | CRUD + rebalance triggers               |
+| **Markets**         | `recipes/markets/`               | Current market data and price feeds     |
+| **Analytics**       | `recipes/analytics/`             | Performance and risk metrics            |
+| **Strategies**      | `recipes/strategies/`            | Rebalancing strategy management         |
+| **Health**          | `recipes/health/`                | Server health and readiness probes      |
+| **Events**          | `recipes/events/`                | Contract event querying                 |
+| **Notifications**   | `recipes/notifications/`         | Notification channel management         |
+
+---
+
+## Usage
+
+```bash
+# Run any recipe directly
+cd docs/curl-recipes
+chmod +x recipes/**/*.sh
+bash recipes/auth/login.sh
+
+# Pass custom BASE_URL
+BASE_URL=https://api.example.com bash recipes/auth/login.sh
+```
+
+---
+
+## Adding new recipes
+
+1. Add a `.sh` file in the appropriate `recipes/<category>/` folder.
+2. Start with `#!/usr/bin/env bash` and `set -euo pipefail`.
+3. Use `$BASE_URL` (fall back to `http://localhost:3001`).
+4. Print the request URL and method, then the response with `curl -sS`.
+5. Make the script executable (`chmod +x`).
+6. Add the file to the index above.
+
+See [recipes/template.sh](recipes/template.sh) for a reusable template.

--- a/docs/curl-recipes/recipes/analytics/risk.sh
+++ b/docs/curl-recipes/recipes/analytics/risk.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+TOKEN="${TOKEN:-your-jwt-token}"
+
+PORTFOLIO_ID="${1:-your-portfolio-id}"
+
+echo "=== GET /api/risk/metrics/{portfolioId} ==="
+curl -sS "$BASE_URL/api/risk/metrics/$PORTFOLIO_ID" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""
+
+echo "=== GET /api/risk/check/{portfolioId} (Risk check) ==="
+curl -sS "$BASE_URL/api/risk/check/$PORTFOLIO_ID" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""

--- a/docs/curl-recipes/recipes/auth/consent.sh
+++ b/docs/curl-recipes/recipes/auth/consent.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+
+echo "=== POST /api/consent (Record consent) ==="
+curl -sS -X POST "$BASE_URL/api/consent" \
+  -H "Content-Type: application/json" \
+  -d '{"userId": "GA123...", "consentVersion": "1.0", "acceptedAt": "2026-05-28T00:00:00Z"}'
+echo ""

--- a/docs/curl-recipes/recipes/auth/login.sh
+++ b/docs/curl-recipes/recipes/auth/login.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+
+echo "=== POST /api/auth/login (JWT login) ==="
+curl -sS -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"address": "GA123...", "signature": "0x..."}'
+echo ""

--- a/docs/curl-recipes/recipes/auth/logout.sh
+++ b/docs/curl-recipes/recipes/auth/logout.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+TOKEN="${TOKEN:-your-jwt-token}"
+
+echo "=== POST /api/auth/logout (Logout) ==="
+curl -sS -X POST "$BASE_URL/api/auth/logout" \
+  -H "Authorization: Bearer $TOKEN"
+echo ""

--- a/docs/curl-recipes/recipes/auth/refresh.sh
+++ b/docs/curl-recipes/recipes/auth/refresh.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+TOKEN="${TOKEN:-your-jwt-token}"
+
+echo "=== POST /api/auth/refresh (Refresh JWT) ==="
+curl -sS -X POST "$BASE_URL/api/auth/refresh" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"refreshToken": "your-refresh-token"}'
+echo ""

--- a/docs/curl-recipes/recipes/events/status.sh
+++ b/docs/curl-recipes/recipes/events/status.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+TOKEN="${TOKEN:-your-jwt-token}"
+
+echo "=== GET /api/rebalance/history (Rebalance history) ==="
+curl -sS "$BASE_URL/api/rebalance/history?limit=5" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""
+
+echo "=== GET /api/system/status (System status) ==="
+curl -sS "$BASE_URL/api/system/status" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""
+
+echo "=== GET /api/queue/health (Queue health) ==="
+curl -sS "$BASE_URL/api/queue/health" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""

--- a/docs/curl-recipes/recipes/health/basic.sh
+++ b/docs/curl-recipes/recipes/health/basic.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+TOKEN="${TOKEN:-your-jwt-token}"
+
+echo "=== GET / (API info) ==="
+curl -sS "$BASE_URL/" | jq .
+echo ""
+
+echo "=== GET /health (Health check) ==="
+curl -sS "$BASE_URL/health" | jq .
+echo ""
+
+echo "=== GET /ready (Deep readiness) ==="
+curl -sS "$BASE_URL/ready" | jq .
+echo ""

--- a/docs/curl-recipes/recipes/markets/prices.sh
+++ b/docs/curl-recipes/recipes/markets/prices.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+TOKEN="${TOKEN:-your-jwt-token}"
+
+echo "=== GET /api/prices (Current prices) ==="
+curl -sS "$BASE_URL/api/prices" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""
+
+echo "=== GET /api/prices/enhanced (Prices + risk) ==="
+curl -sS "$BASE_URL/api/prices/enhanced" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""
+
+echo "=== GET /api/market/{asset}/details ==="
+ASSET="${1:-XLM}"
+curl -sS "$BASE_URL/api/market/$ASSET/details" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""
+
+echo "=== GET /api/market/{asset}/chart (Chart history) ==="
+curl -sS "$BASE_URL/api/market/$ASSET/chart?days=7" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""

--- a/docs/curl-recipes/recipes/notifications/manage.sh
+++ b/docs/curl-recipes/recipes/notifications/manage.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+TOKEN="${TOKEN:-your-jwt-token}"
+
+echo "=== POST /api/notifications/subscribe (Subscribe) ==="
+curl -sS -X POST "$BASE_URL/api/notifications/subscribe" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: $(uuidgen 2>/dev/null || date +%s)" \
+  -d '{
+    "userId": "GA123...",
+    "email": "user@example.com",
+    "webhook": "https://hooks.example.com/alerts",
+    "events": ["rebalance_executed", "threshold_breached", "error"]
+  }'
+echo ""
+
+echo "=== GET /api/notifications/preferences (Get preferences) ==="
+curl -sS "$BASE_URL/api/notifications/preferences?userId=GA123..." \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""
+
+echo "=== DELETE /api/notifications/unsubscribe (Unsubscribe) ==="
+curl -sS -X DELETE "$BASE_URL/api/notifications/unsubscribe?userId=GA123..." \
+  -H "Authorization: Bearer $TOKEN"
+echo ""

--- a/docs/curl-recipes/recipes/portfolios/crud.sh
+++ b/docs/curl-recipes/recipes/portfolios/crud.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+TOKEN="${TOKEN:-your-jwt-token}"
+
+echo "=== POST /api/portfolio (Create portfolio) ==="
+curl -sS -X POST "$BASE_URL/api/portfolio" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: $(uuidgen 2>/dev/null || date +%s)" \
+  -d '{
+    "userAddress": "GA123...",
+    "allocations": {"XLM": 50, "USDC": 30, "ETH": 20},
+    "threshold": 5,
+    "slippageTolerance": 1.0
+  }'
+echo ""
+
+echo "=== GET /api/portfolio/{id} (Get portfolio) ==="
+PORTFOLIO_ID="${1:-your-portfolio-id}"
+curl -sS "$BASE_URL/api/portfolio/$PORTFOLIO_ID" \
+  -H "Authorization: Bearer $TOKEN"
+echo ""

--- a/docs/curl-recipes/recipes/portfolios/list-analytics.sh
+++ b/docs/curl-recipes/recipes/portfolios/list-analytics.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+TOKEN="${TOKEN:-your-jwt-token}"
+
+PORTFOLIO_ID="${1:-your-portfolio-id}"
+USER_ADDRESS="${2:-GA123...}"
+
+echo "=== GET /api/portfolio/{id}/analytics (Analytics) ==="
+curl -sS "$BASE_URL/api/portfolio/$PORTFOLIO_ID/analytics?days=30" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""
+
+echo "=== GET /api/portfolio/{id}/performance-summary ==="
+curl -sS "$BASE_URL/api/portfolio/$PORTFOLIO_ID/performance-summary" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""
+
+echo "=== GET /api/user/{address}/portfolios (List portfolios) ==="
+curl -sS "$BASE_URL/api/user/$USER_ADDRESS/portfolios" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""

--- a/docs/curl-recipes/recipes/portfolios/rebalance.sh
+++ b/docs/curl-recipes/recipes/portfolios/rebalance.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+TOKEN="${TOKEN:-your-jwt-token}"
+
+PORTFOLIO_ID="${1:-your-portfolio-id}"
+
+echo "=== GET /api/portfolio/{id}/rebalance-plan (Get plan) ==="
+curl -sS "$BASE_URL/api/portfolio/$PORTFOLIO_ID/rebalance-plan" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""
+
+echo "=== POST /api/portfolio/{id}/rebalance (Execute rebalance) ==="
+curl -sS -X POST "$BASE_URL/api/portfolio/$PORTFOLIO_ID/rebalance" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"options": {"simulateOnly": true}}'
+echo ""

--- a/docs/curl-recipes/recipes/strategies/auto-rebalance.sh
+++ b/docs/curl-recipes/recipes/strategies/auto-rebalance.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+TOKEN="${TOKEN:-your-jwt-token}"
+
+echo "=== GET /api/auto-rebalancer/status ==="
+curl -sS "$BASE_URL/api/auto-rebalancer/status" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""
+
+echo "=== POST /api/auto-rebalancer/start (Start — admin) ==="
+curl -sS -X POST "$BASE_URL/api/auto-rebalancer/start" \
+  -H "Authorization: Bearer $TOKEN"
+echo ""
+
+echo "=== POST /api/auto-rebalancer/stop (Stop — admin) ==="
+curl -sS -X POST "$BASE_URL/api/auto-rebalancer/stop" \
+  -H "Authorization: Bearer $TOKEN"
+echo ""
+
+echo "=== POST /api/auto-rebalancer/force-check (Force — admin) ==="
+curl -sS -X POST "$BASE_URL/api/auto-rebalancer/force-check" \
+  -H "Authorization: Bearer $TOKEN"
+echo ""
+
+echo "=== GET /api/auto-rebalancer/history (History — admin) ==="
+curl -sS "$BASE_URL/api/auto-rebalancer/history?limit=5" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+echo ""

--- a/docs/curl-recipes/recipes/template.sh
+++ b/docs/curl-recipes/recipes/template.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Recipe template — copy this to add a new endpoint
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+
+echo "=== Request ==="
+echo "METHOD /path"
+
+echo ""
+echo "=== Response ==="
+curl -sS "$BASE_URL/path" | jq .


### PR DESCRIPTION
## Description

Add a complete set of copy-paste-ready `curl` recipes covering every API route in the Stellar Portfolio Rebalancer.

Closes #578

## Changes

- **docs/curl-recipes/README.md** — Setup, usage, recipe index, and contribution guide
- **recipes/auth/** — login, refresh, logout, consent endpoints (4 scripts)
- **recipes/portfolios/** — create, get, rebalance-plan, execute-rebalance, list user portfolios, analytics, performance-summary (3 scripts)
- **recipes/markets/** — prices, enhanced prices, market details, chart history (1 script)
- **recipes/analytics/** — risk metrics, risk check (1 script)
- **recipes/strategies/** — auto-rebalancer status, start, stop, force-check, history (1 script)
- **recipes/events/** — rebalance history, system status, queue health (1 script)
- **recipes/notifications/** — subscribe, get preferences, unsubscribe (1 script)
- **recipes/template.sh** — reusable template for contributors

## Verification

- All scripts use `set -euo pipefail` for safety
- Each script prints the request method/path before executing
- Consistent variable naming (`BASE_URL`, `TOKEN`, `PORTFOLIO_ID`)
- All scripts are executable (`chmod +x`)

Wallet: USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3