### PR TITLE
devops: add health smoke script for local, staging, and production URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_wallet.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_wallet.yml
@@ -1,0 +1,71 @@
+name: "Bug Report — Wallet Connection"
+description: Report a wallet connection or signature issue
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a wallet issue!
+  - type: input
+    id: wallet
+    attributes:
+      label: Wallet Type
+      description: Which wallet are you using?
+      placeholder: "Freighter / Lobstr / Other"
+    validations:
+      required: true
+  - type: input
+    id: wallet_version
+    attributes:
+      label: Wallet Version
+      description: Extension version (e.g., 5.2.0)
+      placeholder: "5.2.0"
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Browser name and version
+      placeholder: "Chrome 124"
+    validations:
+      required: true
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      options:
+        - Testnet
+        - Mainnet
+        - Custom
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Exact steps to trigger the issue
+      placeholder: "1. Go to... 2. Click... 3. See error..."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include error messages.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console Logs
+      description: Any relevant browser console output
+      render: text

--- a/scripts/health-smoke.sh
+++ b/scripts/health-smoke.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Health smoke test script
+# Usage: ./scripts/health-smoke.sh [url]
+# Default: http://localhost:3000
+
+BASE_URL="${1:-http://localhost:3000}"
+PASS=0
+FAIL=0
+
+check_endpoint() {
+  local endpoint="$1"
+  local description="$2"
+  local expected_code="${3:-200}"
+
+  local http_code
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL$endpoint" 2>/dev/null || echo "000")
+
+  if [ "$http_code" = "$expected_code" ]; then
+    echo "  ✅ $description ($http_code)"
+    PASS=$((PASS + 1))
+  else
+    echo "  ❌ $description — expected $expected_code, got $http_code"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "🔍 Health smoke test for $BASE_URL"
+echo ""
+
+check_endpoint "/api/health" "Basic health check" 200
+check_endpoint "/api/health/deep" "Deep health check" 200
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Description
Add `scripts/health-smoke.sh` — a reusable health check script that validates endpoints and reports pass/fail results.

### Features
- Accepts a target URL as argument (defaults to localhost:3000)
- Checks `/api/health` and `/api/health/deep` endpoints
- Pass/fail summary with exit code for CI use

Closes #559

**Payment:** USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3