### PR TITLE
Add backup verification to destructive maintenance operations

### DIFF
--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -417,6 +417,43 @@ export class DatabaseService {
     logger.info("[DB] SQLite database ready", { dbPath });
   }
 
+  // ─────────────────────────────────────────────
+  // Backup verification (high‑risk operations)
+  // ─────────────────────────────────────────────
+
+  /**
+   * Checks whether a recent usable backup exists.
+   * The implementation looks for a KV entry `backup_last_success` and ensures it
+   * is within the configured TTL (default 24 hours). Adjust the logic to match
+   * your actual backup service.
+   */
+  private verifyBackupExists(): void {
+    try {
+      const row = this.db
+        .prepare<[string]>("SELECT value FROM kv_store WHERE key = ?")
+        .get("backup_last_success") as { value: string } | undefined;
+      if (!row) {
+        throw new BackupVerificationError(
+          "No backup record found; a recent backup is required before performing this operation.",
+        );
+      }
+      const timestamp = new Date(row.value).getTime();
+      const now = Date.now();
+      const ttlMs = 24 * 60 * 60 * 1000; // 24 hours
+      if (now - timestamp > ttlMs) {
+        throw new BackupVerificationError(
+          "Backup is older than 24 hours; please create a fresh backup before proceeding.",
+        );
+      }
+    } catch (err) {
+      if (err instanceof BackupVerificationError) throw err;
+      // If the KV table does not exist or query fails, treat as missing backup
+      throw new BackupVerificationError(
+        `Backup verification failed: ${err}`,
+      );
+    }
+  }
+
   private _migrateSchema(): void {
     const cols = this.db
       .prepare("PRAGMA table_info(portfolios)")
@@ -748,6 +785,8 @@ export class DatabaseService {
   }
 
   deletePortfolio(id: string): boolean {
+    // Verify a recent backup before destructive delete
+    this.verifyBackupExists();
     try {
       const result = this.db
         .prepare("DELETE FROM portfolios WHERE id = ?")
@@ -875,6 +914,8 @@ export class DatabaseService {
   }
 
   removeAsset(symbol: string): boolean {
+    // Verify a recent backup before destructive asset removal
+    this.verifyBackupExists();
     try {
       const result = this.db
         .prepare("DELETE FROM assets WHERE symbol = ?")

--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -5,7 +5,7 @@ import { randomUUID } from "node:crypto";
 import type { RebalanceEvent } from "./rebalanceHistory.js";
 import { getFeatureFlags } from "../config/featureFlags.js";
 import { logger } from "../utils/logger.js";
-import { ConflictError } from "../types/index.js";
+import { ConflictError, BackupVerificationError } from "../types/index.js";
 import type { Portfolio } from "../types/index.js";
 import { AssetRegistryConflictError } from "./assetRegistryValidation.js";
 
@@ -1103,6 +1103,8 @@ export class DatabaseService {
   }
 
   deleteUserData(userId: string): void {
+    // Verify a recent backup before destructive user data deletion
+    this.verifyBackupExists();
     this.db.prepare("DELETE FROM legal_consent WHERE user_id = ?").run(userId);
     this.db.prepare("DELETE FROM consent_audit_events WHERE user_id = ?").run(userId);
     const portfolios = this.db
@@ -1122,6 +1124,8 @@ export class DatabaseService {
   }
 
   clearAll(): void {
+    // Verify a recent backup before clearing all database tables
+    this.verifyBackupExists();
     try {
       this.db.prepare("DELETE FROM rebalance_history").run();
       this.db.prepare("DELETE FROM portfolios").run();
@@ -1412,6 +1416,8 @@ export class DatabaseService {
   }
 
   clearHistory(portfolioId?: string): void {
+    // Verify a recent backup before clearing rebalance history
+    this.verifyBackupExists();
     try {
       if (portfolioId) {
         this.db

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -95,6 +95,15 @@ export class ConflictError extends Error {
     }
 }
 
+// Thrown when a destructive database operation lacks a recent backup
+export class BackupVerificationError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'BackupVerificationError'
+    }
+}
+
+
 // Rebalance event interface
 export interface RebalanceEvent {
     id: string


### PR DESCRIPTION
This pr closes #462


This PR integrates backup verification checks for all remaining destructive database maintenance operations in the backend to prevent accidental data loss.

High-risk operations now invoke a private helper method `verifyBackupExists()` which queries the SQLite `kv_store` table for a `backup_last_success` entry and enforces a strict 24-hour TTL (Time-to-Live) requirement.

### Key Changes
1. **Defined BackupVerificationError**: Added a new custom error class in `backend/src/types/index.ts` to represent backup validation failures.
2. **Guarded Destructive Operations**: Integrated `verifyBackupExists()` checks at the beginning of the following methods in `backend/src/services/databaseService.ts`:
   - `clearAll()`
   - `clearHistory(portfolioId?: string)`
   - `deleteUserData(userId: string)`
   - `deletePortfolio(id: string)` (validated)
   - `removeAsset(symbol: string)` (validated)

## Impact
- **Safety**: Guaranteed that no major destructive actions can take place in production without a verified, up-to-date backup.
- **Robustness**: Prevents data loss scenarios during administrative and maintenance tasks.

.