### PR TITLE
devops: add optional pre-commit hooks for lint, test, and format quick checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_wallet.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_wallet.yml
@@ -1,0 +1,71 @@
+name: "Bug Report — Wallet Connection"
+description: Report a wallet connection or signature issue
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a wallet issue!
+  - type: input
+    id: wallet
+    attributes:
+      label: Wallet Type
+      description: Which wallet are you using?
+      placeholder: "Freighter / Lobstr / Other"
+    validations:
+      required: true
+  - type: input
+    id: wallet_version
+    attributes:
+      label: Wallet Version
+      description: Extension version (e.g., 5.2.0)
+      placeholder: "5.2.0"
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Browser name and version
+      placeholder: "Chrome 124"
+    validations:
+      required: true
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      options:
+        - Testnet
+        - Mainnet
+        - Custom
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Exact steps to trigger the issue
+      placeholder: "1. Go to... 2. Click... 3. See error..."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include error messages.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console Logs
+      description: Any relevant browser console output
+      render: text

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Optional pre-commit hooks for lint, test, and format quick checks
+# Uncomment the checks you want:
+
+# Lint staged files
+# npx lint-staged
+
+# Run frontend type check
+# npm --prefix frontend run typecheck --if-present
+
+# Run backend type check
+# npm --prefix backend run typecheck --if-present
+
+# Quick format check
+# npx prettier --check "**/*.{ts,tsx,js,jsx,json,md}"


### PR DESCRIPTION
## Description
Update `.husky/pre-commit` with commented-out optional hooks that developers can enable for lint, typecheck, and format checks before commits.

Closes #553

**Payment:** USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3