### PR TITLE
docs: publish public roadmap with now, next, and later buckets

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,31 @@
+# Project Roadmap
+
+This roadmap outlines planned features and improvements for the Stellar Portfolio Rebalancer.
+
+## ✅ Now — In Progress
+
+- **Docker Compose profiles** — Minimal, full-stack, and observability modes
+- **CI/CD improvements** — Faster test runs, sharded backend tests
+- **Health smoke tests** — Automated health checks for local and production
+
+## 🔜 Next — Upcoming
+
+- **Soroban contract v2** — Support for multi-hop swaps and limit orders
+- **Webhook notifications** — Real-time alerts for rebalance completions and failures
+- **Analytics dashboard** — Performance tracking and historical P&L charts
+- **Backend caching** — Redis integration for faster API responses
+
+## 📅 Later — Future Considerations
+
+- **Mobile app** — React Native companion app
+- **Multi-user support** — Team portfolios with role-based access
+- **Governance** — DAO voting for protocol parameters
+- **Cross-chain** — Bridge support for non-Stellar assets
+
+## Contributing
+
+Interested in helping with any of these items? Check [open issues](https://github.com/ritik4ever/stellar-portfolio-rebalancer/issues) or open a new one to discuss.
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for completed releases.


### PR DESCRIPTION
## Description
Add `ROADMAP.md` to communicate planned features and priorities to the community.

### Buckets
- **Now** — Docker profiles, CI improvements, health checks
- **Next** — Soroban v2, webhooks, analytics, caching
- **Later** — Mobile app, multi-user, governance, cross-chain

Closes #573

**Payment:** USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3