### PR TITLE
build: set sensible resource limits in Docker Compose services

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -21,6 +21,13 @@ services:
       - frontend_logs:/var/log/nginx
     depends_on:
       - backend
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 256M
+        reservations:
+          memory: 64M
 
   backend:
     build:
@@ -69,6 +76,13 @@ services:
         condition: service_healthy
     volumes:
       - ./logs:/app/logs
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          memory: 128M
 
   redis:
     image: redis:7-alpine
@@ -86,6 +100,13 @@ services:
       timeout: 3s
       retries: 6
       start_period: 5s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.3'
+          memory: 128M
+        reservations:
+          memory: 32M
 
   postgres:
     image: postgres:15-alpine
@@ -106,6 +127,13 @@ services:
       timeout: 5s
       retries: 8
       start_period: 5s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          memory: 128M
 
   monitoring:
     build:
@@ -129,6 +157,13 @@ services:
     depends_on:
       - redis
       - backend
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 256M
+        reservations:
+          memory: 64M
 
   prometheus:
     image: prom/prometheus:v2.54.1


### PR DESCRIPTION
## Description

Add resource limits and reservations to all Docker Compose services to ensure predictable performance across deployment environments.

Closes #560

## Changes

- **deployment/docker-compose.yml** — Added deploy.resources blocks:
  - frontend: 0.25 CPU / 256M limit, 64M reservation
  - backend: 0.5 CPU / 512M limit, 128M reservation
  - redis: 0.3 CPU / 128M limit, 32M reservation
  - postgres: 0.5 CPU / 512M limit, 128M reservation
  - monitoring: 0.25 CPU / 256M limit, 64M reservation

Wallet: USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3