### PR TITLE
ci: enforce commit message conventions in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      - name: Commit message check
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.js
+          helpURL: https://github.com/ritik4ever/stellar-portfolio-rebalancer/blob/main/docs/CONTRIBUTING.md#commit-messages
 
       - name: Frontend lint
         working-directory: frontend

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [2, 'always', [
+      'feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test',
+      'build', 'ci', 'chore', 'revert'
+    ]],
+    'subject-case': [2, 'always', ['lower-case', 'sentence-case']],
+    'header-max-length': [2, 'always', 72],
+  },
+}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -418,6 +418,57 @@ STELLAR_REBALANCE_SECRET=<TESTNET_SIGNER_SECRET>
 
 ---
 
+## Commit message conventions
+
+This project enforces **Conventional Commits** in CI via commitlint. Every pull request's commits must follow this format:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Allowed types
+
+| Type       | Usage                                |
+| ---------- | ------------------------------------ |
+| `feat`     | A new feature                        |
+| `fix`      | A bug fix                            |
+| `docs`     | Documentation only                   |
+| `style`    | Formatting, missing semicolons, etc. |
+| `refactor` | Code change that neither fixes nor adds |
+| `perf`     | Performance improvement              |
+| `test`     | Adding or updating tests             |
+| `build`    | Build system or dependencies         |
+| `ci`       | CI configuration or scripts          |
+| `chore`    | Maintenance tasks                    |
+| `revert`   | Reverts a previous commit            |
+
+### Scope examples
+
+- `feat(backend)` — backend API changes
+- `fix(frontend)` — frontend UI fixes
+- `docs(contracts)` — smart contract documentation
+- `ci(lint)` — lint workflow changes
+
+### Rule enforcement
+
+Commit messages are checked automatically in CI via the `wagoid/commitlint-github-action` action. PRs with non-conforming commits will fail the `Commit message check` step. To fix:
+
+```bash
+# Rebase and fix the first commit
+git rebase -i HEAD~N  # then reword
+
+# Or squash everything into one valid commit
+git reset --soft main && git commit -m "feat: description"
+```
+
+See [commitlint.config.js](../commitlint.config.js) for the full rule set.
+
+---
+
 ## Further reading
 
 - [Operations handbook](OPERATIONS.md) — Redis, workers, indexer, health vs readiness, restarts


### PR DESCRIPTION
## Description

Add commit message convention enforcement to the CI pipeline using commitlint with conventional commit rules.

Closes #554

## Changes

- **commitlint.config.js** — New config file with @commitlint/config-conventional rules
- **.github/workflows/lint.yml** — Added Commit message check step using wagoid/commitlint-github-action
- **docs/CONTRIBUTING.md** — Added Commitment message conventions section with type reference, scope examples, and fix instructions

Wallet: USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3