### PR TITLE
Post benchmark regression summaries as pull request comments

### DIFF
--- a/.github/workflows/contract-smoke.yml
+++ b/.github/workflows/contract-smoke.yml
@@ -58,6 +58,33 @@ jobs:
         working-directory: ./contracts
         run: cargo build --target wasm32-unknown-unknown --release
 
+      - name: Run benchmarks
+        working-directory: ./contracts
+        if: github.event_name == 'pull_request'
+        run: |
+          cargo test benchmark_ -- --nocapture > bench_output.txt || true
+          python3 -c '
+          lines = [line.strip() for line in open("bench_output.txt") if "BENCHMARK_RESULT|" in line]
+          with open("bench_summary.md", "w") as f:
+              f.write("## Benchmark Results\n")
+              f.write("| Benchmark | CPU | Baseline CPU | Δ CPU | Mem | Baseline Mem | Δ Mem |\n")
+              f.write("|-----------|-----|--------------|-------|-----|--------------|-------|\n")
+              for line in lines:
+                  parts = line.split("|")
+                  name, cpu, base_cpu, mem, base_mem = parts[1], int(parts[2]), int(parts[3]), int(parts[4]), int(parts[5])
+                  cpu_diff = (cpu - base_cpu) / base_cpu * 100
+                  mem_diff = (mem - base_mem) / base_mem * 100
+                  f.write(f"| `{name}` | {cpu:,} | {base_cpu:,} | {cpu_diff:+.2f}% | {mem:,} | {base_mem:,} | {mem_diff:+.2f}% |\n")
+          '
+          cat bench_summary.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Post benchmark summary
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          header: benchmark
+          path: contracts/bench_summary.md
+
       - name: Deploy and initialize on testnet
         working-directory: ./contracts
         run: |

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -1359,6 +1359,7 @@ fn benchmark_initialize_gas() {
     let admin = Address::generate(&env);
     let _ = client.initialize(&admin, &reflector_id);
     assert_cost_within_tolerance(
+        "initialize",
         env.budget().cpu_instruction_cost(),
         env.budget().memory_bytes_cost(),
         BASELINE_INITIALIZE_CPU,
@@ -1385,6 +1386,7 @@ fn benchmark_create_portfolio_gas() {
     env.budget().reset_tracker();
     let _ = client.create_portfolio(&user, &allocations, &5, &50);
     assert_cost_within_tolerance(
+        "create_portfolio",
         env.budget().cpu_instruction_cost(),
         env.budget().memory_bytes_cost(),
         BASELINE_CREATE_PORTFOLIO_CPU,
@@ -1422,6 +1424,7 @@ fn benchmark_execute_rebalance_gas() {
     env.budget().reset_tracker();
     let _ = client.execute_rebalance(&pid, &Map::new(&env));
     assert_cost_within_tolerance(
+        "execute_rebalance",
         env.budget().cpu_instruction_cost(),
         env.budget().memory_bytes_cost(),
         BASELINE_EXECUTE_REBALANCE_CPU,
@@ -1450,6 +1453,7 @@ fn benchmark_deposit_gas() {
     env.budget().reset_tracker();
     client.deposit(&pid, &asset, &100);
     assert_cost_within_tolerance(
+        "deposit",
         env.budget().cpu_instruction_cost(),
         env.budget().memory_bytes_cost(),
         BASELINE_DEPOSIT_CPU,
@@ -1457,9 +1461,10 @@ fn benchmark_deposit_gas() {
     );
 }
 
-fn assert_cost_within_tolerance(cpu: u64, mem: u64, baseline_cpu: u64, baseline_mem: u64) {
+fn assert_cost_within_tolerance(name: &str, cpu: u64, mem: u64, baseline_cpu: u64, baseline_mem: u64) {
     let cpu_limit = baseline_cpu + (baseline_cpu * BENCHMARK_TOLERANCE_PERCENT / 100);
     let mem_limit = baseline_mem + (baseline_mem * BENCHMARK_TOLERANCE_PERCENT / 100);
+    std::println!("BENCHMARK_RESULT|{}|{}|{}|{}|{}", name, cpu, baseline_cpu, mem, baseline_mem);
     assert!(
         cpu <= cpu_limit,
         "CPU instruction usage exceeded threshold: actual={}, baseline={}, max_allowed={}",


### PR DESCRIPTION
### Description
This pull request turns the raw benchmark output into a PR-friendly summary that automatically highlights gas/cost regressions and improvements directly in the PR conversation. 

**Changes Included:**
- Modified the benchmark tests in `contracts/src/test.rs` to output a strictly formatted string (`BENCHMARK_RESULT`) that makes it easy to extract metric data during the `make bench` process.
- Added a new parsing step in `.github/workflows/contract-smoke.yml` that runs the benchmarks on pull requests.
- Implemented a lightweight inline script within the workflow to calculate the percentage differences (`Δ CPU`, `Δ Mem`) between the current run and the established baselines.
- Integrated the `marocchino/sticky-pull-request-comment` action to post the generated Markdown summary table directly as a pull request comment and to the GitHub Actions step summary.

This makes benchmark data significantly more actionable, allowing reviewers to see performance deltas directly in the PR instead of hunting through CI logs.

close #563