### PR TITLE
Capture optional notification unsubscribe reason

### DIFF
--- a/backend/src/api/notifications.routes.ts
+++ b/backend/src/api/notifications.routes.ts
@@ -103,9 +103,11 @@ notificationsRouter.delete('/notifications/unsubscribe', requireJwtWhenEnabled, 
             return fail(res, 400, 'VALIDATION_ERROR', 'userId query parameter is required')
         }
 
+        const unsubscribeReason = typeof req.query.reason === 'string' ? req.query.reason.trim() : undefined
+
         notificationService.unsubscribe(userId)
 
-        logger.info('User unsubscribed from notifications', { userId })
+        logger.info('User unsubscribed from notifications', { userId, reason: unsubscribeReason || undefined })
 
         return ok(res, { message: 'Successfully unsubscribed from all notifications' })
     } catch (error) {

--- a/backend/src/api/validation.ts
+++ b/backend/src/api/validation.ts
@@ -122,7 +122,8 @@ export { notificationEventsSchema };
 export const notificationSubscribeSchema = notificationPreferencesSchema;
 
 export const notificationQuerySchema = z.object({
-    userId: z.string().min(1, 'userId query parameter is required').optional()
+    userId: z.string().min(1, 'userId query parameter is required').optional(),
+    reason: z.string().trim().max(280, 'Reason must be 280 characters or fewer').optional()
 });
 
 // ─── Admin asset schemas ──────────────────────────────────────────────────────

--- a/frontend/src/components/NotificationPreferences.test.tsx
+++ b/frontend/src/components/NotificationPreferences.test.tsx
@@ -12,6 +12,19 @@ function renderWithQuery(ui: React.ReactElement) {
     return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
 }
 
+const enabledPreferences = {
+    emailEnabled: true,
+    emailAddress: 'user@example.com',
+    webhookEnabled: true,
+    webhookUrl: 'https://example.com/webhook',
+    events: {
+        rebalance: true,
+        circuitBreaker: true,
+        priceMovement: true,
+        riskChange: true,
+    },
+}
+
 describe('NotificationPreferences', () => {
     beforeEach(() => {
         cleanup()
@@ -128,5 +141,76 @@ describe('NotificationPreferences', () => {
         expect(saveBtn.disabled).toBe(true)
         fireEvent.click(saveBtn)
         expect(postSpy).not.toHaveBeenCalled()
+    })
+
+    it('shows an optional reason step before unsubscribing', async () => {
+        vi.spyOn(api, 'get').mockResolvedValue({ preferences: enabledPreferences } as any)
+        vi.spyOn(api, 'delete').mockResolvedValue({ success: true } as any)
+
+        renderWithQuery(<NotificationPreferences userId="user-1" />)
+        expect(await screen.findByText('Notifications')).toBeTruthy()
+
+        fireEvent.click(screen.getByRole('button', { name: /unsubscribe from all/i }))
+
+        expect(screen.getByRole('dialog', { name: /before you unsubscribe/i })).toBeTruthy()
+        expect(screen.getByLabelText(/reason \(optional\)/i)).toBeTruthy()
+        expect(screen.getByRole('button', { name: /skip and unsubscribe/i })).toBeTruthy()
+    })
+
+    it('skips the optional reason and unsubscribes with the original request', async () => {
+        vi.spyOn(api, 'get').mockResolvedValue({ preferences: enabledPreferences } as any)
+        const deleteSpy = vi.spyOn(api, 'delete').mockResolvedValue({ success: true } as any)
+
+        renderWithQuery(<NotificationPreferences userId="user-1" />)
+        expect(await screen.findByText('Notifications')).toBeTruthy()
+
+        fireEvent.click(screen.getByRole('button', { name: /unsubscribe from all/i }))
+        fireEvent.change(screen.getByLabelText(/reason \(optional\)/i), {
+            target: { value: 'Too frequent' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: /skip and unsubscribe/i }))
+
+        await waitFor(() => {
+            expect(deleteSpy).toHaveBeenCalledWith(ENDPOINTS.NOTIFICATIONS_UNSUBSCRIBE('user-1'))
+        })
+        expect(await screen.findByText(/preferences saved successfully/i)).toBeTruthy()
+    })
+
+    it('submits a trimmed optional reason when provided', async () => {
+        vi.spyOn(api, 'get').mockResolvedValue({ preferences: enabledPreferences } as any)
+        const deleteSpy = vi.spyOn(api, 'delete').mockResolvedValue({ success: true } as any)
+
+        renderWithQuery(<NotificationPreferences userId="user-1" />)
+        expect(await screen.findByText('Notifications')).toBeTruthy()
+
+        fireEvent.click(screen.getByRole('button', { name: /unsubscribe from all/i }))
+        fireEvent.change(screen.getByLabelText(/reason \(optional\)/i), {
+            target: { value: ' Too many alerts ' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: /^unsubscribe$/i }))
+
+        await waitFor(() => {
+            expect(deleteSpy).toHaveBeenCalledWith(
+                ENDPOINTS.NOTIFICATIONS_UNSUBSCRIBE('user-1', 'Too many alerts')
+            )
+        })
+    })
+
+    it('keeps the reason step open when unsubscribe fails', async () => {
+        vi.spyOn(api, 'get').mockResolvedValue({ preferences: enabledPreferences } as any)
+        vi.spyOn(api, 'delete').mockRejectedValue(new Error('Network unavailable'))
+
+        renderWithQuery(<NotificationPreferences userId="user-1" />)
+        expect(await screen.findByText('Notifications')).toBeTruthy()
+
+        fireEvent.click(screen.getByRole('button', { name: /unsubscribe from all/i }))
+        fireEvent.change(screen.getByLabelText(/reason \(optional\)/i), {
+            target: { value: 'Not useful right now' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: /^unsubscribe$/i }))
+
+        expect(await screen.findByText(/network unavailable/i)).toBeTruthy()
+        expect(screen.getByRole('dialog', { name: /before you unsubscribe/i })).toBeTruthy()
+        expect(screen.getByDisplayValue(/not useful right now/i)).toBeTruthy()
     })
 })

--- a/frontend/src/components/NotificationPreferences.tsx
+++ b/frontend/src/components/NotificationPreferences.tsx
@@ -39,6 +39,8 @@ const NotificationPreferences: React.FC<NotificationPreferencesProps> = ({ userI
     const [webhookError, setWebhookError] = useState<string | null>(null)
     const [emailError, setEmailError] = useState<string | null>(null)
     const [exporting, setExporting] = useState<'json' | 'csv' | 'pdf' | null>(null)
+    const [showUnsubscribeReason, setShowUnsubscribeReason] = useState(false)
+    const [unsubscribeReason, setUnsubscribeReason] = useState('')
 
     const saving = saveMutation.isPending || unsubscribeMutation.isPending
 
@@ -129,15 +131,30 @@ const NotificationPreferences: React.FC<NotificationPreferencesProps> = ({ userI
         }
     }
 
-    const handleUnsubscribe = async () => {
-        if (!confirm('Are you sure you want to unsubscribe from all notifications?')) {
+    const handleUnsubscribeClick = () => {
+        setShowUnsubscribeReason(true)
+        setError(null)
+        setSaveSuccess(false)
+    }
+
+    const handleCancelUnsubscribe = () => {
+        setShowUnsubscribeReason(false)
+        setUnsubscribeReason('')
+        setError(null)
+    }
+
+    const handleUnsubscribe = async (includeReason: boolean) => {
+        if (saving) {
             return
         }
 
         setError(null)
+        setSaveSuccess(false)
+
+        const reason = includeReason ? unsubscribeReason.trim() : undefined
 
         try {
-            await unsubscribeMutation.mutateAsync()
+            await unsubscribeMutation.mutateAsync(reason)
 
             setPreferences(prev => ({
                 ...prev,
@@ -153,6 +170,8 @@ const NotificationPreferences: React.FC<NotificationPreferencesProps> = ({ userI
                       }
                     : null
             )
+            setShowUnsubscribeReason(false)
+            setUnsubscribeReason('')
 
             setSaveSuccess(true)
             setTimeout(() => setSaveSuccess(false), 3000)
@@ -485,10 +504,72 @@ const NotificationPreferences: React.FC<NotificationPreferencesProps> = ({ userI
             </div>
 
             {/* Action Buttons */}
-            <div className="flex items-center justify-between pt-4 border-t border-gray-200">
+            {showUnsubscribeReason && (
+                <div
+                    role="dialog"
+                    aria-labelledby="unsubscribe-reason-title"
+                    className="mb-4 p-4 border border-red-200 rounded-lg bg-red-50"
+                >
+                    <div className="flex items-start justify-between gap-3 mb-3">
+                        <div>
+                            <h3 id="unsubscribe-reason-title" className="text-sm font-semibold text-red-900">
+                                Before you unsubscribe
+                            </h3>
+                            <p className="mt-1 text-sm text-red-800">
+                                Sharing why is optional and helps us improve notifications.
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={handleCancelUnsubscribe}
+                            disabled={saving}
+                            className="text-sm font-medium text-red-700 hover:text-red-900 disabled:text-gray-400"
+                        >
+                            Cancel
+                        </button>
+                    </div>
+
+                    <label htmlFor="unsubscribe-reason" className="block text-sm font-medium text-red-900 mb-1">
+                        Reason (optional)
+                    </label>
+                    <textarea
+                        id="unsubscribe-reason"
+                        value={unsubscribeReason}
+                        onChange={(e) => setUnsubscribeReason(e.target.value.slice(0, 280))}
+                        rows={3}
+                        maxLength={280}
+                        disabled={saving}
+                        placeholder="Too many notifications, not relevant, or another reason"
+                        className="w-full px-3 py-2 border border-red-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 disabled:bg-gray-100"
+                    />
+                    <div className="mt-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                        <span className="text-xs text-red-700">{unsubscribeReason.length}/280</span>
+                        <div className="flex flex-col sm:flex-row gap-2">
+                            <button
+                                type="button"
+                                onClick={() => handleUnsubscribe(false)}
+                                disabled={saving}
+                                className="px-4 py-2 text-sm font-medium border border-red-200 rounded-lg text-red-700 hover:bg-red-100 disabled:text-gray-400 disabled:cursor-not-allowed"
+                            >
+                                Skip and unsubscribe
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => handleUnsubscribe(true)}
+                                disabled={saving}
+                                className="px-4 py-2 text-sm font-medium bg-red-600 hover:bg-red-700 disabled:bg-gray-300 disabled:cursor-not-allowed text-white rounded-lg"
+                            >
+                                {saving ? 'Unsubscribing...' : 'Unsubscribe'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 pt-4 border-t border-gray-200">
                 <button
-                    onClick={handleUnsubscribe}
-                    disabled={saving || (!preferences.emailEnabled && !preferences.webhookEnabled)}
+                    onClick={handleUnsubscribeClick}
+                    disabled={saving || showUnsubscribeReason || (!preferences.emailEnabled && !preferences.webhookEnabled)}
                     className="text-sm text-red-600 hover:text-red-700 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors"
                 >
                     Unsubscribe from all

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -153,8 +153,14 @@ export const API_CONFIG = {
         RISK_CHECK: (portfolioId: string) => `${API_RESOURCE_ROOT}/risk/check/${portfolioId}`,
         NOTIFICATIONS_PREFERENCES: `${API_RESOURCE_ROOT}/notifications/preferences`,
         NOTIFICATIONS_SUBSCRIBE: `${API_RESOURCE_ROOT}/notifications/subscribe`,
-        NOTIFICATIONS_UNSUBSCRIBE: (userId: string) =>
-            `${API_RESOURCE_ROOT}/notifications/unsubscribe?userId=${encodeURIComponent(userId)}`,
+        NOTIFICATIONS_UNSUBSCRIBE: (userId: string, reason?: string) => {
+            const params = new URLSearchParams({ userId })
+            const trimmedReason = reason?.trim()
+            if (trimmedReason) {
+                params.set('reason', trimmedReason)
+            }
+            return `${API_RESOURCE_ROOT}/notifications/unsubscribe?${params.toString()}`
+        },
         NOTIFICATIONS_TEST: `${API_RESOURCE_ROOT}/notifications/test`,
         NOTIFICATIONS_TEST_ALL: `${API_RESOURCE_ROOT}/notifications/test-all`,
         TEST_CORS: '/test/cors',

--- a/frontend/src/hooks/mutations/useNotificationMutations.test.tsx
+++ b/frontend/src/hooks/mutations/useNotificationMutations.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { api } from '../../config/api'
+import { api, ENDPOINTS } from '../../config/api'
 import {
     useSaveNotificationPreferencesMutation,
     useUnsubscribeNotificationsMutation,
@@ -65,9 +65,27 @@ describe('useNotificationMutations', () => {
         })
 
         await act(async () => {
-            await result.current.mutateAsync()
+            await result.current.mutateAsync(undefined)
         })
 
         expect(spy).toHaveBeenCalledWith({ queryKey: notificationKeys.preferences(userId) })
+    })
+
+    it('includes an optional unsubscribe reason when provided', async () => {
+        const qc = createTestClient()
+        const deleteSpy = vi.spyOn(api, 'delete').mockResolvedValue({ ok: true })
+        const userId = 'GUSER789'
+
+        const { result } = renderHook(() => useUnsubscribeNotificationsMutation(userId), {
+            wrapper: withClient(qc),
+        })
+
+        await act(async () => {
+            await result.current.mutateAsync(' Too many alerts ')
+        })
+
+        expect(deleteSpy).toHaveBeenCalledWith(
+            ENDPOINTS.NOTIFICATIONS_UNSUBSCRIBE(userId, 'Too many alerts')
+        )
     })
 })

--- a/frontend/src/hooks/mutations/useNotificationMutations.ts
+++ b/frontend/src/hooks/mutations/useNotificationMutations.ts
@@ -22,7 +22,10 @@ export function useUnsubscribeNotificationsMutation(userId: string) {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: () => api.delete(ENDPOINTS.NOTIFICATIONS_UNSUBSCRIBE(userId)),
+        mutationFn: (reason?: string) => {
+            const trimmedReason = reason?.trim()
+            return api.delete(ENDPOINTS.NOTIFICATIONS_UNSUBSCRIBE(userId, trimmedReason))
+        },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: notificationKeys.preferences(userId) })
         },


### PR DESCRIPTION
Added an optional unsubscribe reason step to notification preferences. Users now see a skippable inline prompt before unsubscribing, can provide a short reason, or skip and unsubscribe immediately.

Updated the unsubscribe mutation/API URL to send the optional reason, allowed the backend to accept and log it, and added tests for showing the prompt, skipping, submitting a reason, and handling unsubscribe failures.

closes #523 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When unsubscribing from notifications, users can now optionally provide a reason for their decision (up to 280 characters). The reason field is optional and can be skipped.

* **Tests**
  * Added comprehensive test coverage for the unsubscribe flow with optional reason functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->