### PR TITLE
ci: commit-message lint, sharded tests, health smoke, and artifact freshness guard

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -13,12 +13,17 @@ on:
       - 'backend/**'
       - '.github/workflows/backend-tests.yml'
 
+# Total number of shards the backend test suite is split across. Keep this in
+# sync with the `matrix.shard` list in the `backend-tests` job below.
+env:
+  SHARD_TOTAL: 4
+
 jobs:
-  backend-tests:
+  # OpenAPI contract verification is independent of the test suite, so it runs
+  # once in its own job instead of being repeated in every test shard.
+  openapi-contract:
+    name: OpenAPI contract check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: ['20.x']
 
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20.x
           cache: npm
           cache-dependency-path: backend/package-lock.json
 
@@ -34,21 +39,94 @@ jobs:
         working-directory: ./backend
         run: npm ci
 
-      - name: OpenAPI contract check
+      - name: Verify OpenAPI spec and docs
         working-directory: ./backend
         run: |
           npm run spec:check
           npm run api:validate
 
-      - name: Run backend tests with coverage
-        working-directory: ./backend
-        run: npm run test:coverage
+  # Test files are split into SHARD_TOTAL parallel shards. Vitest distributes
+  # test files across shards, so total wall-clock time scales down roughly
+  # linearly with the shard count. Each shard collects coverage into a blob
+  # report; thresholds are enforced later in the `backend-coverage` job once all
+  # blobs are merged.
+  backend-tests:
+    name: Tests (shard ${{ matrix.shard }} of 4)
+    runs-on: ubuntu-latest
+    strategy:
+      # Run every shard even if one fails so a single shard failure never masks
+      # failures in the others.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
-      - name: Upload backend coverage artifact
-        if: success()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ./backend
+        run: npm ci
+
+      - name: Run tests (shard ${{ matrix.shard }})
+        working-directory: ./backend
+        run: npm run test:shard -- --shard=${{ matrix.shard }}/${{ env.SHARD_TOTAL }}
+
+      - name: Upload shard blob report
+        # Upload even when the shard fails so the merge job can still combine the
+        # passing shards' coverage; fail loudly if a shard produced nothing.
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: backend-coverage-${{ matrix.node-version }}
+          name: backend-blob-report-${{ matrix.shard }}
+          path: backend/.vitest-reports/*
+          include-hidden-files: true
+          if-no-files-found: error
+
+  # Merge the per-shard blob reports into a single coverage report and enforce
+  # the coverage thresholds defined in backend/vitest.config.ts against the full
+  # suite. This job only runs when every shard passed.
+  backend-coverage:
+    name: Merge coverage and enforce thresholds
+    needs: backend-tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ./backend
+        run: npm ci
+
+      - name: Download shard blob reports
+        uses: actions/download-artifact@v4
+        with:
+          path: backend/.vitest-reports
+          pattern: backend-blob-report-*
+          merge-multiple: true
+
+      - name: Merge reports and check coverage thresholds
+        working-directory: ./backend
+        run: npm run test:merge-coverage
+
+      - name: Upload merged backend coverage artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
           path: backend/coverage/
           if-no-files-found: warn
 

--- a/.github/workflows/generated-artifact-guard.yml
+++ b/.github/workflows/generated-artifact-guard.yml
@@ -18,5 +18,33 @@ jobs:
       - name: Fetch main for diff base
         run: git fetch origin main --depth=1
 
-      - name: Fail on generated/runtime artifacts
+      # Only the OpenAPI freshness check needs backend deps, so install them
+      # only when the spec source, its export, or the exporter changed.
+      - name: Detect OpenAPI-related changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            openapi:
+              - 'backend/src/openapi/**'
+              - 'backend/openapi.json'
+              - 'backend/scripts/export-openapi.ts'
+
+      - name: Setup Node.js
+        if: steps.changes.outputs.openapi == 'true' || github.event_name != 'pull_request'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies (for OpenAPI freshness check)
+        if: steps.changes.outputs.openapi == 'true' || github.event_name != 'pull_request'
+        working-directory: ./backend
+        run: npm ci
+
+      # The script always runs the runtime-artifact blocklist. When backend
+      # deps are present (installed above), it also regenerates backend/openapi.json
+      # from source and fails if the committed copy is stale.
+      - name: Guard artifacts and verify generated docs are fresh
         run: bash scripts/check-generated-artifacts.sh origin/main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,3 +24,19 @@ jobs:
         run: |
           npm ci
           npm run lint || echo "No backend lint configured"
+
+  commit-messages:
+    name: Commit message lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need the PR base and head commits to inspect the full range.
+          fetch-depth: 0
+
+      - name: Validate Conventional Commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/check-commit-messages.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Changelog entries are organized by impact:
 - Project-level changelog automation script using `conventional-changelog-cli`.
 - CI commit message lint that enforces Conventional Commits on pull requests, with a locally runnable `scripts/check-commit-messages.sh` helper and contributor documentation.
 - Sharded backend test execution in CI (4 parallel shards with merged coverage and threshold enforcement) plus `test:shard`/`test:merge-coverage` scripts and contributor docs for reproducing it locally.
+- Portable health smoke script (`scripts/health-smoke.sh`, `npm run smoke`) that probes `/health`, `/api/health`, `/ready`, and `/metrics` across local/staging/prod with a clear pass/fail summary, documented in OPERATIONS.md and API.md.
 
 ## [1.3.0] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Changelog entries are organized by impact:
 - WebSocket integration tests for `portfolio_update` message shape, reconnect behavior, and per-user event isolation.
 - Feature-flag test coverage for env parsing, runtime toggles, fail-safe defaults, and startup logging visibility.
 - Project-level changelog automation script using `conventional-changelog-cli`.
+- CI commit message lint that enforces Conventional Commits on pull requests, with a locally runnable `scripts/check-commit-messages.sh` helper and contributor documentation.
 
 ## [1.3.0] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Changelog entries are organized by impact:
 - Feature-flag test coverage for env parsing, runtime toggles, fail-safe defaults, and startup logging visibility.
 - Project-level changelog automation script using `conventional-changelog-cli`.
 - CI commit message lint that enforces Conventional Commits on pull requests, with a locally runnable `scripts/check-commit-messages.sh` helper and contributor documentation.
+- Sharded backend test execution in CI (4 parallel shards with merged coverage and threshold enforcement) plus `test:shard`/`test:merge-coverage` scripts and contributor docs for reproducing it locally.
 
 ## [1.3.0] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Changelog entries are organized by impact:
 - CI commit message lint that enforces Conventional Commits on pull requests, with a locally runnable `scripts/check-commit-messages.sh` helper and contributor documentation.
 - Sharded backend test execution in CI (4 parallel shards with merged coverage and threshold enforcement) plus `test:shard`/`test:merge-coverage` scripts and contributor docs for reproducing it locally.
 - Portable health smoke script (`scripts/health-smoke.sh`, `npm run smoke`) that probes `/health`, `/api/health`, `/ready`, and `/metrics` across local/staging/prod with a clear pass/fail summary, documented in OPERATIONS.md and API.md.
+- Tightened generated-artifact guard: `backend/openapi.json` freshness is now verified by regenerating from source and diffing (replacing a heuristic that referenced a non-existent spec path), wired into the Generated Artifact Guard workflow and documented in backend/docs/openapi.md.
 
 ## [1.3.0] - 2026-04-27
 

--- a/backend/docs/openapi.md
+++ b/backend/docs/openapi.md
@@ -49,3 +49,22 @@ The `api:validate` script (`backend/scripts/validate-api-docs.ts`) checks that `
 ```
 
 Always run `npm run openapi:export` before committing spec changes.
+
+## Generated Artifact Guard
+
+In addition to the backend `api:validate` check, the repo-level **Generated Artifact Guard** workflow (`.github/workflows/generated-artifact-guard.yml`) enforces freshness before merge by actually regenerating the export and diffing it:
+
+- It runs `scripts/check-generated-artifacts.sh`, which — when `backend/src/openapi/spec.ts`, `backend/openapi.json`, or the exporter change — installs backend deps, runs `npm run openapi:export`, and fails if the committed `backend/openapi.json` differs from the freshly generated output.
+- The same script also blocks committed runtime/build artifacts (databases, `coverage/`, `playwright-report/`, `test-results/`, `.nyc_output/`).
+
+Reproduce the guard locally:
+
+```bash
+# Verify only the OpenAPI export is fresh
+cd backend && npm ci && npm run spec:check
+
+# Or run the full guard exactly as CI does (from the repo root)
+scripts/check-generated-artifacts.sh origin/main
+```
+
+If the guard fails with "`backend/openapi.json` is out of date", run `cd backend && npm run openapi:export` and commit the regenerated file. To skip only the freshness regeneration (e.g. for an offline blocklist-only run), set `SKIP_OPENAPI_FRESHNESS=1`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,8 @@
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
         "test:ci": "npm run test:coverage",
+        "test:shard": "vitest run --coverage --reporter=blob",
+        "test:merge-coverage": "vitest run --merge-reports --coverage",
         "test:rate-limits": "node scripts/test-rate-limits.js",
         "test:notifications:dev": "node scripts/test-notifications-dev.mjs",
         "openapi:export": "tsx scripts/export-openapi.ts",

--- a/docs/API.md
+++ b/docs/API.md
@@ -3,3 +3,16 @@
 The HTTP API (versioning, envelopes, and endpoint overview) lives in the repository root:
 
 **[API.md](../API.md)**
+
+## Operational endpoints
+
+These unversioned endpoints support health checks and monitoring:
+
+| Endpoint           | Purpose                                                       |
+|--------------------|--------------------------------------------------------------|
+| `GET /health`      | Plain-text `200 ok` liveness probe for load balancers.       |
+| `GET /api/health`  | JSON `{ status, timestamp }` API health.                     |
+| `GET /ready`, `GET /readiness` | Deep readiness probe (DB, Redis/queues, workers, indexer); returns `503` until ready. |
+| `GET /metrics`     | Prometheus metrics exposition.                               |
+
+To probe these surfaces across environments, use the health smoke script (`npm run smoke`). See **[OPERATIONS.md](OPERATIONS.md#health-smoke-test)** for usage and the health-vs-readiness distinction.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -418,6 +418,43 @@ STELLAR_REBALANCE_SECRET=<TESTNET_SIGNER_SECRET>
 
 ---
 
+## 11. Commit message conventions
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/). Each commit subject must match:
+
+```
+<type>[optional scope][!]: <description>
+```
+
+**Allowed types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+
+**Examples:**
+
+- `feat(api): add portfolio export endpoint`
+- `fix(auth): resolve JWT token expiration handling`
+- `docs: update API client examples`
+- `chore(deps): update stellar-sdk to v12.0.1`
+
+This convention powers the automated changelog (`npm run changelog:update`) and keeps release history consistent.
+
+### CI enforcement
+
+Pull requests run a **Commit message lint** check (in the `Lint` workflow) that validates every commit in the PR against the format above. The check fails with a clear message listing any non-conforming commits.
+
+Run the same check locally before opening a PR:
+
+```bash
+# Check the current branch against origin/main
+scripts/check-commit-messages.sh
+
+# Or check an explicit range
+scripts/check-commit-messages.sh origin/main..HEAD
+```
+
+If the check flags a commit, amend or rebase to fix the subject line, e.g. `git commit --amend` for the latest commit or `git rebase -i origin/main` for earlier ones.
+
+---
+
 ## Further reading
 
 - [Maintainer Triage Guide](TRIAGE.md) — Issue and PR triage procedures for maintainers

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -260,6 +260,24 @@ npm test -- --watch   # watch mode
 
 Tests use an isolated SQLite database per run (no external dependencies required).
 
+#### Sharded test runs (CI parity)
+
+To keep CI fast, the **Backend Tests** workflow splits the suite into 4 parallel shards (`SHARD_TOTAL` in `.github/workflows/backend-tests.yml`). Each shard collects coverage into a [blob report](https://vitest.dev/guide/reporters#blob-reporter); a final job merges the blobs and enforces the coverage thresholds in `backend/vitest.config.ts` against the full suite.
+
+You can reproduce the sharded flow locally without any CI-specific tooling:
+
+```bash
+cd backend
+
+# Run a single shard (e.g. shard 1 of 4). Repeat for shards 2/4, 3/4, 4/4.
+npm run test:shard -- --shard=1/4
+
+# After running all shards, merge the blob reports and check coverage thresholds
+npm run test:merge-coverage
+```
+
+Each shard writes its blob report to `backend/.vitest-reports/`, which `test:merge-coverage` reads when combining results. To change the shard count, update `SHARD_TOTAL` and the `matrix.shard` list in the workflow together.
+
 ### Frontend unit tests
 
 ```bash

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -71,6 +71,37 @@ The indexer uses bounded exponential backoff when the Soroban RPC is unreachable
 
 Use `/health` for load balancer liveness. Use `/ready` before traffic shifts in environments that depend on Redis, workers, or the indexer.
 
+## Health smoke test
+
+`scripts/health-smoke.sh` probes the key operational surfaces (`/health`, `/api/health`, `/ready`, `/metrics`) and prints a pass/fail summary. Use it after a deploy or during triage against local, staging, or production.
+
+```bash
+# From the repository root
+npm run smoke                 # probe local (default http://localhost:3001)
+npm run smoke -- staging      # probe SMOKE_STAGING_URL
+npm run smoke -- prod         # probe SMOKE_PROD_URL
+npm run smoke -- https://api.example.com   # probe an explicit base URL
+
+# Or call the script directly
+scripts/health-smoke.sh local
+```
+
+Configure non-local targets and tuning via environment variables:
+
+| Variable            | Purpose                                                    |
+|---------------------|-----------------------------------------------------------|
+| `SMOKE_LOCAL_URL`   | Base URL for `local` (default `http://localhost:3001`)    |
+| `SMOKE_STAGING_URL` | Base URL for `staging` (required when target is `staging`)|
+| `SMOKE_PROD_URL`    | Base URL for `prod` (required when target is `prod`)      |
+| `SMOKE_TIMEOUT`     | Per-request timeout in seconds (default `10`)             |
+
+**Pass/fail semantics:**
+
+- `liveness` (`/health`) and `api-health` (`/api/health`) are **required** — a failure exits non-zero.
+- `readiness` (`/ready`) and `metrics` (`/metrics`) are **advisory** — they report a warning rather than failing the run, because readiness is legitimately `503` until Redis, workers, and the indexer are up (see the table above).
+
+The script exits `0` when all required checks pass and `1` otherwise, so it can gate a deploy step or be run by hand without manual interpretation.
+
 ## Safe shutdown and restart
 
 - **Process stop:** Stopping Node terminates open HTTP and WebSocket connections. BullMQ workers in the same process should be stopped with their `stop*Worker` helpers before exit if you add a worker host; repeatable jobs remain in Redis until removed via `stopQueueScheduler()`.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "changelog:update": "conventional-changelog -p conventionalcommits -i CHANGELOG.md -s",
     "changelog:preview": "conventional-changelog -p conventionalcommits",
     "validate:env-examples": "node scripts/validate-env-examples.mjs",
+    "smoke": "bash scripts/health-smoke.sh",
     "lint": "npm run lint:backend && npm run lint:frontend",
     "lint:backend": "cd backend && npm run lint",
     "lint:frontend": "cd frontend && npm run lint",

--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# check-commit-messages.sh
+#
+# Lightweight Conventional Commits policy check. Validates the subject line of
+# every commit in a range against the format documented in docs/CONTRIBUTING.md:
+#
+#   <type>[optional scope][!]: <description>
+#
+# Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci,
+#                chore, revert
+#
+# Usage:
+#   scripts/check-commit-messages.sh [<range>]
+#
+#   <range>   A git revision range (e.g. origin/main..HEAD). When omitted, the
+#             script falls back to BASE_SHA..HEAD_SHA from the environment, then
+#             to origin/main..HEAD.
+#
+# Examples:
+#   scripts/check-commit-messages.sh                 # check local branch vs origin/main
+#   scripts/check-commit-messages.sh origin/main..HEAD
+#   BASE_SHA=abc123 HEAD_SHA=def456 scripts/check-commit-messages.sh
+#
+# Exit code 0 when all commit subjects are valid, 1 otherwise.
+
+set -euo pipefail
+
+# Conventional Commits subject pattern. The description must be non-empty.
+PATTERN='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._/-]+\))?(!)?: .+'
+
+# Resolve the commit range to inspect.
+if [[ $# -ge 1 && -n "${1:-}" ]]; then
+  RANGE="$1"
+elif [[ -n "${BASE_SHA:-}" && -n "${HEAD_SHA:-}" ]]; then
+  RANGE="${BASE_SHA}..${HEAD_SHA}"
+else
+  RANGE="origin/main..HEAD"
+fi
+
+echo "Validating commit messages in range: ${RANGE}"
+
+# Collect commit hashes in the range. Use a here-string + while loop (portable
+# to bash 3.2, e.g. the default macOS bash) instead of `mapfile` (bash 4+).
+COMMITS="$(git rev-list --no-merges "${RANGE}")"
+
+if [[ -z "${COMMITS}" ]]; then
+  echo "No non-merge commits to validate."
+  exit 0
+fi
+
+failed=0
+while IFS= read -r sha; do
+  [[ -z "${sha}" ]] && continue
+  subject="$(git log -1 --format=%s "${sha}")"
+
+  # Skip auto-generated revert/merge style subjects that git may produce.
+  if [[ "${subject}" == Merge* ]]; then
+    continue
+  fi
+
+  if [[ "${subject}" =~ ${PATTERN} ]]; then
+    echo "  ✓ ${sha:0:8}  ${subject}"
+  else
+    echo "  ✗ ${sha:0:8}  ${subject}"
+    failed=1
+  fi
+done <<< "${COMMITS}"
+
+if [[ ${failed} -ne 0 ]]; then
+  cat <<'EOF'
+
+✗ One or more commit messages do not follow Conventional Commits.
+
+Expected format:
+  <type>[optional scope][!]: <description>
+
+Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+
+Examples:
+  feat(api): add portfolio export endpoint
+  fix(auth): resolve JWT token expiration handling
+  docs: update API client examples
+  chore(deps): update stellar-sdk to v12.0.1
+
+See docs/CONTRIBUTING.md (Commit message conventions) for details.
+EOF
+  exit 1
+fi
+
+echo "✓ All commit messages follow Conventional Commits."

--- a/scripts/check-generated-artifacts.sh
+++ b/scripts/check-generated-artifacts.sh
@@ -1,5 +1,27 @@
 #!/usr/bin/env bash
-set -euo pipefail
+#
+# check-generated-artifacts.sh
+#
+# Pre-merge guard for generated outputs. It enforces two things:
+#
+#   A. Runtime/build artifacts must never be committed (databases, coverage,
+#      Playwright reports, test-results, etc.).
+#   B. Generated docs/code outputs must be FRESH — i.e. regenerating them from
+#      source produces no diff. Today that means backend/openapi.json must match
+#      what `npm run openapi:export` produces from backend/src/openapi/spec.ts.
+#
+# Usage:
+#   scripts/check-generated-artifacts.sh [<base-ref>]
+#     <base-ref>   git ref to diff against (default: origin/main)
+#
+# Environment:
+#   SKIP_OPENAPI_FRESHNESS=1   skip the OpenAPI regenerate-and-diff check
+#                              (the blocklist check still runs)
+#
+# Exit 0 when everything is clean; exit 1 when a runtime artifact is committed
+# or a generated file is stale. Failures print the exact remediation command.
+
+set -uo pipefail
 
 BASE_REF="${1:-origin/main}"
 
@@ -18,6 +40,9 @@ if [[ -z "${CHANGED_FILES}" ]]; then
   exit 0
 fi
 
+# ---------------------------------------------------------------------------
+# Part A — block committed runtime/build artifacts
+# ---------------------------------------------------------------------------
 OFFENDING_FILES=()
 while IFS= read -r file; do
   [[ -z "${file}" ]] && continue
@@ -27,16 +52,44 @@ while IFS= read -r file; do
 done <<< "${CHANGED_FILES}"
 
 if [[ "${#OFFENDING_FILES[@]}" -gt 0 ]]; then
-  echo "Generated/runtime artifacts are not allowed in tracked changes:"
-  printf '%s\n' "${OFFENDING_FILES[@]}"
+  echo "✗ Generated/runtime artifacts are not allowed in tracked changes:"
+  printf '  %s\n' "${OFFENDING_FILES[@]}"
+  echo "  Remove them from the PR (they should be git-ignored)."
   exit 1
 fi
 
-if [[ "${CHANGED_FILES}" == *"backend/openapi.json"* ]]; then
-  if [[ "${CHANGED_FILES}" != *"backend/src/api/spec.ts"* ]]; then
-    echo "Detected change to backend/openapi.json without backend/src/api/spec.ts."
-    echo "If this file is generated, regenerate from source or exclude it from the PR."
-    exit 1
+# ---------------------------------------------------------------------------
+# Part B — verify generated OpenAPI export is fresh (no drift from source)
+# ---------------------------------------------------------------------------
+SPEC_SOURCE="backend/src/openapi/spec.ts"
+SPEC_EXPORT="backend/openapi.json"
+
+needs_openapi_check=false
+case "${CHANGED_FILES}" in
+  *"${SPEC_EXPORT}"*) needs_openapi_check=true ;;
+esac
+case "${CHANGED_FILES}" in
+  *"${SPEC_SOURCE}"*) needs_openapi_check=true ;;
+esac
+
+if [[ "${needs_openapi_check}" == true && "${SKIP_OPENAPI_FRESHNESS:-0}" != "1" ]]; then
+  if command -v npm >/dev/null 2>&1 && [[ -d backend/node_modules ]]; then
+    echo "Verifying ${SPEC_EXPORT} is freshly generated from ${SPEC_SOURCE}…"
+    if ! ( cd backend && npm run --silent openapi:export ); then
+      echo "✗ Failed to regenerate ${SPEC_EXPORT} (npm run openapi:export errored)."
+      exit 1
+    fi
+    if ! git diff --quiet -- "${SPEC_EXPORT}"; then
+      echo "✗ ${SPEC_EXPORT} is out of date with ${SPEC_SOURCE}."
+      echo "  Run: cd backend && npm run openapi:export   then commit the regenerated file."
+      git --no-pager diff --stat -- "${SPEC_EXPORT}" || true
+      exit 1
+    fi
+    echo "✓ ${SPEC_EXPORT} is fresh."
+  else
+    echo "… Backend dependencies not installed; skipping OpenAPI freshness regeneration."
+    echo "  Verify locally with: cd backend && npm ci && npm run spec:check"
+    echo "  (CI installs deps so the 'Generated Artifact Guard' job runs this check.)"
   fi
 fi
 

--- a/scripts/health-smoke.sh
+++ b/scripts/health-smoke.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# health-smoke.sh
+#
+# Portable health smoke test. Probes the backend's key operational surfaces and
+# prints an easy-to-read pass/fail summary. Use it after a deploy or during
+# triage against local, staging, or production.
+#
+# Usage:
+#   scripts/health-smoke.sh [target]
+#
+#   target   One of: local | staging | prod, or a full base URL
+#            (e.g. https://api.example.com). Defaults to "local".
+#
+# Environment overrides (base URLs per target):
+#   SMOKE_LOCAL_URL     default: http://localhost:3001
+#   SMOKE_STAGING_URL   (required when target=staging and no URL is given)
+#   SMOKE_PROD_URL      (required when target=prod and no URL is given)
+#   SMOKE_TIMEOUT       per-request timeout in seconds (default: 10)
+#
+# Examples:
+#   scripts/health-smoke.sh                      # probe local
+#   scripts/health-smoke.sh staging              # probe SMOKE_STAGING_URL
+#   scripts/health-smoke.sh https://api.host     # probe an explicit URL
+#
+# Exit code 0 when all REQUIRED checks pass, 1 otherwise. Non-required checks
+# (readiness, metrics) report a warning instead of failing the run, because they
+# can be legitimately degraded (e.g. readiness is 503 until Redis/workers are up).
+
+set -uo pipefail
+
+TARGET="${1:-local}"
+TIMEOUT="${SMOKE_TIMEOUT:-10}"
+
+# Resolve the base URL from the target argument.
+case "${TARGET}" in
+  local)
+    BASE_URL="${SMOKE_LOCAL_URL:-http://localhost:3001}"
+    ;;
+  staging)
+    BASE_URL="${SMOKE_STAGING_URL:-}"
+    if [[ -z "${BASE_URL}" ]]; then
+      echo "✗ target 'staging' selected but SMOKE_STAGING_URL is not set." >&2
+      exit 1
+    fi
+    ;;
+  prod|production)
+    BASE_URL="${SMOKE_PROD_URL:-}"
+    if [[ -z "${BASE_URL}" ]]; then
+      echo "✗ target 'prod' selected but SMOKE_PROD_URL is not set." >&2
+      exit 1
+    fi
+    ;;
+  http://*|https://*)
+    BASE_URL="${TARGET}"
+    ;;
+  *)
+    echo "✗ unknown target '${TARGET}'. Use: local | staging | prod | <base URL>" >&2
+    exit 1
+    ;;
+esac
+
+# Strip any trailing slash so path concatenation is clean.
+BASE_URL="${BASE_URL%/}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "✗ curl is required but was not found on PATH." >&2
+  exit 1
+fi
+
+# Checks are defined as parallel arrays (bash 3.2 compatible — no associative
+# arrays). Keep the indexes aligned across all five arrays.
+#   NAME      human-readable label
+#   PATH      request path appended to BASE_URL
+#   EXPECT    expected HTTP status code
+#   REQUIRED  "true" → a failure fails the whole run; "false" → warning only
+#   MATCH     optional substring that must appear in the response body
+CHECK_NAMES=(  "liveness"     "api-health"   "readiness" "metrics"  )
+CHECK_PATHS=(  "/health"      "/api/health"  "/ready"    "/metrics" )
+CHECK_EXPECT=( "200"          "200"          "200"       "200"      )
+CHECK_REQUIRED=( "true"       "true"         "false"     "false"    )
+CHECK_MATCH=(  "ok"           "status"       ""          ""         )
+
+echo "Health smoke test → ${BASE_URL}  (target: ${TARGET}, timeout: ${TIMEOUT}s)"
+echo "-------------------------------------------------------------------------"
+
+pass_count=0
+fail_count=0
+warn_count=0
+body_file="$(mktemp 2>/dev/null || echo /tmp/health-smoke-body.$$)"
+trap 'rm -f "${body_file}"' EXIT
+
+i=0
+while [[ ${i} -lt ${#CHECK_NAMES[@]} ]]; do
+  name="${CHECK_NAMES[$i]}"
+  path="${CHECK_PATHS[$i]}"
+  expect="${CHECK_EXPECT[$i]}"
+  required="${CHECK_REQUIRED[$i]}"
+  match="${CHECK_MATCH[$i]}"
+  url="${BASE_URL}${path}"
+
+  # Capture status code and total time; body goes to a temp file for matching.
+  metrics="$(curl -sS -o "${body_file}" -w '%{http_code} %{time_total}' \
+    --max-time "${TIMEOUT}" "${url}" 2>/dev/null)"
+  curl_rc=$?
+
+  if [[ ${curl_rc} -ne 0 ]]; then
+    status="000"
+    elapsed="-"
+  else
+    status="${metrics%% *}"
+    elapsed="${metrics##* }s"
+  fi
+
+  reason=""
+  ok=true
+  if [[ "${status}" != "${expect}" ]]; then
+    ok=false
+    reason="expected HTTP ${expect}, got ${status}"
+  elif [[ -n "${match}" ]] && ! grep -qi -- "${match}" "${body_file}" 2>/dev/null; then
+    ok=false
+    reason="body did not contain '${match}'"
+  fi
+
+  if [[ "${ok}" == "true" ]]; then
+    printf '  \xE2\x9C\x93 %-11s %-13s %s (%s)\n' "${name}" "${path}" "${status}" "${elapsed}"
+    pass_count=$((pass_count + 1))
+  elif [[ "${required}" == "true" ]]; then
+    printf '  \xE2\x9C\x97 %-11s %-13s FAIL — %s\n' "${name}" "${path}" "${reason}"
+    fail_count=$((fail_count + 1))
+  else
+    printf '  \xE2\x9A\xA0 %-11s %-13s WARN — %s\n' "${name}" "${path}" "${reason}"
+    warn_count=$((warn_count + 1))
+  fi
+
+  i=$((i + 1))
+done
+
+echo "-------------------------------------------------------------------------"
+echo "Summary: ${pass_count} passed, ${fail_count} failed, ${warn_count} warning(s)"
+
+if [[ ${fail_count} -ne 0 ]]; then
+  echo "✗ Health smoke test FAILED for ${BASE_URL}"
+  exit 1
+fi
+
+echo "✓ Health smoke test passed for ${BASE_URL}"
+exit 0


### PR DESCRIPTION
## Summary

Bundles four DevOps / Stellar Wave improvements to the CI and operational tooling. Each change is a self-contained commit.

- **CI: enforce Conventional Commits on PRs** (Closes #554) — adds `scripts/check-commit-messages.sh` (also runnable locally) and a "Commit message lint" job to the Lint workflow that validates the PR commit range. Keeps release-notes automation reliable.
- **CI: shard backend tests** (Closes #555) — splits the backend Vitest suite into 4 parallel shards via native `--shard`, each emitting a coverage blob; a `backend-coverage` job merges blobs and enforces thresholds against the full suite. The OpenAPI contract check is extracted into its own job so it runs once. Adds `test:shard` / `test:merge-coverage` scripts.
- **feat: portable health smoke script** (Closes #559) — `scripts/health-smoke.sh` (`npm run smoke`) probes `/health`, `/api/health`, `/ready`, and `/metrics` against `local | staging | prod | <url>` with a clear pass/fail/warning summary. Required liveness/api-health failures exit non-zero; readiness/metrics are advisory.
- **CI: verify generated docs/artifacts are fresh** (Closes #564) — replaces a fragile heuristic (referenced a non-existent spec path) in `scripts/check-generated-artifacts.sh` with a real regenerate-and-diff freshness check for `backend/openapi.json`, wired into the Generated Artifact Guard workflow. Still blocks committed runtime artifacts.

## Testing

- `scripts/check-commit-messages.sh`, `scripts/health-smoke.sh`, and `scripts/check-generated-artifacts.sh` validated with `bash -n` and run locally (bash 3.2 compatible).
- Workflow YAML validated by parse.
- Docs updated: CONTRIBUTING.md, OPERATIONS.md, API.md, backend/docs/openapi.md, and CHANGELOG.md.

Closes #554
Closes #555
Closes #559
Closes #564


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health smoke test script and npm command for validating operational endpoints

* **CI/CD**
  * Backend tests now execute in parallel shards with merged coverage reporting
  * Commit message linting enforces Conventional Commits format
  * Generated artifact guard validates OpenAPI specification freshness

* **Documentation**
  * Documented operational endpoints (health, readiness, metrics)
  * Added contribution guidance for test sharding and commit conventions
  * Added operations documentation for health smoke testing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-portfolio-rebalancer/pull/690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->