### PR TITLE
docs: publish public roadmap with now, next, and later buckets

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,77 @@
+# Stellar Portfolio Rebalancer — Public Roadmap
+
+This roadmap shows where the project is heading. It's a living document updated as priorities shift.
+
+---
+
+## 🎯 Now (actively being worked on)
+
+_These items have active PRs or assigned contributors._
+
+| Item | Description | Target release |
+| ---- | ----------- | -------------- |
+| **Issue & PR templates** | Standardized issue templates for bugs, features, docs, ops, security, and wallets | v0.8.0 |
+| **Maintainer triage guide** | Documented triage workflow for maintainers | v0.8.0 |
+| **ADR folder** | Architecture Decision Records for tracking design decisions | v0.8.0 |
+| **cURL recipe examples** | Copy-paste `curl` commands for all API endpoints | v0.8.0 |
+| **Glossary** | Stellar, Soroban, and Reflector terminology reference | v0.8.0 |
+| **Demo walkthrough** | Step-by-step visual guide for new users | v0.8.0 |
+| **API error code glossary** | Documented error codes with examples in API docs | v0.8.0 |
+| **Wallet FAQ** | Troubleshooting guide for wallet connection issues | v0.8.0 |
+| **SECURITY.md** | Security disclosure and vulnerability reporting process | v0.8.0 |
+
+---
+
+## 🔜 Next (upcoming quarter)
+
+_These items are planned and scoped but not yet started._
+
+| Item | Description | Est. complexity |
+| ---- | ----------- | --------------- |
+| **Auto-rebalancer UI** | Dashboard controls for auto-rebalancer settings, status, and history | Medium |
+| **Notification system** | Email/webhook notifications for rebalance events and threshold breaches | Medium |
+| **Soroban vault contract** | On-chain vault for secure fund management with multi-sig support | High |
+| **Price oracle integration** | Multiple oracle sources with fallback and staleness checks | Medium |
+| **Portfolio analytics v2** | Advanced metrics: Sharpe ratio, volatility, drawdown analysis | Medium |
+| **Mobile-responsive frontend** | Full mobile support for the React dashboard | Medium |
+| **i18n support** | Internationalization for frontend with English + Chinese initial languages | Low |
+
+---
+
+## 🗺️ Later (future direction)
+
+_These items are aspirational — scoping and prioritization have not yet happened._
+
+| Item | Description | Rationale |
+| ---- | ----------- | --------- |
+| **Mobile native app** | React Native or Flutter app for iOS/Android | Broader user reach |
+| **Yield farming strategies** | Automated yield optimization across liquidity pools | Feature parity with DeFi competitors |
+| **Social trading** | Copy-trading and shared portfolio templates | Community growth |
+| **Soroban multi-chain bridge** | Cross-chain portfolio management | Expand beyond Stellar |
+| **DA Governance** | Token-based voting on rebalancing strategies | Community ownership |
+| **Risk scoring API** | ML-powered portfolio risk scoring | Premium feature |
+| **Performance benchmarks** | Automated benchmark comparisons against index/HODL strategies | Transparency |
+
+---
+
+## ✅ Completed
+
+_Milestones the project has already shipped._
+
+| Quarter | Milestone | Key features |
+| ------- | --------- | ------------ |
+| Q1 2026 | v0.1 – MVP | Basic portfolio CRUD, manual rebalancing, demo mode |
+| Q2 2026 | v0.5 – Automation | Auto-rebalancer, risk checks, analytics dashboard |
+
+---
+
+## How to contribute
+
+- **Pick a "Now" item** with an open issue and submit a PR
+- **Browse `good first issue`** labels for beginner-friendly tasks
+- **Propose a "Next" item** by filing a feature request with scope details
+- **Upvote "Later" items** you'd like to see prioritized by commenting on the issue
+
+---
+
+_Last updated: May 2026_


### PR DESCRIPTION
## Description

Add a public roadmap document to communicate the project's current work, upcoming plans, and future direction to contributors and users.

Closes #573

## Changes

- **docs/ROADMAP.md** — Public roadmap with three time buckets:
  - **Now:** 9 actively worked items (templates, guides, docs) targeting v0.8.0
  - **Next:** 7 planned items for upcoming quarter with complexity estimates
  - **Later:** 8 aspirational features with rationale for each
  - **Completed:** Q1/Q2 2026 milestone summary
  - Contribution guidance

Wallet: USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3