### PR TITLE
docs: create wallet-specific bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/wallet_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/wallet_bug_report.md
@@ -1,0 +1,70 @@
+---
+name: Wallet integration bug
+about: Report a bug specific to wallet connection, transaction signing, or address management
+title: "[Wallet] "
+labels: bug, wallet
+assignees: ""
+---
+
+## Wallet details
+
+- **Wallet:** Freighter / xBull / Albedo / Lobstr / Other
+- **Wallet version:** (e.g., Freighter v6.0.0)
+- **Browser:** Chrome / Firefox / Safari / Edge
+- **Network:** Public / Testnet / Local (Futurenet / Standalone)
+- **Stellar address:** (G... / test account)
+
+## Bug description
+
+What happened? What did you expect to happen?
+
+### Connection
+
+- [ ] Wallet fails to connect
+- [ ] Wallet connects but shows wrong address
+- [ ] Wallet disconnects unexpectedly
+- [ ] Multiple wallets conflict
+
+### Signing
+
+- [ ] Transaction signing fails with error
+- [ ] Signing succeeds but transaction is rejected
+- [ ] Signing popup does not appear
+- [ ] Signature verification fails
+
+### Transaction
+
+- [ ] Transaction submitted but not confirmed
+- [ ] Wrong operation executed
+- [ ] Fees higher than expected
+- [ ] Transaction stuck in pending state
+
+## Steps to reproduce
+
+1. Open the app at '...'
+2. Click 'Connect Wallet'
+3. Select '...'
+4. Perform '...'
+5. See error
+
+## Console / network logs
+
+```
+Paste any relevant console errors, network request responses, or wallet extension logs here.
+```
+
+## Screenshots / recordings
+
+If applicable, add screenshots or screen recordings of the wallet interaction flow.
+
+## Transaction hashes (if applicable)
+
+- **Failed TX:** ``
+- **Successful TX (unexpected behavior):** ``
+
+## Additional context
+
+- Does the issue reproduce on the Stellar Laboratory? Yes / No
+- Does the issue reproduce with other wallets? Yes / No (specify which)
+- First occurrence date:
+- Frequency: Always / Intermittent / Once


### PR DESCRIPTION
## Description

Add a specialized bug report template for wallet integration issues across Freighter, xBull, Albedo, and Lobstr wallets.

Closes #569

## Changes

- **wallet_bug_report.md** — Wallet-specific template with:
  - Wallet details section (type, version, browser, network)
  - Bug type checkboxes (connection, signing, transaction issues)
  - Structured reproduction steps
  - Transaction hash tracking for failed and unexpected transactions
  - Cross-wallet reproducibility field

Wallet: USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3