### PR TITLE
feat:Prepare contract admin flows for future multisig/governed deploy…

### DIFF
--- a/contracts/CONTRACT_ABI.md
+++ b/contracts/CONTRACT_ABI.md
@@ -15,10 +15,23 @@ For common invocation examples and debugging commands, see the [Soroban Cookbook
 - **Parameters:**
   - `env`: Soroban execution environment.
   - `admin`: Admin address stored for privileged actions (for example emergency stop).
+    - This may be a standard account or a contract-managed/governance address.
+    - Future multisig or governed deployments can provide an address that authorizes via Soroban auth rules.
   - `reflector_address`: Reflector oracle contract address used for price lookups.
 - **Returns:** `Ok(())` on success, `Err(Error::AlreadyInitialized)` if already initialized.
 - **Preconditions:**
   - Contract must not already be initialized.
+
+- **State:** `EmergencyStop` is initialized to `false` during contract initialization.
+
+### `get_admin(env: Env) -> Address`
+
+- **Purpose:** Reads the configured admin address from contract instance storage.
+- **Parameters:**
+  - `env`: Soroban execution environment.
+- **Returns:** Stored admin `Address`.
+- **Notes:**
+  - External clients can use this to confirm the configured governance/admin address before invoking privileged actions.
 
 ### `create_portfolio(env: Env, user: Address, target_allocations: Map<Address, u32>, rebalance_threshold: u32, slippage_tolerance: u32) -> Result<u64, Error>`
 
@@ -91,6 +104,7 @@ For common invocation examples and debugging commands, see the [Soroban Cookbook
 - **Returns:** No return value.
 - **Preconditions:**
   - Admin address stored in `DataKey::Admin` must authorize the call.
+  - The configured admin may be a multisig/governance contract address, as long as it authorizes via Soroban auth.
 
 ## Error Codes (`contracts/src/types.rs`)
 

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -23,8 +23,13 @@ impl PortfolioRebalancer {
         env.storage()
             .instance()
             .set(&DataKey::ReflectorAddress, &reflector_address);
+        env.storage().instance().set(&DataKey::EmergencyStop, &false);
         env.storage().instance().set(&DataKey::Initialized, &true);
         Ok(())
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance().get(&DataKey::Admin).unwrap()
     }
 
     pub fn create_portfolio(
@@ -260,8 +265,12 @@ impl PortfolioRebalancer {
     }
 
     pub fn set_emergency_stop(env: Env, stop: bool) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        admin.require_auth();
+        require_admin(&env);
         env.storage().instance().set(&DataKey::EmergencyStop, &stop);
     }
+}
+
+fn require_admin(env: &Env) {
+    let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+    admin.require_auth();
 }

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -1147,6 +1147,21 @@ fn test_emergency_stop_admin_pause_and_reactivate() {
 }
 
 #[test]
+fn test_get_admin_returns_configured_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    let configured_admin = client.get_admin();
+    assert_eq!(configured_admin, admin);
+}
+
+#[test]
 #[should_panic]
 fn test_emergency_stop_non_admin_rejected() {
     let env = Env::default();

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -30,6 +30,8 @@ pub struct Portfolio {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {
+    /// Admin address for privileged actions such as emergency stop.
+    /// This can be a standard account or a contract-managed governance address.
     Admin,
     ReflectorAddress,
     EmergencyStop,


### PR DESCRIPTION
Close #420 

## PR Description

### Title
Prepare contract admin flows for future multisig/governed deployment

### Summary
This PR refactors the `PortfolioRebalancer` contract admin flow to be deterministic and more easily adoptable by future governed or multisig deployments.

### What changed
- lib.rs
  - Explicitly initializes `EmergencyStop` to `false` in `initialize`
  - Adds `get_admin(env: Env) -> Address` for externally readable configured admin
  - Centralizes admin authorization in `require_admin(&Env)`
- types.rs
  - Documents `DataKey::Admin` as a governance-compatible admin address
- CONTRACT_ABI.md
  - Documents admin semantics for `initialize` and `set_emergency_stop`
  - Adds ABI entry for `get_admin`
- test.rs
  - Adds `test_get_admin_returns_configured_admin`

### Why
- Ensures contract startup state is deterministic
- Makes the admin path explicit and auditable
- Supports a future transition to governance/multisig admin addresses without semantic contract changes
- Preserves existing emergency-stop behavior while improving documentation and test coverage

### Testing
- Added contract test coverage for `get_admin`
- Existing admin emergency-stop tests remain valid

### Files changed
- lib.rs
- types.rs
- CONTRACT_ABI.md
- test.rs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to retrieve the configured admin address through a new method.
  * Emergency stop flag now initialized (set to false) during contract setup.

* **Documentation**
  * Updated contract documentation clarifying admin configuration options and authorization requirements.
  * Enhanced documentation for admin data storage.

* **Tests**
  * Added test verifying admin address retrieval returns the correct address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->