### PR TITLE
feat: add public roadmap with now/next/later buckets (#573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,10 @@ Changelog entries are organized by impact:
 
 ### Added
 
+- Public roadmap with Now, Next, Later buckets ([#573](https://github.com/ritik4ever/stellar-portfolio-rebalancer/issues/573))
+  - Created `docs/ROADMAP.md` with detailed project roadmap
+  - Added roadmap summary table to `README.md` for quick reference
+
 - GitHub Actions build attestations for frontend and backend release bundles, plus CycloneDX SBOM artifacts for frontend, backend, and contracts.
 - A repository-level npm audit baseline and CI policy gate, with a backend-local wrapper command for maintainers.
 - A reusable release checklist template for contract, backend, and frontend releases, together with a contract Makefile helper that points to it.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ It helps users maintain optimal asset allocation through automated rebalancing t
 
 ---
 
+## Project Roadmap
+
+See where the Stellar Portfolio Rebalancer is headed!
+
+| **Now** (Current Sprint) | **Next** (1-2 months) | **Later** (3-6+ months) |
+|-------------------------|------------------------|-------------------------|
+| Core rebalancing algorithm | Portfolio dashboard | Mobile app |
+| Reflector oracle integration | Historical reports | Custom strategies |
+| Wallet connection stability | Notification system | DeFi integration |
+| Bug fixes | Multi-asset support | Tax optimization |
+
+**[View detailed roadmap →](docs/ROADMAP.md)**
+
+---
+
+
 ## Architecture
 ```text
 stellar-portfolio-rebalancer/

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,42 @@
+# Stellar Portfolio Rebalancer - Public Roadmap
+
+*Last Updated: June 1, 2026*
+
+## Now (Current Sprint)
+
+These items are actively being worked on:
+
+| Priority | Feature | Description |
+|----------|---------|-------------|
+| High | Core rebalancing algorithm | Optimize gas usage and execution speed |
+| High | Reflector oracle integration | Complete real-time price feed integration |
+| Medium | Wallet connection stability | Improve Freighter/Rabet/xBull compatibility |
+| Ongoing | Bug fixes | Issues identified in testing |
+
+##  Next (1-2 months)
+
+| Feature | Description | Status |
+|---------|-------------|--------|
+| Portfolio Dashboard | Visual asset allocation and performance charts | Planning |
+| Historical Reports | Track past rebalancing events | Design |
+| Notification System | Email/Discord alerts for rebalancing | Research |
+| Multi-asset Support | Expand beyond current asset types | Planning |
+
+##  Later (3-6+ months)
+
+| Feature | Description |
+|---------|-------------|
+| Mobile Application | iOS/Android app for portfolio monitoring |
+| Custom Strategies | User-defined rebalancing rules |
+| DeFi Integration | Connect with Stellar DEX and lending protocols |
+| Tax Optimization | Minimize tax impact during rebalancing |
+
+##  How to Contribute
+
+1. Check issues labeled `good-first-issue` or `help-wanted`
+2. Comment on the issue you want to work on
+3. Follow the [CONTRIBUTING.md](CONTRIBUTING.md) guide
+
+## Roadmap Updates
+
+This document is reviewed monthly and after major releases.


### PR DESCRIPTION
Closes #573

## Changes Made
- Created `docs/ROADMAP.md` with detailed Now/Next/Later buckets
- Added roadmap summary table to `README.md`
- Updated `CHANGELOG.md` with roadmap addition

## Acceptance Criteria Checklist
- [x] New guidance is easy to discover from main contributor path
- [x] Examples match current codebase and terminology (Reflector, Soroban, Stellar)
- [x] Readers can complete documented workflow without reading source first

## Testing Performed
- Verified all internal links work correctly
- Confirmed markdown renders properly
- Checked that roadmap aligns with existing documentation structure

## Screenshots
[Add screenshots showing the roadmap table in README.md]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Published a public product roadmap with planning timelines (Now, Next 1–2 months, Later 3–6+ months), contribution guidance, progress tracking, and feedback instructions.
  * Added a Project Roadmap section to the README with sprint/status tracking and link to the full roadmap.
  * Improved the release-notes pre-release checklist into a detailed, numbered workflow for preparing releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->