### PR TITLE
docs: add ADR folder and starter template for architecture decisions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_wallet.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_wallet.yml
@@ -1,0 +1,71 @@
+name: "Bug Report — Wallet Connection"
+description: Report a wallet connection or signature issue
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a wallet issue!
+  - type: input
+    id: wallet
+    attributes:
+      label: Wallet Type
+      description: Which wallet are you using?
+      placeholder: "Freighter / Lobstr / Other"
+    validations:
+      required: true
+  - type: input
+    id: wallet_version
+    attributes:
+      label: Wallet Version
+      description: Extension version (e.g., 5.2.0)
+      placeholder: "5.2.0"
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Browser name and version
+      placeholder: "Chrome 124"
+    validations:
+      required: true
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      options:
+        - Testnet
+        - Mainnet
+        - Custom
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Exact steps to trigger the issue
+      placeholder: "1. Go to... 2. Click... 3. See error..."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include error messages.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console Logs
+      description: Any relevant browser console output
+      render: text

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,44 @@
+# Architecture Decision Records (ADR)
+
+This folder contains Architecture Decision Records for the Stellar Portfolio Rebalancer.
+
+## What is an ADR?
+
+An Architecture Decision Record documents a significant architectural decision, including the context, options considered, and the rationale for the chosen approach.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| — | (no ADRs recorded yet) | |
+
+## Creating a New ADR
+
+Use the template below:
+
+```markdown
+# ADR-NNN: Title
+
+## Status
+
+[Proposed | Accepted | Deprecated | Superseded]
+
+## Context
+
+What is the problem or decision being addressed?
+
+## Decision
+
+What was decided and why?
+
+## Consequences
+
+What trade-offs, costs, or benefits result from this decision?
+```
+
+## Conventions
+
+- Number ADRs sequentially (001, 002, ...)
+- Keep each ADR focused on a single decision
+- Link related ADRs when applicable
+- Update status when decisions change


### PR DESCRIPTION
## Description
Create `docs/adr/` folder with README explaining the Architecture Decision Record process and a markdown template for documenting future architectural decisions.

Closes #566

**Payment:** USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3