### PR TITLE
feat(ui): link capability warnings to actionable docs (#495)

### DIFF
--- a/frontend/src/components/BackendCapabilitiesBanner.test.tsx
+++ b/frontend/src/components/BackendCapabilitiesBanner.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import BackendCapabilitiesBanner from './BackendCapabilitiesBanner'
+import type { CapabilityNotice } from '../hooks/useReadinessReport'
+
+afterEach(cleanup)
+
+const defaultProps = { loadError: false, loading: false, belowRealtimeBar: false }
+
+function notice(id: string, kind: CapabilityNotice['kind'] = 'disabled', text = 'Some issue.'): CapabilityNotice {
+    return { id, kind, text }
+}
+
+describe('BackendCapabilitiesBanner', () => {
+    it('renders nothing when no notices and no error', () => {
+        const { container } = render(<BackendCapabilitiesBanner {...defaultProps} notices={[]} />)
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('renders load-error message when loadError is true and no notices', () => {
+        render(<BackendCapabilitiesBanner {...defaultProps} loadError notices={[]} />)
+        expect(screen.getByRole('status')).toHaveTextContent(/could not load backend service status/i)
+    })
+
+    it('renders notice text', () => {
+        render(<BackendCapabilitiesBanner {...defaultProps} notices={[notice('database', 'limited', 'DB is down.')]} />)
+        expect(screen.getByText(/DB is down\./)).toBeInTheDocument()
+    })
+
+    it('attaches a doc link for database notice', () => {
+        render(<BackendCapabilitiesBanner {...defaultProps} notices={[notice('database', 'limited')]} />)
+        const link = screen.getByRole('link', { name: /database setup/i })
+        expect(link).toHaveAttribute('href', expect.stringContaining('#database-setup'))
+        expect(link).toHaveAttribute('target', '_blank')
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('attaches a doc link for queue-workers notice', () => {
+        render(<BackendCapabilitiesBanner {...defaultProps} notices={[notice('queue-workers')]} />)
+        const link = screen.getByRole('link', { name: /redis \/ worker setup/i })
+        expect(link).toHaveAttribute('href', expect.stringContaining('CONTRIBUTING'))
+    })
+
+    it('attaches a doc link for indexer notice', () => {
+        render(<BackendCapabilitiesBanner {...defaultProps} notices={[notice('indexer')]} />)
+        const link = screen.getByRole('link', { name: /environment setup/i })
+        expect(link).toHaveAttribute('href', expect.stringContaining('ENVIRONMENT'))
+    })
+
+    it('attaches a doc link for auto-rebalancer notice', () => {
+        render(<BackendCapabilitiesBanner {...defaultProps} notices={[notice('auto-rebalancer')]} />)
+        const link = screen.getByRole('link', { name: /environment setup/i })
+        expect(link).toBeInTheDocument()
+    })
+
+    it('renders multiple notices each with their own link', () => {
+        const notices = [notice('database', 'limited'), notice('queue-workers')]
+        const { container } = render(<BackendCapabilitiesBanner {...defaultProps} notices={notices} />)
+        const banner = container.querySelector('[role="status"]')!
+        expect(within(banner as HTMLElement).getByRole('link', { name: /database setup/i })).toBeInTheDocument()
+        expect(within(banner as HTMLElement).getByRole('link', { name: /redis \/ worker setup/i })).toBeInTheDocument()
+    })
+
+    it('applies top-14 class when belowRealtimeBar is true', () => {
+        render(<BackendCapabilitiesBanner {...defaultProps} notices={[notice('database', 'limited')]} belowRealtimeBar />)
+        expect(screen.getByRole('status').className).toContain('top-14')
+    })
+
+    it('applies top-0 class when belowRealtimeBar is false', () => {
+        render(<BackendCapabilitiesBanner {...defaultProps} notices={[notice('database', 'limited')]} />)
+        expect(screen.getByRole('status').className).toContain('top-0')
+    })
+
+    it('uses amber styling when any notice is limited', () => {
+        render(<BackendCapabilitiesBanner {...defaultProps} notices={[notice('database', 'limited')]} />)
+        expect(screen.getByRole('status').className).toContain('amber')
+    })
+
+    it('uses slate styling when all notices are disabled', () => {
+        render(<BackendCapabilitiesBanner {...defaultProps} notices={[notice('queue-workers', 'disabled')]} />)
+        expect(screen.getByRole('status').className).not.toContain('amber')
+    })
+})

--- a/frontend/src/components/BackendCapabilitiesBanner.tsx
+++ b/frontend/src/components/BackendCapabilitiesBanner.tsx
@@ -1,4 +1,4 @@
-import { Info, AlertTriangle } from 'lucide-react'
+import { Info, AlertTriangle, ExternalLink } from 'lucide-react'
 import type { CapabilityNotice } from '../hooks/useReadinessReport'
 
 type Props = {
@@ -6,6 +6,38 @@ type Props = {
     loadError: boolean
     loading: boolean
     belowRealtimeBar: boolean
+}
+
+interface NoticeHint {
+    label: string
+    href: string
+}
+
+const NOTICE_HINTS: Record<string, NoticeHint> = {
+    database: {
+        label: 'Database setup',
+        href: 'https://github.com/ritik4ever/stellar-portfolio-rebalancer#database-setup',
+    },
+    'queue-workers': {
+        label: 'Redis / worker setup',
+        href: 'https://github.com/ritik4ever/stellar-portfolio-rebalancer/blob/main/docs/CONTRIBUTING.md',
+    },
+    queue: {
+        label: 'Redis / worker setup',
+        href: 'https://github.com/ritik4ever/stellar-portfolio-rebalancer/blob/main/docs/CONTRIBUTING.md',
+    },
+    workers: {
+        label: 'Redis / worker setup',
+        href: 'https://github.com/ritik4ever/stellar-portfolio-rebalancer/blob/main/docs/CONTRIBUTING.md',
+    },
+    indexer: {
+        label: 'Environment setup',
+        href: 'https://github.com/ritik4ever/stellar-portfolio-rebalancer/blob/main/docs/ENVIRONMENT.md',
+    },
+    'auto-rebalancer': {
+        label: 'Environment setup',
+        href: 'https://github.com/ritik4ever/stellar-portfolio-rebalancer/blob/main/docs/ENVIRONMENT.md',
+    },
 }
 
 export default function BackendCapabilitiesBanner({ notices, loadError, loading, belowRealtimeBar }: Props) {
@@ -57,16 +89,35 @@ export default function BackendCapabilitiesBanner({ notices, loadError, loading,
                         : 'A few optional backend features are turned off for this environment. Nothing is wrong with your wallet — this is expected when Redis, workers, or certain flags are not enabled.'}
                 </p>
                 <ul className="space-y-1.5 leading-snug">
-                    {notices.map((n) => (
-                        <li key={n.id} className="flex gap-2">
-                            {n.kind === 'limited' ? (
-                                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 opacity-80" aria-hidden />
-                            ) : (
-                                <Info className="mt-0.5 h-4 w-4 shrink-0 opacity-80" aria-hidden />
-                            )}
-                            <span>{n.text}</span>
-                        </li>
-                    ))}
+                    {notices.map((n) => {
+                        const hint = NOTICE_HINTS[n.id]
+                        return (
+                            <li key={n.id} className="flex gap-2">
+                                {n.kind === 'limited' ? (
+                                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 opacity-80" aria-hidden />
+                                ) : (
+                                    <Info className="mt-0.5 h-4 w-4 shrink-0 opacity-80" aria-hidden />
+                                )}
+                                <span>
+                                    {n.text}
+                                    {hint && (
+                                        <>
+                                            {' '}
+                                            <a
+                                                href={hint.href}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="inline-flex items-center gap-0.5 underline underline-offset-2 hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-current"
+                                            >
+                                                {hint.label}
+                                                <ExternalLink className="h-3 w-3" aria-hidden />
+                                            </a>
+                                        </>
+                                    )}
+                                </span>
+                            </li>
+                        )
+                    })}
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Closes #495

---

closes#495
- Add NOTICE_HINTS map in BackendCapabilitiesBanner with per-notice doc links for database, queue-workers, queue, workers, indexer, and auto-rebalancer notices
- Render an inline anchor with ExternalLink icon after each notice text, pointing to the relevant README section or docs file
- Links open in a new tab with rel=noopener noreferrer and include focus-visible ring for keyboard accessibility
- Add BackendCapabilitiesBanner.test.tsx with 12 tests covering link presence, href/target/rel attributes, amber vs slate styling, and belowRealtimeBar positioning