### PR TITLE
docs: add CODEOWNERS aligned with backend, frontend, and contracts ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# Code ownership file
+# Each line is a file pattern followed by one or more owners
+
+# Default owners
+* @ritik4ever
+
+# Backend
+/backend/* @ritik4ever
+/backend/src/**/* @ritik4ever
+
+# Frontend
+/frontend/* @ritik4ever
+/frontend/src/**/* @ritik4ever
+
+# Contracts
+/contracts/* @ritik4ever
+/contracts/src/**/* @ritik4ever
+
+# Documentation
+/docs/* @ritik4ever
+*.md @ritik4ever
+
+# DevOps
+/.github/**/* @ritik4ever
+/docker-compose.yml @ritik4ever
+/Dockerfile* @ritik4ever
+
+# Configuration
+/package.json @ritik4ever
+/vitest.config.* @ritik4ever
+/tsconfig*.json @ritik4ever

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report a bug to help us improve
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+A clear description of the bug.
+
+## Steps to Reproduce
+1. Go to '...'
+2. Run '...'
+3. See error
+
+## Expected Behavior
+What should happen.
+
+## Actual Behavior
+What happens instead.
+
+## Environment
+- OS: [e.g. Ubuntu 24.04, macOS 15]
+- Python/Rust/Node version:
+- Rebalance strategy (if applicable):
+
+## Logs / Output
+```
+Paste relevant logs here
+```

--- a/.github/ISSUE_TEMPLATE/bug_report_wallet.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_wallet.yml
@@ -1,0 +1,71 @@
+name: "Bug Report — Wallet Connection"
+description: Report a wallet connection or signature issue
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a wallet issue!
+  - type: input
+    id: wallet
+    attributes:
+      label: Wallet Type
+      description: Which wallet are you using?
+      placeholder: "Freighter / Lobstr / Other"
+    validations:
+      required: true
+  - type: input
+    id: wallet_version
+    attributes:
+      label: Wallet Version
+      description: Extension version (e.g., 5.2.0)
+      placeholder: "5.2.0"
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Browser name and version
+      placeholder: "Chrome 124"
+    validations:
+      required: true
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      options:
+        - Testnet
+        - Mainnet
+        - Custom
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Exact steps to trigger the issue
+      placeholder: "1. Go to... 2. Click... 3. See error..."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include error messages.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console Logs
+      description: Any relevant browser console output
+      render: text

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new rebalancing strategy or platform feature
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+What problem does this feature solve?
+
+## Proposed Solution
+How should the feature work?
+
+## Alternatives
+What alternatives have you considered?
+
+## Additional Context
+Links to similar features, papers, or references.

--- a/.github/ISSUE_TEMPLATE/security_report.md
+++ b/.github/ISSUE_TEMPLATE/security_report.md
@@ -1,0 +1,24 @@
+---
+name: Security report
+about: Report a security vulnerability
+title: ''
+labels: security
+assignees: ''
+---
+
+## Vulnerability Description
+Clearly describe the issue.
+
+## Impact
+What could an attacker achieve?
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Proposed Fix (optional)
+Any suggestions for remediation.
+
+## Disclosure
+Please do not file a public PR for security issues. Contact maintainers directly if the issue is sensitive.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+What does this PR change?
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature / rebalancing strategy
+- [ ] Documentation
+- [ ] Security fix
+- [ ] Performance improvement
+
+## Testing
+- [ ] Unit tests pass
+- [ ] Manual testing completed
+- [ ] No regression in existing strategies
+
+## Related Issues
+Closes #[issue]
+
+## Checklist
+- [ ] Code follows project style
+- [ ] Documentation updated if needed
+- [ ] Tests added/updated

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,33 @@
+# Stellar & Soroban Glossary
+
+## Core Stellar Concepts
+
+| Term | Definition |
+|------|------------|
+| **Stellar** | A decentralized blockchain network optimized for cross-border payments and asset issuance. |
+| **Lumen (XLM)** | The native asset of the Stellar network, used for transaction fees and as a bridge currency. |
+| **Stellar Account** | A public key / secret key pair identified by a `G...` address. |
+| **Friendbot** | A Stellar testnet service that funds new accounts with test XLM. |
+| **Trustline** | An account's declaration of trust in a specific asset issuer, required to hold non-XLM tokens. |
+| **Transaction** | A signed operation submitted to the Stellar network. |
+| **Sequence Number** | A monotonic counter that prevents transaction replay. |
+
+## Soroban Smart Contracts
+
+| Term | Definition |
+|------|------------|
+| **Soroban** | Stellar's smart contract platform supporting Rust/WASM contracts. |
+| **Contract ID** | A `C...` address identifying a deployed Soroban contract. |
+| **WASM** | WebAssembly binary format used to compile Soroban contracts. |
+| **stellar-cli** | Command-line tool for building, deploying, and interacting with Soroban contracts. |
+| **Invoke** | Calling a contract function via a Soroban transaction. |
+
+## Rebalancer-Specific Terms
+
+| Term | Definition |
+|------|------------|
+| **Reflector** | The price oracle service that provides asset price feeds for rebalancing decisions. |
+| **Rebalance Strategy** | A set of rules that determines when and how to adjust portfolio allocations. |
+| **Portfolio** | A collection of asset holdings tracked by the rebalancer. |
+| **Target Allocation** | The desired percentage distribution of assets in a portfolio. |
+| **Drift** | The deviation of current allocation from the target allocation. |


### PR DESCRIPTION
## Description
Add `.github/CODEOWNERS` defining ownership for backend, frontend, contracts, docs, devops, and configuration files.

Closes #542

**Payment:** USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3