### PR TITLE
docs: add issue templates for bug, feature, docs, ops, and security reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Report a reproducible bug in the application
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected behavior
+
+What you expected to happen instead.
+
+## Screenshots / logs
+
+If applicable, add screenshots, console logs, or network request/response bodies.
+
+## Environment (please complete the following)
+
+- **Deployment:** local / staging / production
+- **Backend version:** (commit hash or tag)
+- **Frontend version:** (commit hash or tag)
+- **Wallet:** Freighter / xBull / Albedo / Lobstr
+- **Browser:** Chrome / Firefox / Safari / Edge
+- **OS:** macOS / Linux / Windows
+
+## Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,32 @@
+---
+name: Documentation
+about: Report missing, incorrect, or outdated documentation
+title: "[Docs] "
+labels: docs
+assignees: ""
+---
+
+## What needs to be documented?
+
+Describe the missing or incorrect documentation.
+
+## Location
+
+Which file(s) or section(s) need updating?
+
+- `docs/...`
+- `README.md`
+- `API.md`
+- Other:
+
+## Suggested content
+
+If you have a draft or outline of what should be written, include it here.
+
+## Why is this important?
+
+Who benefits and how? (e.g., new contributors, API consumers, end users)
+
+## Additional context
+
+Add any links, screenshots, or references.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem statement
+
+What problem does this feature solve? What use case does it address?
+
+## Proposed solution
+
+A clear and concise description of what you want to happen.
+
+## Alternative solutions
+
+What alternatives have you considered?
+
+## Impact
+
+- **Users affected:** All / power users / maintainers / specific roles
+- **Complexity:** Low / Medium / High
+- **Dependencies:** List any dependent features, PRs, or external changes
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Additional context
+
+Add any other context, mockups, or examples here.

--- a/.github/ISSUE_TEMPLATE/operations.md
+++ b/.github/ISSUE_TEMPLATE/operations.md
@@ -1,0 +1,35 @@
+---
+name: Operations / DevOps
+about: CI/CD, infrastructure, deployment, or monitoring improvements
+title: "[Ops] "
+labels: devops
+assignees: ""
+---
+
+## What needs improvement?
+
+Describe the operational issue or improvement.
+
+## Current state
+
+How does this work today? Include any relevant logs, error messages, or metrics.
+
+## Desired state
+
+How should it work after the change?
+
+## Impact
+
+- **Deployment:** Does this affect deploy processes?
+- **Monitoring:** Does this change observability or alerting?
+- **Security:** Any security implications?
+- **Cost:** Any infrastructure cost changes?
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Related issues / PRs
+
+- #

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,0 +1,38 @@
+---
+name: Security disclosure
+about: Report a security vulnerability (please do NOT open a public issue)
+title: ""
+labels: security
+assignees: ""
+---
+
+> **⚠️ IMPORTANT:** If you are reporting a security vulnerability that could affect user funds or sensitive data, please follow our [SECURITY.md](../../SECURITY.md) disclosure process instead of filing a public issue.
+
+## Description
+
+Describe the security concern.
+
+## Severity
+
+- Critical / High / Medium / Low
+
+## Affected component
+
+- [ ] Backend API
+- [ ] Frontend
+- [ ] Smart contract
+- [ ] Infrastructure / CI
+- [ ] Dependency
+
+## Steps to reproduce (if applicable)
+
+1.
+2.
+
+## Suggested fix (optional)
+
+If you have a recommendation for addressing the issue.
+
+## Additional context
+
+Any references, CVEs, or related advisories.


### PR DESCRIPTION
## Description

Add comprehensive GitHub issue templates to standardize bug reports, feature requests, and documentation improvements across the project.

Closes #568

## Changes

- **bug_report.md** — Structured template with reproduction steps, environment info, and logs
- **feature_request.md** — Problem/solution format with impact assessment and acceptance criteria
- **documentation.md** — Missing/incorrect docs reporting with location and suggested content
- **operations.md** — CI/CD, infrastructure, deployment, and monitoring improvements
- **security.md** — Security concern reporting with severity and affected component section

Wallet: USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3