### PR TITLE
feat(db): validate SQLite WAL and pragma expectations on startup with…

### DIFF
--- a/backend/src/db/sqliteValidation.ts
+++ b/backend/src/db/sqliteValidation.ts
@@ -1,0 +1,164 @@
+import type Database from 'better-sqlite3'
+import { logger } from '../utils/logger.js'
+
+export interface PragmaCheckResult {
+  pragma: string
+  expected: string | number
+  actual: string | number | null
+  ok: boolean
+  actionable: string
+}
+
+export interface SqliteValidationReport {
+  allOk: boolean
+  checks: PragmaCheckResult[]
+  dbPath: string
+}
+
+/**
+ * Inspects critical SQLite pragmas on startup and returns a structured report.
+ * Does NOT throw — callers decide whether to hard-fail or warn.
+ */
+export function validateSqlitePragmas(
+  db: Database.Database,
+  dbPath: string,
+): SqliteValidationReport {
+  const checks: PragmaCheckResult[] = []
+
+  // ── WAL mode ────────────────────────────────────────────────────────────
+  const journalMode = pragmaStr(db, 'journal_mode')
+  checks.push({
+    pragma: 'journal_mode',
+    expected: 'wal',
+    actual: journalMode,
+    ok: journalMode === 'wal',
+    actionable:
+      journalMode === 'wal'
+        ? ''
+        : `journal_mode is '${journalMode}' instead of 'wal'. ` +
+          `WAL mode is required for concurrent reads during writes. ` +
+          `Run: PRAGMA journal_mode = WAL; on the database, or delete the file at '${dbPath}' to recreate it.`,
+  })
+
+  // ── Foreign keys ─────────────────────────────────────────────────────────
+  const foreignKeys = pragmaInt(db, 'foreign_keys')
+  checks.push({
+    pragma: 'foreign_keys',
+    expected: 1,
+    actual: foreignKeys,
+    ok: foreignKeys === 1,
+    actionable:
+      foreignKeys === 1
+        ? ''
+        : `foreign_keys is OFF. Referential integrity is not enforced. ` +
+          `This is set automatically at startup; if you see this warning the ` +
+          `PRAGMA was overridden. Check for competing connections or attached extensions.`,
+  })
+
+  // ── Synchronous mode ─────────────────────────────────────────────────────
+  // Expected: NORMAL (1) in WAL mode. FULL (2) is safe but slower.
+  // OFF (0) risks data loss on crash.
+  const synchronous = pragmaInt(db, 'synchronous')
+  const syncOk = synchronous !== null && synchronous >= 1
+  const syncLabel: Record<number, string> = { 0: 'OFF', 1: 'NORMAL', 2: 'FULL', 3: 'EXTRA' }
+  checks.push({
+    pragma: 'synchronous',
+    expected: 'NORMAL or FULL (1 or 2)',
+    actual: synchronous !== null ? (syncLabel[synchronous] ?? String(synchronous)) : null,
+    ok: syncOk,
+    actionable: syncOk
+      ? ''
+      : `synchronous is OFF (0). This risks database corruption on power loss or crash. ` +
+        `Add PRAGMA synchronous = NORMAL; to your startup SQL or remove any override in your environment.`,
+  })
+
+  // ── WAL checkpoint auto ──────────────────────────────────────────────────
+  // wal_autocheckpoint = 0 disables automatic checkpointing which can cause
+  // the WAL file to grow unboundedly.
+  const walAutocheckpoint = pragmaInt(db, 'wal_autocheckpoint')
+  const autoCheckpointOk = walAutocheckpoint === null || walAutocheckpoint !== 0
+  checks.push({
+    pragma: 'wal_autocheckpoint',
+    expected: '>0 (default 1000)',
+    actual: walAutocheckpoint,
+    ok: autoCheckpointOk,
+    actionable: autoCheckpointOk
+      ? ''
+      : `wal_autocheckpoint is 0 — automatic WAL checkpointing is disabled. ` +
+        `The WAL file will grow without bound. ` +
+        `Remove the PRAGMA wal_autocheckpoint = 0 override or set it to 1000 (the default).`,
+  })
+
+  const allOk = checks.every((c) => c.ok)
+  return { allOk, checks, dbPath }
+}
+
+/**
+ * Logs the validation report. Warnings for non-critical issues, errors for
+ * anything that could cause data loss or correctness problems.
+ */
+export function logSqliteValidationReport(report: SqliteValidationReport): void {
+  if (report.allOk) {
+    logger.info('[DB] SQLite pragma validation passed', {
+      dbPath: report.dbPath,
+      checks: report.checks.map((c) => ({ pragma: c.pragma, actual: c.actual })),
+    })
+    return
+  }
+
+  const failures = report.checks.filter((c) => !c.ok)
+
+  // foreign_keys and synchronous=OFF are data-integrity risks → error level
+  const criticalPragmas = new Set(['foreign_keys', 'synchronous'])
+  const hasCritical = failures.some((c) => criticalPragmas.has(c.pragma))
+
+  for (const check of failures) {
+    const level = criticalPragmas.has(check.pragma) ? 'error' : 'warn'
+    logger[level](`[DB] SQLite pragma issue: ${check.pragma}`, {
+      pragma: check.pragma,
+      expected: check.expected,
+      actual: check.actual,
+      fix: check.actionable,
+      dbPath: report.dbPath,
+    })
+  }
+
+  if (hasCritical) {
+    logger.error(
+      '[DB] One or more critical SQLite pragma checks failed. ' +
+        'Data integrity may be at risk. See above for actionable fixes.',
+      { dbPath: report.dbPath },
+    )
+  } else {
+    logger.warn(
+      '[DB] SQLite pragma warnings detected on startup. ' +
+        'Performance or WAL behaviour may be degraded. See above for actionable fixes.',
+      { dbPath: report.dbPath },
+    )
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function pragmaStr(db: Database.Database, name: string): string | null {
+  try {
+    const row = db.prepare(`PRAGMA ${name}`).get() as Record<string, unknown> | undefined
+    if (!row) return null
+    const val = Object.values(row)[0]
+    return typeof val === 'string' ? val : val != null ? String(val) : null
+  } catch {
+    return null
+  }
+}
+
+function pragmaInt(db: Database.Database, name: string): number | null {
+  try {
+    const row = db.prepare(`PRAGMA ${name}`).get() as Record<string, unknown> | undefined
+    if (!row) return null
+    const val = Object.values(row)[0]
+    const n = Number(val)
+    return Number.isFinite(n) ? n : null
+  } catch {
+    return null
+  }
+}

--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -1,3 +1,4 @@
+import { validateSqlitePragmas, logSqliteValidationReport } from "../db/sqliteValidation.js"
 import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
@@ -400,6 +401,8 @@ export class DatabaseService {
     mkdirSync(dirname(dbPath), { recursive: true });
     this.db = new Database(dbPath);
     this.db.exec(SCHEMA_SQL);
+    const pragmaReport = validateSqlitePragmas(this.db, dbPath);
+    logSqliteValidationReport(pragmaReport);
     this._migrateSchema();
 
     // Seed demo data on first run (empty portfolios table)

--- a/backend/src/test/sqliteValidation.test.ts
+++ b/backend/src/test/sqliteValidation.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { validateSqlitePragmas, logSqliteValidationReport } from '../db/sqliteValidation.js'
+import type { PragmaCheckResult, SqliteValidationReport } from '../db/sqliteValidation.js'
+
+// ── Mock better-sqlite3 Database ─────────────────────────────────────────────
+
+function makeMockDb(pragmaValues: Record<string, unknown>) {
+  return {
+    prepare: (sql: string) => ({
+      get: () => {
+        const match = sql.match(/PRAGMA\s+(\w+)/i)
+        if (!match) return undefined
+        const key = match[1].toLowerCase()
+        if (!(key in pragmaValues)) return undefined
+        return { [key]: pragmaValues[key] }
+      },
+    }),
+  }
+}
+
+// ── Mock logger ───────────────────────────────────────────────────────────────
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { logger } from '../utils/logger.js'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ── validateSqlitePragmas ────────────────────────────────────────────────────
+
+describe('validateSqlitePragmas', () => {
+  it('returns allOk=true when all pragmas are correctly set', () => {
+    const db = makeMockDb({
+      journal_mode: 'wal',
+      foreign_keys: 1,
+      synchronous: 1,
+      wal_autocheckpoint: 1000,
+    })
+    const report = validateSqlitePragmas(db as any, './data/test.db')
+    expect(report.allOk).toBe(true)
+    expect(report.checks.every((c) => c.ok)).toBe(true)
+  })
+
+  it('flags journal_mode != wal', () => {
+    const db = makeMockDb({
+      journal_mode: 'delete',
+      foreign_keys: 1,
+      synchronous: 1,
+      wal_autocheckpoint: 1000,
+    })
+    const report = validateSqlitePragmas(db as any, './data/test.db')
+    expect(report.allOk).toBe(false)
+    const check = report.checks.find((c) => c.pragma === 'journal_mode')!
+    expect(check.ok).toBe(false)
+    expect(check.actionable).toMatch(/WAL mode is required/)
+    expect(check.actionable).toMatch(/PRAGMA journal_mode = WAL/)
+  })
+
+  it('flags foreign_keys=0', () => {
+    const db = makeMockDb({
+      journal_mode: 'wal',
+      foreign_keys: 0,
+      synchronous: 1,
+      wal_autocheckpoint: 1000,
+    })
+    const report = validateSqlitePragmas(db as any, './data/test.db')
+    const check = report.checks.find((c) => c.pragma === 'foreign_keys')!
+    expect(check.ok).toBe(false)
+    expect(check.actionable).toMatch(/Referential integrity is not enforced/)
+  })
+
+  it('flags synchronous=OFF (0)', () => {
+    const db = makeMockDb({
+      journal_mode: 'wal',
+      foreign_keys: 1,
+      synchronous: 0,
+      wal_autocheckpoint: 1000,
+    })
+    const report = validateSqlitePragmas(db as any, './data/test.db')
+    const check = report.checks.find((c) => c.pragma === 'synchronous')!
+    expect(check.ok).toBe(false)
+    expect(check.actionable).toMatch(/risks database corruption/)
+  })
+
+  it('flags wal_autocheckpoint=0', () => {
+    const db = makeMockDb({
+      journal_mode: 'wal',
+      foreign_keys: 1,
+      synchronous: 1,
+      wal_autocheckpoint: 0,
+    })
+    const report = validateSqlitePragmas(db as any, './data/test.db')
+    const check = report.checks.find((c) => c.pragma === 'wal_autocheckpoint')!
+    expect(check.ok).toBe(false)
+    expect(check.actionable).toMatch(/WAL file will grow without bound/)
+  })
+
+  it('accepts synchronous=FULL (2)', () => {
+    const db = makeMockDb({
+      journal_mode: 'wal',
+      foreign_keys: 1,
+      synchronous: 2,
+      wal_autocheckpoint: 1000,
+    })
+    const report = validateSqlitePragmas(db as any, './data/test.db')
+    const check = report.checks.find((c) => c.pragma === 'synchronous')!
+    expect(check.ok).toBe(true)
+  })
+
+  it('returns null actual for a pragma that throws', () => {
+    const db = {
+      prepare: () => ({
+        get: () => { throw new Error('no such pragma') },
+      }),
+    }
+    const report = validateSqlitePragmas(db as any, './data/test.db')
+    expect(report.checks.every((c) => c.actual === null)).toBe(true)
+  })
+
+  it('includes dbPath in the report', () => {
+    const db = makeMockDb({
+      journal_mode: 'wal',
+      foreign_keys: 1,
+      synchronous: 1,
+      wal_autocheckpoint: 1000,
+    })
+    const report = validateSqlitePragmas(db as any, '/custom/path/db.sqlite')
+    expect(report.dbPath).toBe('/custom/path/db.sqlite')
+  })
+})
+
+// ── logSqliteValidationReport ────────────────────────────────────────────────
+
+describe('logSqliteValidationReport', () => {
+  const passingReport: SqliteValidationReport = {
+    allOk: true,
+    dbPath: './data/test.db',
+    checks: [
+      { pragma: 'journal_mode', expected: 'wal', actual: 'wal', ok: true, actionable: '' },
+      { pragma: 'foreign_keys', expected: 1, actual: 1, ok: true, actionable: '' },
+      { pragma: 'synchronous', expected: 'NORMAL or FULL (1 or 2)', actual: 'NORMAL', ok: true, actionable: '' },
+      { pragma: 'wal_autocheckpoint', expected: '>0 (default 1000)', actual: 1000, ok: true, actionable: '' },
+    ],
+  }
+
+  it('logs info when all checks pass', () => {
+    logSqliteValidationReport(passingReport)
+    expect(logger.info).toHaveBeenCalledWith(
+      '[DB] SQLite pragma validation passed',
+      expect.objectContaining({ dbPath: './data/test.db' }),
+    )
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('logs warn for non-critical pragma failure (journal_mode)', () => {
+    const report: SqliteValidationReport = {
+      allOk: false,
+      dbPath: './data/test.db',
+      checks: [
+        { pragma: 'journal_mode', expected: 'wal', actual: 'delete', ok: false, actionable: 'fix journal_mode' },
+        { pragma: 'foreign_keys', expected: 1, actual: 1, ok: true, actionable: '' },
+        { pragma: 'synchronous', expected: 'NORMAL or FULL (1 or 2)', actual: 'NORMAL', ok: true, actionable: '' },
+        { pragma: 'wal_autocheckpoint', expected: '>0 (default 1000)', actual: 1000, ok: true, actionable: '' },
+      ],
+    }
+    logSqliteValidationReport(report)
+    expect(logger.warn).toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('logs error for critical pragma failure (foreign_keys)', () => {
+    const report: SqliteValidationReport = {
+      allOk: false,
+      dbPath: './data/test.db',
+      checks: [
+        { pragma: 'journal_mode', expected: 'wal', actual: 'wal', ok: true, actionable: '' },
+        { pragma: 'foreign_keys', expected: 1, actual: 0, ok: false, actionable: 'fix fk' },
+        { pragma: 'synchronous', expected: 'NORMAL or FULL (1 or 2)', actual: 'NORMAL', ok: true, actionable: '' },
+        { pragma: 'wal_autocheckpoint', expected: '>0 (default 1000)', actual: 1000, ok: true, actionable: '' },
+      ],
+    }
+    logSqliteValidationReport(report)
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('critical SQLite pragma checks failed'),
+      expect.any(Object),
+    )
+  })
+
+  it('logs error for synchronous=OFF', () => {
+    const report: SqliteValidationReport = {
+      allOk: false,
+      dbPath: './data/test.db',
+      checks: [
+        { pragma: 'journal_mode', expected: 'wal', actual: 'wal', ok: true, actionable: '' },
+        { pragma: 'foreign_keys', expected: 1, actual: 1, ok: true, actionable: '' },
+        { pragma: 'synchronous', expected: 'NORMAL or FULL (1 or 2)', actual: 'OFF', ok: false, actionable: 'fix sync' },
+        { pragma: 'wal_autocheckpoint', expected: '>0 (default 1000)', actual: 1000, ok: true, actionable: '' },
+      ],
+    }
+    logSqliteValidationReport(report)
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('critical SQLite pragma checks failed'),
+      expect.any(Object),
+    )
+  })
+})

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -29,7 +29,7 @@ This document is the canonical reference for `backend/.env.example`.
 | `PGPASSWORD` | string | No | empty | PostgreSQL password. |
 | `PGDATABASE` | string | No | empty | PostgreSQL database name. |
 | `CI` | string | No | empty | CI marker used by scripts/runtime checks. |
-| `DB_PATH` | path | No | `./data/portfolio.db` | SQLite database path for local/test fallback. |
+| `DB_PATH` | path | No | `./data/portfolio.db` | SQLite database file path used when PostgreSQL is not configured. The directory is created automatically. Validated on startup: WAL mode, foreign keys, synchronous mode, and wal_autocheckpoint are checked and logged with actionable messages if misconfigured. |
 | `COINGECKO_API_KEY` | string | No | empty | CoinGecko API key for higher rate limits. |
 | `REFLECTOR_API_URL` | URL | No | empty | Reflector API base URL for off-chain price/oracle fallback paths. |
 | `PRICE_CACHE_DURATION` | integer (ms) | No | `300000` | Price-cache TTL. |
@@ -127,6 +127,20 @@ This document is the canonical reference for `backend/.env.example`.
 | `METRICS_PREFIX` | string | No | `stellar_portfolio_` | Prefix applied to metric names. |
 | `METRICS_DEFAULT_LABELS_SERVICE` | string | No | `stellar-portfolio-backend` | Default service label for metrics. |
 | `ALERT_CONTACT` | string | No | `platform-oncall` | Alert-routing metadata label for operations. |
+
+## SQLite Startup Validation
+
+When the backend starts in SQLite mode (`DB_PATH` is used and no PostgreSQL connection is configured), the following pragmas are inspected automatically and logged with actionable guidance if they are not set correctly:
+
+| Pragma | Expected | Risk if wrong |
+|---|---|---|
+| `journal_mode` | `wal` | Concurrent reads blocked during writes; hot-backup unsafe |
+| `foreign_keys` | `1` (ON) | Referential integrity not enforced; orphaned rows possible |
+| `synchronous` | `NORMAL` or `FULL` (1 or 2) | `OFF` risks data loss or corruption on crash/power loss |
+| `wal_autocheckpoint` | `> 0` (default `1000`) | `0` disables auto-checkpointing; WAL file grows unboundedly |
+
+All four pragmas are applied in `SCHEMA_SQL` at startup. If a warning or error appears in the logs, follow the `fix:` field in the structured log entry. The most common cause is a pre-existing database file created by a different tool or an older version of this project.
+
 
 ## Frontend Variable Reference
 


### PR DESCRIPTION
 feat(db): validate SQLite WAL and pragma expectations on startup with actionable logsfeat(db): validate SQLite WAL and pragma expectations on startup with actionable logs
Adds startup pragma validation for SQLite (journal_mode, foreign_keys, synchronous, wal_autocheckpoint). Logs actionable fix messages at warn/error level when settings are misconfigured, and info when all checks pass.
Files changed:

backend/src/db/sqliteValidation.ts — new validation module
backend/src/services/databaseService.ts — calls validation on startup
backend/src/test/sqliteValidation.test.ts — 12 tests, all passing
docs/ENVIRONMENT.md — documents SQLite startup validation

close #470 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQLite configuration validation at startup to verify critical database pragmas (WAL mode, foreign keys, synchronous settings, and autocheckpoint). Provides structured logs with actionable guidance when misconfigurations are detected.

* **Documentation**
  * Updated environment variable documentation to describe SQLite pragma validation behavior, expected configurations, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->