### PR TITLE
feat: propagate-correlation-ids-to-workers

### DIFF
--- a/backend/src/monitoring/rebalancer.ts
+++ b/backend/src/monitoring/rebalancer.ts
@@ -1,203 +1,248 @@
-import { WebSocketServer } from 'ws'
-import { StellarService } from '../services/stellar.js'
-import { ReflectorService } from '../services/reflector.js'
-import { rebalanceHistoryService, riskManagementService } from '../services/serviceContainer.js'
-import { portfolioStorage } from '../services/portfolioStorage.js'
-import { getPortfolioCheckQueue } from '../queue/queues.js'
-import { logger } from '../utils/logger.js'
-import { recordAnomaly, getAnomalySummary, resetAnomalyCounts } from './anomalyTracker.js'
-import type { Portfolio, RiskAlert } from '../types/index.js'
+import { WebSocketServer } from "ws";
+import { StellarService } from "../services/stellar.js";
+import { ReflectorService } from "../services/reflector.js";
+import {
+  rebalanceHistoryService,
+  riskManagementService,
+} from "../services/serviceContainer.js";
+import { portfolioStorage } from "../services/portfolioStorage.js";
+import { getPortfolioCheckQueue } from "../queue/queues.js";
+import { getRequestId } from "../utils/requestContext.js";
+import { randomUUID } from "node:crypto";
+import { logger } from "../utils/logger.js";
+import {
+  recordAnomaly,
+  getAnomalySummary,
+  resetAnomalyCounts,
+} from "./anomalyTracker.js";
+import type { Portfolio, RiskAlert } from "../types/index.js";
 
 export class RebalancingService {
-    private stellarService: StellarService
-    private reflectorService: ReflectorService
-    private wss: WebSocketServer
+  private stellarService: StellarService;
+  private reflectorService: ReflectorService;
+  private wss: WebSocketServer;
 
-    constructor(wss: WebSocketServer) {
-        this.stellarService = new StellarService()
-        this.reflectorService = new ReflectorService()
-        this.wss = wss
+  constructor(wss: WebSocketServer) {
+    this.stellarService = new StellarService();
+    this.reflectorService = new ReflectorService();
+    this.wss = wss;
+  }
+
+  /**
+   * Start the monitoring service.
+   * Recurring portfolio checks and risk metric updates are now handled by
+   * the BullMQ portfolio-check worker. This method sets up WebSocket
+   * broadcasting hooks only.
+   *
+   * NOTE: node-cron schedules have been removed – replaced by the queue
+   * scheduler in src/queue/scheduler.ts.
+   */
+  start() {
+    logger.info(
+      "[REBALANCING-SERVICE] Monitoring service started (queue-backed). WebSocket broadcasting active.",
+    );
+  }
+
+  /**
+   * Record an anomaly occurrence for operational monitoring.
+   * Delegates to the shared anomaly tracker so ops routes can also record.
+   */
+  recordAnomaly(
+    type:
+      | "risk_alert"
+      | "rebalance_block"
+      | "price_feed_anomaly"
+      | "circuit_breaker_trigger",
+    severity?: "critical" | "warning" | "info",
+  ): void {
+    recordAnomaly(type, severity);
+  }
+
+  /**
+   * Get the current anomaly summary for ops dashboards.
+   */
+  getAnomalySummary() {
+    return getAnomalySummary();
+  }
+
+  /**
+   * Reset all anomaly counters.
+   */
+  resetAnomalyCounts(): void {
+    resetAnomalyCounts();
+  }
+
+  /**
+   * Manually check a specific portfolio and broadcast results via WebSocket.
+   */
+  async forceCheckPortfolio(portfolioId: string): Promise<any> {
+    try {
+      await this.checkPortfolioForRebalancing(portfolioId);
+      return { success: true, message: "Portfolio check completed" };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger.error(`Force check failed for portfolio ${portfolioId}:`, {
+        error: errorMessage,
+      });
+      return { success: false, error: errorMessage };
     }
+  }
 
-    /**
-     * Start the monitoring service.
-     * Recurring portfolio checks and risk metric updates are now handled by
-     * the BullMQ portfolio-check worker. This method sets up WebSocket
-     * broadcasting hooks only.
-     *
-     * NOTE: node-cron schedules have been removed – replaced by the queue
-     * scheduler in src/queue/scheduler.ts.
-     */
-    start() {
-        logger.info('[REBALANCING-SERVICE] Monitoring service started (queue-backed). WebSocket broadcasting active.')
-    }
+  async getStatus(): Promise<any> {
+    const stats = await rebalanceHistoryService.getHistoryStats();
+    const circuitBreakers = riskManagementService.getCircuitBreakerStatus();
+    const active = await this.getActivePortfolios();
+    return {
+      activePortfolios: active.length,
+      rebalanceHistory: stats,
+      circuitBreakers,
+      riskManagement: { enabled: true, lastUpdate: new Date().toISOString() },
+      anomalySummary: this.getAnomalySummary(),
+    };
+  }
 
-    /**
-     * Record an anomaly occurrence for operational monitoring.
-     * Delegates to the shared anomaly tracker so ops routes can also record.
-     */
-    recordAnomaly(type: 'risk_alert' | 'rebalance_block' | 'price_feed_anomaly' | 'circuit_breaker_trigger', severity?: 'critical' | 'warning' | 'info'): void {
-        recordAnomaly(type, severity)
-    }
+  // ─── Internal helpers (used by forceCheckPortfolio) ──────────────────────
 
-    /**
-     * Get the current anomaly summary for ops dashboards.
-     */
-    getAnomalySummary() {
-        return getAnomalySummary()
-    }
+  private async checkPortfolioForRebalancing(portfolioId: string) {
+    try {
+      const prices = await this.reflectorService.getCurrentPrices();
+      const portfolio = await this.stellarService.getPortfolio(portfolioId);
 
-    /**
-     * Reset all anomaly counters.
-     */
-    resetAnomalyCounts(): void {
-        resetAnomalyCounts()
-    }
+      const riskAlerts = riskManagementService.updatePriceData(prices);
+      const needsRebalance =
+        await this.stellarService.checkRebalanceNeeded(portfolioId);
 
-    /**
-     * Manually check a specific portfolio and broadcast results via WebSocket.
-     */
-    async forceCheckPortfolio(portfolioId: string): Promise<any> {
-        try {
-            await this.checkPortfolioForRebalancing(portfolioId)
-            return { success: true, message: 'Portfolio check completed' }
-        } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error)
-            logger.error(`Force check failed for portfolio ${portfolioId}:`, { error: errorMessage })
-            return { success: false, error: errorMessage }
+      if (needsRebalance) {
+        logger.info(
+          `Portfolio ${portfolioId} needs rebalancing – enqueueing job`,
+        );
+
+        // Use the stored portfolio (Record<string, number> allocations) for risk checks,
+        // NOT the UI response from stellarService.getPortfolio() which has an array shape.
+        const storedPortfolio =
+          await portfolioStorage.getPortfolio(portfolioId);
+        if (!storedPortfolio) {
+          logger.warn(
+            `Portfolio ${portfolioId} not found in storage during risk check`,
+          );
+          return;
         }
-    }
+        const riskCheck = riskManagementService.shouldAllowRebalance(
+          storedPortfolio,
+          prices,
+        );
 
-    async getStatus(): Promise<any> {
-        const stats = await rebalanceHistoryService.getHistoryStats()
-        const circuitBreakers = riskManagementService.getCircuitBreakerStatus()
-        const active = await this.getActivePortfolios()
-        return {
-            activePortfolios: active.length,
-            rebalanceHistory: stats,
-            circuitBreakers,
-            riskManagement: { enabled: true, lastUpdate: new Date().toISOString() },
-            anomalySummary: this.getAnomalySummary(),
+        if (!riskCheck.allowed) {
+          this.recordAnomaly("rebalance_block");
         }
-    }
 
-    // ─── Internal helpers (used by forceCheckPortfolio) ──────────────────────
+        if (riskCheck.allowed) {
+          // Enqueue a rebalance job rather than executing inline
+          const queue = getPortfolioCheckQueue();
+          if (queue) {
+            await queue.add(
+              `manual-check-${portfolioId}`,
+              {
+                triggeredBy: "manual",
+                correlationId: getRequestId() || randomUUID(),
+              },
+              { priority: 1 },
+            );
+            this.notifyClients(portfolioId, "rebalance_queued", {
+              message: "Rebalance job enqueued",
+            });
+          }
+        } else {
+          logger.warn(
+            `Rebalancing blocked for ${portfolioId}: ${riskCheck.reason}`,
+          );
+          this.notifyClients(portfolioId, "rebalance_blocked", {
+            message: "Rebalancing temporarily blocked by safety systems",
+            reason: riskCheck.reason,
+            alerts: riskCheck.alerts,
+          });
 
-    private async checkPortfolioForRebalancing(portfolioId: string) {
-        try {
-            const prices = await this.reflectorService.getCurrentPrices()
-            const portfolio = await this.stellarService.getPortfolio(portfolioId)
-
-            const riskAlerts = riskManagementService.updatePriceData(prices)
-            const needsRebalance = await this.stellarService.checkRebalanceNeeded(portfolioId)
-
-            if (needsRebalance) {
-                logger.info(`Portfolio ${portfolioId} needs rebalancing – enqueueing job`)
-
-                // Use the stored portfolio (Record<string, number> allocations) for risk checks,
-                // NOT the UI response from stellarService.getPortfolio() which has an array shape.
-                const storedPortfolio = await portfolioStorage.getPortfolio(portfolioId)
-                if (!storedPortfolio) {
-                    logger.warn(`Portfolio ${portfolioId} not found in storage during risk check`)
-                    return
-                }
-                const riskCheck = riskManagementService.shouldAllowRebalance(storedPortfolio, prices)
-
-                if (!riskCheck.allowed) {
-                    this.recordAnomaly('rebalance_block')
-                }
-
-                if (riskCheck.allowed) {
-                    // Enqueue a rebalance job rather than executing inline
-                    const queue = getPortfolioCheckQueue()
-                    if (queue) {
-                        await queue.add(
-                            `manual-check-${portfolioId}`,
-                            { triggeredBy: 'manual' },
-                            { priority: 1 }
-                        )
-                        this.notifyClients(portfolioId, 'rebalance_queued', {
-                            message: 'Rebalance job enqueued',
-                        })
-                    }
-                } else {
-                    logger.warn(`Rebalancing blocked for ${portfolioId}: ${riskCheck.reason}`)
-                    this.notifyClients(portfolioId, 'rebalance_blocked', {
-                        message: 'Rebalancing temporarily blocked by safety systems',
-                        reason: riskCheck.reason,
-                        alerts: riskCheck.alerts,
-                    })
-
-                    await rebalanceHistoryService.recordRebalanceEvent({
-                        portfolioId,
-                        trigger: 'Automatic Check – Blocked',
-                        trades: 0,
-                        gasUsed: '0 XLM',
-                        status: 'failed',
-                        prices,
-                        portfolio: storedPortfolio,
-                    })
-                }
-            }
-
-            if (riskAlerts.length > 0) {
-                const criticalAlerts = riskAlerts.filter((a: RiskAlert) => a.severity === 'critical')
-                const warningAlerts = riskAlerts.filter((a: RiskAlert) => a.severity === 'warning')
-                if (criticalAlerts.length > 0) {
-                    this.notifyClients(portfolioId, 'risk_alert', {
-                        message: 'Critical risk conditions detected',
-                        alerts: criticalAlerts,
-                    })
-                    this.recordAnomaly('risk_alert', 'critical')
-                }
-                if (warningAlerts.length > 0) {
-                    this.recordAnomaly('risk_alert', 'warning')
-                }
-            }
-        } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error)
-            logger.error(`Failed to check portfolio ${portfolioId} for rebalancing:`, {
-                error: errorMessage,
-                portfolioId,
-            })
-        }
-    }
-
-    private async getActivePortfolios(): Promise<Array<{ id: string; autoRebalance: boolean }>> {
-        const allPortfolios = await portfolioStorage.getAllPortfolios()
-        return allPortfolios
-            .filter((p: Portfolio) => p.threshold > 0)
-            .map((p: Portfolio) => ({ id: p.id, autoRebalance: true }))
-    }
-
-    private notifyClients(portfolioId: string, event: string, data: any = {}) {
-        const message = JSON.stringify({
-            type: 'portfolio_update',
+          await rebalanceHistoryService.recordRebalanceEvent({
             portfolioId,
-            event,
-            data,
-            timestamp: new Date().toISOString(),
-        })
+            trigger: "Automatic Check – Blocked",
+            trades: 0,
+            gasUsed: "0 XLM",
+            status: "failed",
+            prices,
+            portfolio: storedPortfolio,
+          });
+        }
+      }
 
-        this.wss.clients.forEach(client => {
-            if (client.readyState === 1) client.send(message)
-        })
-
-        logger.info(`Notification sent: ${event} for portfolio ${portfolioId}`)
+      if (riskAlerts.length > 0) {
+        const criticalAlerts = riskAlerts.filter(
+          (a: RiskAlert) => a.severity === "critical",
+        );
+        const warningAlerts = riskAlerts.filter(
+          (a: RiskAlert) => a.severity === "warning",
+        );
+        if (criticalAlerts.length > 0) {
+          this.notifyClients(portfolioId, "risk_alert", {
+            message: "Critical risk conditions detected",
+            alerts: criticalAlerts,
+          });
+          this.recordAnomaly("risk_alert", "critical");
+        }
+        if (warningAlerts.length > 0) {
+          this.recordAnomaly("risk_alert", "warning");
+        }
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger.error(
+        `Failed to check portfolio ${portfolioId} for rebalancing:`,
+        {
+          error: errorMessage,
+          portfolioId,
+        },
+      );
     }
+  }
 
-    private broadcastToAllClients(event: string, data: any = {}) {
-        const message = JSON.stringify({
-            type: 'market_update',
-            event,
-            data,
-            timestamp: new Date().toISOString(),
-        })
+  private async getActivePortfolios(): Promise<
+    Array<{ id: string; autoRebalance: boolean }>
+  > {
+    const allPortfolios = await portfolioStorage.getAllPortfolios();
+    return allPortfolios
+      .filter((p: Portfolio) => p.threshold > 0)
+      .map((p: Portfolio) => ({ id: p.id, autoRebalance: true }));
+  }
 
-        this.wss.clients.forEach(client => {
-            if (client.readyState === 1) client.send(message)
-        })
+  private notifyClients(portfolioId: string, event: string, data: any = {}) {
+    const message = JSON.stringify({
+      type: "portfolio_update",
+      portfolioId,
+      event,
+      data,
+      timestamp: new Date().toISOString(),
+    });
 
-        logger.info(`Market broadcast sent: ${event}`)
-    }
+    this.wss.clients.forEach((client) => {
+      if (client.readyState === 1) client.send(message);
+    });
+
+    logger.info(`Notification sent: ${event} for portfolio ${portfolioId}`);
+  }
+
+  private broadcastToAllClients(event: string, data: any = {}) {
+    const message = JSON.stringify({
+      type: "market_update",
+      event,
+      data,
+      timestamp: new Date().toISOString(),
+    });
+
+    this.wss.clients.forEach((client) => {
+      if (client.readyState === 1) client.send(message);
+    });
+
+    logger.info(`Market broadcast sent: ${event}`);
+  }
 }

--- a/backend/src/queue/queues.ts
+++ b/backend/src/queue/queues.ts
@@ -1,140 +1,126 @@
-import { Queue } from 'bullmq'
-import { getConnectionOptions } from './connection.js'
-import { logger } from '../utils/logger.js'
-import { getRequestId } from '../utils/requestContext.js'
+import { Queue } from "bullmq";
+import { getConnectionOptions } from "./connection.js";
+import { logger } from "../utils/logger.js";
 
 export const QUEUE_NAMES = {
-    PORTFOLIO_CHECK: 'portfolio-check',
-    REBALANCE: 'rebalance',
-    ANALYTICS_SNAPSHOT: 'analytics-snapshot',
-    IDEMPOTENCY_CLEANUP: 'idempotency-cleanup',
-} as const
+  PORTFOLIO_CHECK: "portfolio-check",
+  REBALANCE: "rebalance",
+  ANALYTICS_SNAPSHOT: "analytics-snapshot",
+  IDEMPOTENCY_CLEANUP: "idempotency-cleanup",
+} as const;
 
 export interface PortfolioCheckJobData {
-    triggeredBy?: 'scheduler' | 'manual' | 'startup'
-    correlationId?: string
+  triggeredBy?: "scheduler" | "manual" | "startup";
+  correlationId?: string;
 }
 
 export interface RebalanceJobData {
-    portfolioId: string
-    triggeredBy?: 'auto' | 'manual' | 'force'
-    correlationId?: string
+  portfolioId: string;
+  triggeredBy?: "auto" | "manual" | "force";
+  correlationId?: string;
 }
 
 export interface AnalyticsSnapshotJobData {
-    triggeredBy?: 'scheduler' | 'manual' | 'startup'
-    correlationId?: string
+  triggeredBy?: "scheduler" | "manual" | "startup";
+  correlationId?: string;
 }
 
 export interface IdempotencyCleanupJobData {
-    triggeredBy?: 'scheduler' | 'manual' | 'startup'
-    correlationId?: string
-}
-
-export interface RebalanceJobData {
-    portfolioId: string
-    triggeredBy?: 'auto' | 'manual' | 'force'
-}
-
-export interface AnalyticsSnapshotJobData {
-    triggeredBy?: 'scheduler' | 'manual' | 'startup'
-}
-
-export interface IdempotencyCleanupJobData {
-    triggeredBy?: 'scheduler' | 'manual' | 'startup'
+  triggeredBy?: "scheduler" | "manual" | "startup";
+  correlationId?: string;
 }
 
 // ─── Singleton Queues ─────────────────────────────────────────────────────────
 
-let portfolioCheckQueue: Queue<PortfolioCheckJobData> | null = null
-let rebalanceQueue: Queue<RebalanceJobData> | null = null
-let analyticsSnapshotQueue: Queue<AnalyticsSnapshotJobData> | null = null
-let idempotencyCleanupQueue: Queue<IdempotencyCleanupJobData> | null = null
+let portfolioCheckQueue: Queue<PortfolioCheckJobData> | null = null;
+let rebalanceQueue: Queue<RebalanceJobData> | null = null;
+let analyticsSnapshotQueue: Queue<AnalyticsSnapshotJobData> | null = null;
+let idempotencyCleanupQueue: Queue<IdempotencyCleanupJobData> | null = null;
 
 function getDefaultJobOptions() {
-    return {
-        removeOnComplete: { count: 100 },
-        removeOnFail: { count: 200 },
-        attempts: 5,
-        backoff: {
-            type: 'exponential' as const,
-            delay: 5000, // 5s → 10s → 20s → 40s → 80s
-        },
-    }
+  return {
+    removeOnComplete: { count: 100 },
+    removeOnFail: { count: 200 },
+    attempts: 5,
+    backoff: {
+      type: "exponential" as const,
+      delay: 5000, // 5s → 10s → 20s → 40s → 80s
+    },
+  };
 }
 
 export function getPortfolioCheckQueue(): Queue<PortfolioCheckJobData> | null {
-    try {
-        if (!portfolioCheckQueue) {
-            portfolioCheckQueue = new Queue(QUEUE_NAMES.PORTFOLIO_CHECK, {
-                connection: getConnectionOptions(),
-                defaultJobOptions: getDefaultJobOptions(),
-            })
-            logger.info(`[QUEUE] Created queue: ${QUEUE_NAMES.PORTFOLIO_CHECK}`)
-        }
-        return portfolioCheckQueue
-    } catch {
-        return null
+  try {
+    if (!portfolioCheckQueue) {
+      portfolioCheckQueue = new Queue(QUEUE_NAMES.PORTFOLIO_CHECK, {
+        connection: getConnectionOptions(),
+        defaultJobOptions: getDefaultJobOptions(),
+      });
+      logger.info(`[QUEUE] Created queue: ${QUEUE_NAMES.PORTFOLIO_CHECK}`);
     }
+    return portfolioCheckQueue;
+  } catch {
+    return null;
+  }
 }
 
 export function getRebalanceQueue(): Queue<RebalanceJobData> | null {
-    try {
-        if (!rebalanceQueue) {
-            rebalanceQueue = new Queue(QUEUE_NAMES.REBALANCE, {
-                connection: getConnectionOptions(),
-                defaultJobOptions: getDefaultJobOptions(),
-            })
-            logger.info(`[QUEUE] Created queue: ${QUEUE_NAMES.REBALANCE}`)
-        }
-        return rebalanceQueue
-    } catch {
-        return null
+  try {
+    if (!rebalanceQueue) {
+      rebalanceQueue = new Queue(QUEUE_NAMES.REBALANCE, {
+        connection: getConnectionOptions(),
+        defaultJobOptions: getDefaultJobOptions(),
+      });
+      logger.info(`[QUEUE] Created queue: ${QUEUE_NAMES.REBALANCE}`);
     }
+    return rebalanceQueue;
+  } catch {
+    return null;
+  }
 }
 
 export function getAnalyticsSnapshotQueue(): Queue<AnalyticsSnapshotJobData> | null {
-    try {
-        if (!analyticsSnapshotQueue) {
-            analyticsSnapshotQueue = new Queue(QUEUE_NAMES.ANALYTICS_SNAPSHOT, {
-                connection: getConnectionOptions(),
-                defaultJobOptions: getDefaultJobOptions(),
-            })
-            logger.info(`[QUEUE] Created queue: ${QUEUE_NAMES.ANALYTICS_SNAPSHOT}`)
-        }
-        return analyticsSnapshotQueue
-    } catch {
-        return null
+  try {
+    if (!analyticsSnapshotQueue) {
+      analyticsSnapshotQueue = new Queue(QUEUE_NAMES.ANALYTICS_SNAPSHOT, {
+        connection: getConnectionOptions(),
+        defaultJobOptions: getDefaultJobOptions(),
+      });
+      logger.info(`[QUEUE] Created queue: ${QUEUE_NAMES.ANALYTICS_SNAPSHOT}`);
     }
+    return analyticsSnapshotQueue;
+  } catch {
+    return null;
+  }
 }
 
 export function getIdempotencyCleanupQueue(): Queue<IdempotencyCleanupJobData> | null {
-    try {
-        if (!idempotencyCleanupQueue) {
-            idempotencyCleanupQueue = new Queue(QUEUE_NAMES.IDEMPOTENCY_CLEANUP, {
-                connection: getConnectionOptions(),
-                defaultJobOptions: getDefaultJobOptions(),
-            })
-            logger.info(`[QUEUE] Created queue: ${QUEUE_NAMES.IDEMPOTENCY_CLEANUP}`)
-        }
-        return idempotencyCleanupQueue
-    } catch {
-        return null
+  try {
+    if (!idempotencyCleanupQueue) {
+      idempotencyCleanupQueue = new Queue(QUEUE_NAMES.IDEMPOTENCY_CLEANUP, {
+        connection: getConnectionOptions(),
+        defaultJobOptions: getDefaultJobOptions(),
+      });
+      logger.info(`[QUEUE] Created queue: ${QUEUE_NAMES.IDEMPOTENCY_CLEANUP}`);
     }
+    return idempotencyCleanupQueue;
+  } catch {
+    return null;
+  }
 }
 
 // ─── Graceful Close ───────────────────────────────────────────────────────────
 
 export async function closeAllQueues(): Promise<void> {
-    await Promise.all([
-        portfolioCheckQueue?.close(),
-        rebalanceQueue?.close(),
-        analyticsSnapshotQueue?.close(),
-        idempotencyCleanupQueue?.close(),
-    ])
-    portfolioCheckQueue = null
-    rebalanceQueue = null
-    analyticsSnapshotQueue = null
-    idempotencyCleanupQueue = null
-    logger.info('[QUEUE] All queues closed')
+  await Promise.all([
+    portfolioCheckQueue?.close(),
+    rebalanceQueue?.close(),
+    analyticsSnapshotQueue?.close(),
+    idempotencyCleanupQueue?.close(),
+  ]);
+  portfolioCheckQueue = null;
+  rebalanceQueue = null;
+  analyticsSnapshotQueue = null;
+  idempotencyCleanupQueue = null;
+  logger.info("[QUEUE] All queues closed");
 }

--- a/backend/src/queue/workers/analyticsSnapshotWorker.ts
+++ b/backend/src/queue/workers/analyticsSnapshotWorker.ts
@@ -1,22 +1,24 @@
-import { Worker, Job } from 'bullmq'
-import { getConnectionOptions } from '../connection.js'
-import { analyticsService } from '../../services/analyticsService.js'
-import { logger } from '../../utils/logger.js'
-import type { AnalyticsSnapshotJobData } from '../queues.js'
+import { Worker, Job } from "bullmq";
+import { randomUUID } from "node:crypto";
+import { runWithRequestContext } from "../../utils/requestContext.js";
+import { getConnectionOptions } from "../connection.js";
+import { analyticsService } from "../../services/analyticsService.js";
+import { logger } from "../../utils/logger.js";
+import type { AnalyticsSnapshotJobData } from "../queues.js";
 import {
-    createWorkerRuntimeStatus,
-    markWorkerFailed,
-    markWorkerJobCompleted,
-    markWorkerJobFailed,
-    markWorkerReady,
-    markWorkerStarting,
-    markWorkerStopped,
-    snapshotWorkerRuntimeStatus,
-    type WorkerRuntimeStatus,
-} from './workerRuntime.js'
+  createWorkerRuntimeStatus,
+  markWorkerFailed,
+  markWorkerJobCompleted,
+  markWorkerJobFailed,
+  markWorkerReady,
+  markWorkerStarting,
+  markWorkerStopped,
+  snapshotWorkerRuntimeStatus,
+  type WorkerRuntimeStatus,
+} from "./workerRuntime.js";
 
-let worker: Worker | null = null
-const runtimeStatus = createWorkerRuntimeStatus('analytics-snapshot', 1)
+let worker: Worker | null = null;
+const runtimeStatus = createWorkerRuntimeStatus("analytics-snapshot", 1);
 
 /**
  * Core processor: triggers a snapshot of all portfolios.
@@ -25,15 +27,21 @@ const runtimeStatus = createWorkerRuntimeStatus('analytics-snapshot', 1)
 export async function processAnalyticsSnapshotJob(
   job: Job<AnalyticsSnapshotJobData>,
 ): Promise<void> {
-  logger.info("[WORKER:analytics-snapshot] Capturing portfolio snapshots", {
-    jobId: job.id,
-    triggeredBy: job.data.triggeredBy ?? "scheduler",
-  });
+  const correlationId = (job.data as AnalyticsSnapshotJobData).correlationId;
+  const requestId = correlationId ?? randomUUID();
 
-  await analyticsService.captureAllPortfolios();
+  return runWithRequestContext({ requestId }, async () => {
+    logger.info("[WORKER:analytics-snapshot] Capturing portfolio snapshots", {
+      jobId: job.id,
+      triggeredBy: job.data.triggeredBy ?? "scheduler",
+      correlationId,
+    });
 
-  logger.info("[WORKER:analytics-snapshot] Snapshot cycle complete", {
-    jobId: job.id,
+    await analyticsService.captureAllPortfolios();
+
+    logger.info("[WORKER:analytics-snapshot] Snapshot cycle complete", {
+      jobId: job.id,
+    });
   });
 }
 
@@ -43,67 +51,72 @@ export async function processAnalyticsSnapshotJob(
 export function startAnalyticsSnapshotWorker(): Worker | null {
   if (worker) return worker;
 
-    try {
-        markWorkerStarting(runtimeStatus)
-        worker = new Worker(
-            'analytics-snapshot',
-            processAnalyticsSnapshotJob,
-            {
-                connection: getConnectionOptions(),
-                concurrency: 1,
-            }
-        )
-    } catch (err) {
-        markWorkerFailed(runtimeStatus, err)
-        logger.warn('[WORKER:analytics-snapshot] Failed to start – Redis may be unavailable', {
-            error: err instanceof Error ? err.message : String(err),
-        })
-        return null
-    }
+  try {
+    markWorkerStarting(runtimeStatus);
+    worker = new Worker("analytics-snapshot", processAnalyticsSnapshotJob, {
+      connection: getConnectionOptions(),
+      concurrency: 1,
+    });
+  } catch (err) {
+    markWorkerFailed(runtimeStatus, err);
+    logger.warn(
+      "[WORKER:analytics-snapshot] Failed to start – Redis may be unavailable",
+      {
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+    return null;
+  }
 
-    void worker.waitUntilReady()
-        .then(() => {
-            markWorkerReady(runtimeStatus)
-            logger.info('[WORKER:analytics-snapshot] Worker ready')
-        })
-        .catch((err) => {
-            markWorkerFailed(runtimeStatus, err)
-            logger.error('[WORKER:analytics-snapshot] Worker failed readiness check', {
-                error: err instanceof Error ? err.message : String(err),
-            })
-        })
-
-    worker.on('completed', (job) => {
-        markWorkerJobCompleted(runtimeStatus)
-        logger.info('[WORKER:analytics-snapshot] Job completed', { jobId: job.id })
+  void worker
+    .waitUntilReady()
+    .then(() => {
+      markWorkerReady(runtimeStatus);
+      logger.info("[WORKER:analytics-snapshot] Worker ready");
     })
+    .catch((err) => {
+      markWorkerFailed(runtimeStatus, err);
+      logger.error(
+        "[WORKER:analytics-snapshot] Worker failed readiness check",
+        {
+          error: err instanceof Error ? err.message : String(err),
+        },
+      );
+    });
 
-    worker.on('failed', (job, err) => {
-        markWorkerJobFailed(runtimeStatus, err)
-        logger.error('[WORKER:analytics-snapshot] Job failed', {
-            jobId: job?.id,
-            error: err.message,
-            attemptsMade: job?.attemptsMade,
-        })
-    })
+  worker.on("completed", (job) => {
+    markWorkerJobCompleted(runtimeStatus);
+    logger.info("[WORKER:analytics-snapshot] Job completed", { jobId: job.id });
+  });
+
+  worker.on("failed", (job, err) => {
+    markWorkerJobFailed(runtimeStatus, err);
+    logger.error("[WORKER:analytics-snapshot] Job failed", {
+      jobId: job?.id,
+      error: err.message,
+      attemptsMade: job?.attemptsMade,
+    });
+  });
 
   logger.info("[WORKER:analytics-snapshot] Worker started");
   return worker;
 }
 
 export async function stopAnalyticsSnapshotWorker(): Promise<void> {
-    if (worker) {
-        await worker.close()
-        worker = null
-        markWorkerStopped(runtimeStatus)
-        logger.info('[WORKER:analytics-snapshot] Worker stopped')
-    }
+  if (worker) {
+    await worker.close();
+    worker = null;
+    markWorkerStopped(runtimeStatus);
+    logger.info("[WORKER:analytics-snapshot] Worker stopped");
+  }
 }
 
 export function getAnalyticsSnapshotWorkerStatus(): WorkerRuntimeStatus {
-    return snapshotWorkerRuntimeStatus(runtimeStatus)
+  return snapshotWorkerRuntimeStatus(runtimeStatus);
 }
 
-export function setAnalyticsSnapshotSchedulerRegistered(registered: boolean): void {
-    runtimeStatus.schedulerRegistered = registered
+export function setAnalyticsSnapshotSchedulerRegistered(
+  registered: boolean,
+): void {
+  runtimeStatus.schedulerRegistered = registered;
 }

--- a/backend/src/queue/workers/idempotencyCleanupWorker.ts
+++ b/backend/src/queue/workers/idempotencyCleanupWorker.ts
@@ -1,110 +1,125 @@
-import { Worker, Job } from 'bullmq'
-import { getConnectionOptions } from '../connection.js'
-import { dbCleanupExpiredIdempotencyKeys } from '../../db/idempotencyDb.js'
-import { logger } from '../../utils/logger.js'
-import type { IdempotencyCleanupJobData } from '../queues.js'
+import { Worker, Job } from "bullmq";
+import { randomUUID } from "node:crypto";
+import { runWithRequestContext } from "../../utils/requestContext.js";
+import { getConnectionOptions } from "../connection.js";
+import { dbCleanupExpiredIdempotencyKeys } from "../../db/idempotencyDb.js";
+import { logger } from "../../utils/logger.js";
+import type { IdempotencyCleanupJobData } from "../queues.js";
 import {
-    createWorkerRuntimeStatus,
-    markWorkerFailed,
-    markWorkerJobCompleted,
-    markWorkerJobFailed,
-    markWorkerReady,
-    markWorkerStarting,
-    markWorkerStopped,
-    snapshotWorkerRuntimeStatus,
-    type WorkerRuntimeStatus,
-} from './workerRuntime.js'
+  createWorkerRuntimeStatus,
+  markWorkerFailed,
+  markWorkerJobCompleted,
+  markWorkerJobFailed,
+  markWorkerReady,
+  markWorkerStarting,
+  markWorkerStopped,
+  snapshotWorkerRuntimeStatus,
+  type WorkerRuntimeStatus,
+} from "./workerRuntime.js";
 
-let worker: Worker | null = null
-const runtimeStatus = createWorkerRuntimeStatus('idempotency-cleanup', 1)
+let worker: Worker | null = null;
+const runtimeStatus = createWorkerRuntimeStatus("idempotency-cleanup", 1);
 
 /**
  * Core processor: deletes expired idempotency keys from the database.
  * Extracted as a standalone function so tests can call it directly.
  */
 export async function processIdempotencyCleanupJob(
-    job: Job<IdempotencyCleanupJobData>,
+  job: Job<IdempotencyCleanupJobData>,
 ): Promise<void> {
-    logger.info('[WORKER:idempotency-cleanup] Running cleanup cycle', {
-        jobId: job.id,
-        triggeredBy: job.data.triggeredBy ?? 'scheduler',
-    })
+  const correlationId = (job.data as IdempotencyCleanupJobData).correlationId;
+  const requestId = correlationId ?? randomUUID();
 
-    const deleted = dbCleanupExpiredIdempotencyKeys()
+  return runWithRequestContext({ requestId }, async () => {
+    logger.info("[WORKER:idempotency-cleanup] Running cleanup cycle", {
+      jobId: job.id,
+      triggeredBy: job.data.triggeredBy ?? "scheduler",
+      correlationId,
+    });
 
-    logger.info('[WORKER:idempotency-cleanup] Cleanup complete', {
-        jobId: job.id,
-        expiredKeysRemoved: deleted,
-    })
+    const deleted = dbCleanupExpiredIdempotencyKeys();
+
+    logger.info("[WORKER:idempotency-cleanup] Cleanup complete", {
+      jobId: job.id,
+      expiredKeysRemoved: deleted,
+    });
+  });
 }
 
 /**
  * Starts the idempotency-cleanup BullMQ worker (singleton).
  */
 export function startIdempotencyCleanupWorker(): Worker | null {
-    if (worker) return worker
+  if (worker) return worker;
 
-    try {
-        markWorkerStarting(runtimeStatus)
-        worker = new Worker(
-            'idempotency-cleanup',
-            processIdempotencyCleanupJob,
-            {
-                connection: getConnectionOptions(),
-                concurrency: 1,
-            }
-        )
-    } catch (err) {
-        markWorkerFailed(runtimeStatus, err)
-        logger.warn('[WORKER:idempotency-cleanup] Failed to start – Redis may be unavailable', {
-            error: err instanceof Error ? err.message : String(err),
-        })
-        return null
-    }
+  try {
+    markWorkerStarting(runtimeStatus);
+    worker = new Worker("idempotency-cleanup", processIdempotencyCleanupJob, {
+      connection: getConnectionOptions(),
+      concurrency: 1,
+    });
+  } catch (err) {
+    markWorkerFailed(runtimeStatus, err);
+    logger.warn(
+      "[WORKER:idempotency-cleanup] Failed to start – Redis may be unavailable",
+      {
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+    return null;
+  }
 
-    void worker.waitUntilReady()
-        .then(() => {
-            markWorkerReady(runtimeStatus)
-            logger.info('[WORKER:idempotency-cleanup] Worker ready')
-        })
-        .catch((err) => {
-            markWorkerFailed(runtimeStatus, err)
-            logger.error('[WORKER:idempotency-cleanup] Worker failed readiness check', {
-                error: err instanceof Error ? err.message : String(err),
-            })
-        })
-
-    worker.on('completed', (job) => {
-        markWorkerJobCompleted(runtimeStatus)
-        logger.info('[WORKER:idempotency-cleanup] Job completed', { jobId: job.id })
+  void worker
+    .waitUntilReady()
+    .then(() => {
+      markWorkerReady(runtimeStatus);
+      logger.info("[WORKER:idempotency-cleanup] Worker ready");
     })
+    .catch((err) => {
+      markWorkerFailed(runtimeStatus, err);
+      logger.error(
+        "[WORKER:idempotency-cleanup] Worker failed readiness check",
+        {
+          error: err instanceof Error ? err.message : String(err),
+        },
+      );
+    });
 
-    worker.on('failed', (job, err) => {
-        markWorkerJobFailed(runtimeStatus, err)
-        logger.error('[WORKER:idempotency-cleanup] Job failed', {
-            jobId: job?.id,
-            error: err.message,
-            attemptsMade: job?.attemptsMade,
-        })
-    })
+  worker.on("completed", (job) => {
+    markWorkerJobCompleted(runtimeStatus);
+    logger.info("[WORKER:idempotency-cleanup] Job completed", {
+      jobId: job.id,
+    });
+  });
 
-    logger.info('[WORKER:idempotency-cleanup] Worker started')
-    return worker
+  worker.on("failed", (job, err) => {
+    markWorkerJobFailed(runtimeStatus, err);
+    logger.error("[WORKER:idempotency-cleanup] Job failed", {
+      jobId: job?.id,
+      error: err.message,
+      attemptsMade: job?.attemptsMade,
+    });
+  });
+
+  logger.info("[WORKER:idempotency-cleanup] Worker started");
+  return worker;
 }
 
 export async function stopIdempotencyCleanupWorker(): Promise<void> {
-    if (worker) {
-        await worker.close()
-        worker = null
-        markWorkerStopped(runtimeStatus)
-        logger.info('[WORKER:idempotency-cleanup] Worker stopped')
-    }
+  if (worker) {
+    await worker.close();
+    worker = null;
+    markWorkerStopped(runtimeStatus);
+    logger.info("[WORKER:idempotency-cleanup] Worker stopped");
+  }
 }
 
 export function getIdempotencyCleanupWorkerStatus(): WorkerRuntimeStatus {
-    return snapshotWorkerRuntimeStatus(runtimeStatus)
+  return snapshotWorkerRuntimeStatus(runtimeStatus);
 }
 
-export function setIdempotencyCleanupSchedulerRegistered(registered: boolean): void {
-    runtimeStatus.schedulerRegistered = registered
+export function setIdempotencyCleanupSchedulerRegistered(
+  registered: boolean,
+): void {
+  runtimeStatus.schedulerRegistered = registered;
 }

--- a/backend/src/queue/workers/portfolioCheckWorker.ts
+++ b/backend/src/queue/workers/portfolioCheckWorker.ts
@@ -1,5 +1,7 @@
 import type { Job } from "bullmq";
 import { Worker } from "bullmq";
+import { randomUUID } from "node:crypto";
+import { runWithRequestContext } from "../../utils/requestContext.js";
 import { portfolioStorage } from "../../services/portfolioStorage.js";
 import { StellarService } from "../../services/stellar.js";
 import { ReflectorService } from "../../services/reflector.js";
@@ -29,55 +31,64 @@ export async function processPortfolioCheckJob(
   job: Job<PortfolioCheckJobData>,
 ): Promise<void> {
   const { triggeredBy, correlationId } = job.data;
+  const requestId = correlationId ?? randomUUID();
 
-  logger.info("[WORKER:portfolio-check] Running portfolio check cycle", {
-    jobId: job.id,
-    triggeredBy,
-    correlationId,
-  });
-
-  const allPortfolios = await portfolioStorage.getAllPortfolios();
-  const portfolios = allPortfolios.filter((p) => !DEMO_PORTFOLIO_IDS.has(p.id));
-
-  if (portfolios.length === 0) {
-    return;
-  }
-
-  const reflector = new ReflectorService();
-  const prices = await reflector.getCurrentPrices();
-  const market = await CircuitBreakers.checkMarketConditions(prices);
-  if (!market.safe) {
-    logger.warn(
-      "[WORKER:portfolio-check] Skipping rebalance enqueue — market conditions unsafe",
-      {
-        jobId: job.id,
-        reason: market.reason,
-        correlationId,
-      },
-    );
-    return;
-  }
-
-  const queue = getRebalanceQueue();
-  if (!queue) {
-    logger.warn("[WORKER:portfolio-check] Rebalance queue unavailable", {
+  return runWithRequestContext({ requestId }, async () => {
+    logger.info("[WORKER:portfolio-check] Running portfolio check cycle", {
       jobId: job.id,
+      triggeredBy,
       correlationId,
     });
-    return;
-  }
 
-  const stellarService = new StellarService();
-  for (const p of portfolios) {
-    const needed = await stellarService.checkRebalanceNeeded(p.id);
-    if (!needed) continue;
-
-    await queue.add(
-      `rebalance-${p.id}`,
-      { portfolioId: p.id, triggeredBy: "auto" as const, correlationId: correlationId },
-      { removeOnComplete: true },
+    const allPortfolios = await portfolioStorage.getAllPortfolios();
+    const portfolios = allPortfolios.filter(
+      (p) => !DEMO_PORTFOLIO_IDS.has(p.id),
     );
-  }
+
+    if (portfolios.length === 0) {
+      return;
+    }
+
+    const reflector = new ReflectorService();
+    const prices = await reflector.getCurrentPrices();
+    const market = await CircuitBreakers.checkMarketConditions(prices);
+    if (!market.safe) {
+      logger.warn(
+        "[WORKER:portfolio-check] Skipping rebalance enqueue — market conditions unsafe",
+        {
+          jobId: job.id,
+          reason: market.reason,
+          correlationId,
+        },
+      );
+      return;
+    }
+
+    const queue = getRebalanceQueue();
+    if (!queue) {
+      logger.warn("[WORKER:portfolio-check] Rebalance queue unavailable", {
+        jobId: job.id,
+        correlationId,
+      });
+      return;
+    }
+
+    const stellarService = new StellarService();
+    for (const p of portfolios) {
+      const needed = await stellarService.checkRebalanceNeeded(p.id);
+      if (!needed) continue;
+
+      await queue.add(
+        `rebalance-${p.id}`,
+        {
+          portfolioId: p.id,
+          triggeredBy: "auto" as const,
+          correlationId: correlationId,
+        },
+        { removeOnComplete: true },
+      );
+    }
+  });
 }
 
 export function startPortfolioCheckWorker(): Worker | null {
@@ -91,21 +102,27 @@ export function startPortfolioCheckWorker(): Worker | null {
     });
   } catch (err) {
     markWorkerFailed(runtimeStatus, err);
-    logger.warn("[WORKER:portfolio-check] Failed to start - Redis may be unavailable", {
-      error: err instanceof Error ? err.message : String(err),
-    });
+    logger.warn(
+      "[WORKER:portfolio-check] Failed to start - Redis may be unavailable",
+      {
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
     return null;
   }
 
-  void worker.waitUntilReady().then(() => {
-    markWorkerReady(runtimeStatus);
-    logger.info("[WORKER:portfolio-check] Worker ready");
-  }).catch((err) => {
-    markWorkerFailed(runtimeStatus, err);
-    logger.error("[WORKER:portfolio-check] Worker failed readiness check", {
-      error: err instanceof Error ? err.message : String(err),
+  void worker
+    .waitUntilReady()
+    .then(() => {
+      markWorkerReady(runtimeStatus);
+      logger.info("[WORKER:portfolio-check] Worker ready");
+    })
+    .catch((err) => {
+      markWorkerFailed(runtimeStatus, err);
+      logger.error("[WORKER:portfolio-check] Worker failed readiness check", {
+        error: err instanceof Error ? err.message : String(err),
+      });
     });
-  });
 
   worker.on("completed", (j) => {
     markWorkerJobCompleted(runtimeStatus);
@@ -142,6 +159,8 @@ export function getPortfolioCheckWorkerStatus(): WorkerRuntimeStatus {
   return snapshotWorkerRuntimeStatus(runtimeStatus);
 }
 
-export function setPortfolioCheckSchedulerRegistered(registered: boolean): void {
+export function setPortfolioCheckSchedulerRegistered(
+  registered: boolean,
+): void {
   runtimeStatus.schedulerRegistered = registered;
 }

--- a/backend/src/queue/workers/rebalanceWorker.ts
+++ b/backend/src/queue/workers/rebalanceWorker.ts
@@ -1,26 +1,28 @@
-import type { Job } from 'bullmq'
-import { Worker } from 'bullmq'
-import { logger, logAudit } from '../../utils/logger.js'
-import { rebalanceLockService } from '../../services/rebalanceLock.js'
-import { StellarService } from '../../services/stellar.js'
-import { rebalanceHistoryService } from '../../services/serviceContainer.js'
-import { notificationService } from '../../services/notificationService.js'
-import { getConnectionOptions } from '../connection.js'
-import type { RebalanceJobData } from '../queues.js'
+import type { Job } from "bullmq";
+import { Worker } from "bullmq";
+import { randomUUID } from "node:crypto";
+import { runWithRequestContext } from "../../utils/requestContext.js";
+import { logger, logAudit } from "../../utils/logger.js";
+import { rebalanceLockService } from "../../services/rebalanceLock.js";
+import { StellarService } from "../../services/stellar.js";
+import { rebalanceHistoryService } from "../../services/serviceContainer.js";
+import { notificationService } from "../../services/notificationService.js";
+import { getConnectionOptions } from "../connection.js";
+import type { RebalanceJobData } from "../queues.js";
 import {
-    createWorkerRuntimeStatus,
-    markWorkerFailed,
-    markWorkerJobCompleted,
-    markWorkerJobFailed,
-    markWorkerReady,
-    markWorkerStarting,
-    markWorkerStopped,
-    snapshotWorkerRuntimeStatus,
-    type WorkerRuntimeStatus,
-} from './workerRuntime.js'
+  createWorkerRuntimeStatus,
+  markWorkerFailed,
+  markWorkerJobCompleted,
+  markWorkerJobFailed,
+  markWorkerReady,
+  markWorkerStarting,
+  markWorkerStopped,
+  snapshotWorkerRuntimeStatus,
+  type WorkerRuntimeStatus,
+} from "./workerRuntime.js";
 
-let worker: Worker | null = null
-const runtimeStatus = createWorkerRuntimeStatus('rebalance', 3)
+let worker: Worker | null = null;
+const runtimeStatus = createWorkerRuntimeStatus("rebalance", 3);
 
 /**
  * Core processor: executes a single portfolio rebalance.
@@ -30,115 +32,124 @@ export async function processRebalanceJob(
   job: Job<RebalanceJobData>,
 ): Promise<void> {
   const { portfolioId, triggeredBy, correlationId } = job.data;
+  const requestId = correlationId ?? randomUUID();
 
-  logger.info("[WORKER:rebalance] Executing rebalance", {
-    jobId: job.id,
-    portfolioId,
-    triggeredBy,
-    correlationId,
-  });
-  if (triggeredBy === "auto") {
-    logAudit("auto_rebalance_started", {
-      portfolioId,
+  return runWithRequestContext({ requestId }, async () => {
+    logger.info("[WORKER:rebalance] Executing rebalance", {
       jobId: job.id,
-    });
-  }
-
-  const lockAcquired = await rebalanceLockService.acquireLock(portfolioId);
-
-  if (!lockAcquired) {
-    logger.info("[WORKER:rebalance] Rebalance already in progress. Aborting.", {
       portfolioId,
-    });
-    return;
-  }
-
-  const stellarService = new StellarService();
-  try {
-    const portfolio = await stellarService.getPortfolio(portfolioId);
-    const rebalanceResult = await stellarService.executeRebalance(portfolioId);
-
-    await rebalanceHistoryService.recordRebalanceEvent({
-      portfolioId,
-      trigger:
-        triggeredBy === "auto" ? "Automatic Rebalancing" : "Manual Rebalancing",
-      trades: rebalanceResult.trades ?? 0,
-      gasUsed: rebalanceResult.gasUsed ?? "0 XLM",
-      status: "completed",
-      isAutomatic: triggeredBy === "auto",
-    });
-
-    try {
-      await notificationService.notify({
-        userId: portfolio.userAddress,
-        eventType: "rebalance",
-        title: "Portfolio Rebalanced",
-        message: `Your portfolio has been automatically rebalanced. ${rebalanceResult.trades ?? 0} trades executed with ${rebalanceResult.gasUsed ?? "0 XLM"} gas used.`,
-        data: {
-          portfolioId,
-          trades: rebalanceResult.trades,
-          gasUsed: rebalanceResult.gasUsed,
-          trigger: triggeredBy,
-        },
-        timestamp: new Date().toISOString(),
-      });
-    } catch (notifyErr) {
-      logger.error("[WORKER:rebalance] Notification failed (non-fatal)", {
-        portfolioId,
-        error:
-          notifyErr instanceof Error ? notifyErr.message : String(notifyErr),
-      });
-    }
-
-    logger.info("[WORKER:rebalance] Rebalance completed", {
-      portfolioId,
-      trades: rebalanceResult.trades,
+      triggeredBy,
+      correlationId,
     });
     if (triggeredBy === "auto") {
-      logAudit("auto_rebalance_completed", {
+      logAudit("auto_rebalance_started", {
         portfolioId,
         jobId: job.id,
-        trades: rebalanceResult.trades ?? 0,
-        status: "completed",
       });
     }
-  } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
 
+    const lockAcquired = await rebalanceLockService.acquireLock(portfolioId);
+
+    if (!lockAcquired) {
+      logger.info(
+        "[WORKER:rebalance] Rebalance already in progress. Aborting.",
+        {
+          portfolioId,
+        },
+      );
+      return;
+    }
+
+    const stellarService = new StellarService();
     try {
+      const portfolio = await stellarService.getPortfolio(portfolioId);
+      const rebalanceResult =
+        await stellarService.executeRebalance(portfolioId);
+
       await rebalanceHistoryService.recordRebalanceEvent({
         portfolioId,
-        trigger: `Automatic Rebalancing (Failed – attempt ${job.attemptsMade + 1})`,
-        trades: 0,
-        gasUsed: "0 XLM",
-        status: "failed",
+        trigger:
+          triggeredBy === "auto"
+            ? "Automatic Rebalancing"
+            : "Manual Rebalancing",
+        trades: rebalanceResult.trades ?? 0,
+        gasUsed: rebalanceResult.gasUsed ?? "0 XLM",
+        status: "completed",
         isAutomatic: triggeredBy === "auto",
-        error: errorMessage,
       });
-    } catch (histErr) {
-      logger.error("[WORKER:rebalance] Failed to record failure event", {
-        histErr,
-      });
-    }
 
-    logger.error("[WORKER:rebalance] Rebalance failed", {
-      portfolioId,
-      error: errorMessage,
-      attemptsMade: job.attemptsMade,
-    });
-    if (triggeredBy === "auto") {
-      logAudit("auto_rebalance_failed", {
+      try {
+        await notificationService.notify({
+          userId: portfolio.userAddress,
+          eventType: "rebalance",
+          title: "Portfolio Rebalanced",
+          message: `Your portfolio has been automatically rebalanced. ${rebalanceResult.trades ?? 0} trades executed with ${rebalanceResult.gasUsed ?? "0 XLM"} gas used.`,
+          data: {
+            portfolioId,
+            trades: rebalanceResult.trades,
+            gasUsed: rebalanceResult.gasUsed,
+            trigger: triggeredBy,
+          },
+          timestamp: new Date().toISOString(),
+        });
+      } catch (notifyErr) {
+        logger.error("[WORKER:rebalance] Notification failed (non-fatal)", {
+          portfolioId,
+          error:
+            notifyErr instanceof Error ? notifyErr.message : String(notifyErr),
+        });
+      }
+
+      logger.info("[WORKER:rebalance] Rebalance completed", {
         portfolioId,
-        jobId: job.id,
+        trades: rebalanceResult.trades,
+      });
+      if (triggeredBy === "auto") {
+        logAudit("auto_rebalance_completed", {
+          portfolioId,
+          jobId: job.id,
+          trades: rebalanceResult.trades ?? 0,
+          status: "completed",
+        });
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+
+      try {
+        await rebalanceHistoryService.recordRebalanceEvent({
+          portfolioId,
+          trigger: `Automatic Rebalancing (Failed – attempt ${job.attemptsMade + 1})`,
+          trades: 0,
+          gasUsed: "0 XLM",
+          status: "failed",
+          isAutomatic: triggeredBy === "auto",
+          error: errorMessage,
+        });
+      } catch (histErr) {
+        logger.error("[WORKER:rebalance] Failed to record failure event", {
+          histErr,
+        });
+      }
+
+      logger.error("[WORKER:rebalance] Rebalance failed", {
+        portfolioId,
         error: errorMessage,
         attemptsMade: job.attemptsMade,
       });
-    }
+      if (triggeredBy === "auto") {
+        logAudit("auto_rebalance_failed", {
+          portfolioId,
+          jobId: job.id,
+          error: errorMessage,
+          attemptsMade: job.attemptsMade,
+        });
+      }
 
-    throw err;
-  } finally {
-    await rebalanceLockService.releaseLock(portfolioId);
-  }
+      throw err;
+    } finally {
+      await rebalanceLockService.releaseLock(portfolioId);
+    }
+  });
 }
 
 export function startRebalanceWorker(): Worker | null {

--- a/backend/src/test/correlationPropagation.test.ts
+++ b/backend/src/test/correlationPropagation.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getRequestId } from "../utils/requestContext.js";
+import { logger } from "../utils/logger.js";
+
+vi.mock("../services/stellar.js", () => {
+  function StellarService(this: any) {}
+  StellarService.prototype.getPortfolio = vi
+    .fn()
+    .mockResolvedValue({ id: "p1", userAddress: "GUSER" });
+  StellarService.prototype.executeRebalance = vi
+    .fn()
+    .mockResolvedValue({ trades: 0, gasUsed: "0 XLM" });
+  StellarService.prototype.checkRebalanceNeeded = vi
+    .fn()
+    .mockResolvedValue(true);
+  return { StellarService };
+});
+
+vi.mock("../services/reflector.js", () => {
+  function ReflectorService(this: any) {
+    this.getCurrentPrices = vi.fn().mockResolvedValue({});
+  }
+  return { ReflectorService };
+});
+
+vi.mock("../services/rebalanceLock.js", () => ({
+  rebalanceLockService: {
+    acquireLock: vi.fn().mockResolvedValue(true),
+    releaseLock: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+vi.mock("../services/portfolioStorage.js", () => ({
+  portfolioStorage: {
+    getAllPortfolios: vi.fn().mockResolvedValue([{ id: "p1", threshold: 5 }]),
+    getPortfolio: vi.fn().mockResolvedValue({ id: "p1" }),
+  },
+}));
+
+vi.mock("../services/serviceContainer.js", () => ({
+  rebalanceHistoryService: {
+    recordRebalanceEvent: vi.fn().mockResolvedValue({ id: "hist-1" }),
+  },
+}));
+
+vi.mock("../queue/queues.js", () => ({
+  getRebalanceQueue: vi
+    .fn()
+    .mockReturnValue({ add: vi.fn().mockResolvedValue({ id: "job-1" }) }),
+  getPortfolioCheckQueue: vi
+    .fn()
+    .mockReturnValue({ add: vi.fn().mockResolvedValue({ id: "job-2" }) }),
+}));
+
+import { processRebalanceJob } from "../queue/workers/rebalanceWorker.js";
+import { processPortfolioCheckJob } from "../queue/workers/portfolioCheckWorker.js";
+
+describe("correlation propagation into workers", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("exposes correlationId as request context in rebalance worker", async () => {
+    const testCid = "test-cid-rebalance";
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => {
+      expect(getRequestId()).toBe(testCid);
+    });
+
+    const job = {
+      id: "j1",
+      data: {
+        portfolioId: "p1",
+        triggeredBy: "manual",
+        correlationId: testCid,
+      },
+      attemptsMade: 0,
+    } as any;
+    await processRebalanceJob(job);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("exposes correlationId as request context in portfolio-check worker", async () => {
+    const testCid = "test-cid-check";
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => {
+      expect(getRequestId()).toBe(testCid);
+    });
+
+    const job = {
+      id: "j2",
+      data: { triggeredBy: "manual", correlationId: testCid },
+      attemptsMade: 0,
+    } as any;
+    await processPortfolioCheckJob(job);
+    expect(spy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### **Propagate correlation IDs from HTTP requests into queue workers**

**Closes #447** 

**Changes made**
- Propagation implemented: Worker processors now restore request context from job payload 
- Enqueue side: manual enqueues now attach a correlation id when originating from an HTTP request.
- Utilities / types: cleaned duplicate interfaces in queues.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved request tracing across portfolio rebalancing operations for enhanced monitoring and debugging support.
  * Enhanced error logging and diagnostics in background job processing for better system reliability.
  * Consolidated internal job data interfaces to reduce code duplication.
  * Added test coverage for request context propagation in background workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->