### PR TITLE
feat(frontend): rebalance confirm, boot splash, realtime status, expo…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { api, ENDPOINTS } from './config/api'
 import type { LegalDocType } from './components/Legal'
 import RealtimeStatusBanner from './components/RealtimeStatusBanner'
 import BackendCapabilitiesBanner from './components/BackendCapabilitiesBanner'
+import StartupSplash from './components/StartupSplash'
 import { useReadinessReport } from './hooks/useReadinessReport'
 import {
     onAuthSessionExpired,
@@ -34,7 +35,7 @@ function App() {
     const [sessionRecovery, setSessionRecovery] = useState<string | null>(null)
     const [sessionRecoverySource, setSessionRecoverySource] = useState<string | null>(null)
     const [isRecoveringSession, setIsRecoveringSession] = useState(false)
-    const { notices, loadError, loading: readinessLoading } = useReadinessReport()
+    const { notices, loadError, loading: readinessLoading, bootReady } = useReadinessReport()
 
     const showBackendBanner = loadError || notices.length > 0
     const contentTopPad = showBackendBanner ? 'pt-14' : 'pt-4'
@@ -202,6 +203,10 @@ function App() {
     }
 
     const errorTop = showBackendBanner ? 'top-[4.25rem]' : 'top-4'
+
+    if (!bootReady) {
+        return <StartupSplash loading={readinessLoading} loadError={loadError} />
+    }
 
     return (
         <div className={`App min-h-screen ${contentTopPad}`}>

--- a/frontend/src/components/Dashboard.test.tsx
+++ b/frontend/src/components/Dashboard.test.tsx
@@ -63,11 +63,19 @@ vi.mock('../services/authService', () => ({
     logout: vi.fn(async () => undefined),
 }))
 
-vi.mock('../utils/export', () => ({
-    downloadCSV: vi.fn(),
-    downloadJSON: vi.fn(),
-    toCSV: vi.fn(() => 'csv'),
-}))
+vi.mock('../hooks/usePortfolio', async () => {
+    const actual = await vi.importActual<typeof import('../hooks/usePortfolio')>('../hooks/usePortfolio')
+    return {
+        ...actual,
+        usePortfolioExport: () => ({
+            exportProgress: { phase: 'idle', label: '' },
+            resetExportProgress: vi.fn(),
+            exportClientCsv: vi.fn(async () => undefined),
+            exportClientJson: vi.fn(async () => undefined),
+            exportFromServer: vi.fn(async () => undefined),
+        }),
+    }
+})
 
 vi.mock('../config/api', async () => {
     const actual = await vi.importActual<typeof import('../config/api')>('../config/api')

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -13,24 +13,27 @@ import PriceTracker from './PriceTracker'
 import { API_CONFIG } from '../config/api'
 
 // TanStack Query Hooks
-import { useUserPortfolios, usePortfolioDetails, useRebalanceEstimate, portfolioKeys } from '../hooks/queries/usePortfolioQuery'
+import {
+    useUserPortfolios,
+    usePortfolioDetails,
+    useRebalanceEstimate,
+    buildRebalanceConfirmationSummary,
+    portfolioKeys,
+} from '../hooks/queries/usePortfolioQuery'
 import { usePrices, formatPriceFeedSummary, priceKeys } from '../hooks/queries/usePricesQuery'
 import { useExecuteRebalanceMutation } from '../hooks/mutations/usePortfolioMutations'
 import { useQueryClient } from '@tanstack/react-query'
 import { api, ENDPOINTS } from '../config/api'
 import { logout as authLogout } from '../services/authService'
 import RouteErrorState from './RouteErrorState'
-
-//  NEW: export utils (create frontend/src/utils/export.ts first)
-import { downloadCSV, downloadJSON, toCSV } from '../utils/export'
-import { downloadPortfolioExport } from '../config/api'
+import { usePortfolioExport } from '../hooks/usePortfolio'
 
 interface DashboardProps {
     onNavigate: (view: string) => void
     publicKey: string | null
 }
 
-type DashboardPriceRow = { price?: number; change?: number;[key: string]: unknown }
+type DashboardPriceRow = { price?: number; change?: number; [key: string]: unknown }
 
 const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
     const [activeTab, setActiveTab] = useState<'overview' | 'analytics' | 'notifications' | 'test-notifications'>('overview')
@@ -59,7 +62,6 @@ const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
         refetch: refetchPortfolioDetails,
     } = usePortfolioDetails(latestPortfolioId)
 
-    // Query for prices
     const {
         data: priceBundle,
         isLoading: pricesLoading,
@@ -103,769 +105,938 @@ const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
         publicKey &&
         portfoliosLoadError &&
         !portfoliosLoading &&
-        (!portfolios || portfolios.length === 0)
+        (!portfolios || portfolios.length === 0),
     )
+    const feedMeta = priceBundle?.feedMeta
+
+    const estimateXlm = rebalanceEstimate?.gasEstimateXlm ?? 0
+    const estimateUsd = rebalanceEstimate?.gasEstimateUsd ?? 0
+    const hasHighGasWarning = rebalanceEstimate?.gasWarning || estimateXlm > 0.5
+
+    const queryClient = useQueryClient()
+    const {
+        exportProgress,
+        resetExportProgress,
+        exportClientCsv,
+        exportClientJson,
+        exportFromServer,
+    } = usePortfolioExport()
+
+    const [showRebalanceConfirm, setShowRebalanceConfirm] = useState(false)
+    const [showDemoResetConfirm, setShowDemoResetConfirm] = useState(false)
+    const [resettingDemo, setResettingDemo] = useState(false)
+
+    const refreshData = useCallback(async () => {
+        await Promise.all([
+            queryClient.invalidateQueries({ queryKey: portfolioKeys.all }),
+            queryClient.invalidateQueries({ queryKey: priceKeys.all }),
+        ])
+    }, [queryClient])
+
+    const retryPortfolioLoad = useCallback(async () => {
+        await Promise.all([refetchPortfolios(), refetchPortfolioDetails(), refetchPrices()])
+        await refreshData()
+    }, [refetchPortfolioDetails, refetchPortfolios, refetchPrices, refreshData])
+
+    const resetDemoPortfolio = useCallback(async () => {
+        if (publicKey) return
+        setResettingDemo(true)
+        try {
+            await queryClient.invalidateQueries({ queryKey: portfolioKeys.all })
+            await queryClient.invalidateQueries({ queryKey: priceKeys.all })
+            await new Promise((resolve) => setTimeout(resolve, 500))
+            setShowDemoResetConfirm(false)
+        } catch (error) {
+            console.error('Demo reset failed:', error)
+            alert('Failed to reset demo portfolio. Please refresh the page.')
+        } finally {
+            setResettingDemo(false)
+        }
+    }, [publicKey, queryClient])
+
+    const requestRebalance = () => {
+        if (!portfolioData?.id || portfolioData.id === 'demo') {
+            alert('Rebalancing not available in demo mode. Please create a real portfolio.')
+            return
+        }
+        if (!publicKey) {
+            alert('Connect your wallet to execute a rebalance.')
+            return
+        }
+        setShowRebalanceConfirm(true)
+    }
+
+    const confirmRebalance = async () => {
+        try {
+            const result = await executeRebalanceMutation.mutateAsync()
+            setShowRebalanceConfirm(false)
+            alert(`Rebalance executed successfully! Gas used: ${result.result?.gasUsed || 'N/A'}`)
+        } catch (error: unknown) {
+            console.error('Rebalance failed:', error)
+            const msg = error instanceof Error ? error.message : 'Rebalance failed. Please try again.'
+            const isSlippage =
+                typeof msg === 'string' &&
+                (msg.toLowerCase().includes('slippage') || msg.toLowerCase().includes('tolerance'))
+            alert(isSlippage ? `Slippage too high: ${msg}` : msg)
+        }
+    }
+
+    const disconnectWallet = async () => {
+        if (publicKey) {
+            await authLogout(publicKey)
+        }
+        StellarWallet.disconnect()
+        onNavigate('landing')
+    }
+
+    /** GDPR: Delete all user data from the server, then logout and go to landing */
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+    const [deleting, setDeleting] = useState(false)
+    const deleteMyData = async () => {
+        if (!publicKey) return
+        setDeleting(true)
+        try {
+            await api.delete(ENDPOINTS.USER_DATA_DELETE(publicKey))
+            await authLogout(publicKey)
+            StellarWallet.disconnect()
+            setShowDeleteConfirm(false)
+            onNavigate('landing')
+        } catch (e) {
+            console.error('Delete data failed', e)
+            alert(e instanceof Error ? e.message : 'Failed to delete data. Please try again.')
+        } finally {
+            setDeleting(false)
+        }
+    }
+
+    // Create allocation data from portfolio data
+    const allocationData = portfolioData?.allocations?.map((alloc: any, index: number) => ({
+        name: alloc.asset,
+        value: alloc.target || alloc.percentage, // Handle both formats
+        amount: alloc.amount || 0,
+        color: ['#3B82F6', '#10B981', '#F59E0B', '#EF4444'][index] || '#6B7280'
+    })) || []
+
+    // If portfolio has allocations object instead of array, convert it
+    if (portfolioData?.allocations && typeof portfolioData.allocations === 'object' && !Array.isArray(portfolioData.allocations)) {
+        const allocationsArray = Object.entries(portfolioData.allocations).map(([asset, percentage], index) => ({
+            name: asset,
+            value: percentage as number,
+            amount: (portfolioData.totalValue || 10000) * (percentage as number) / 100,
+            color: ['#3B82F6', '#10B981', '#F59E0B', '#EF4444'][index] || '#6B7280'
+        }))
+        allocationData.splice(0, allocationData.length, ...allocationsArray)
+    }
+
+    const missingPriceAssets = allocationData.filter((asset) => {
+        const row = prices[asset.name]
+        return !row || row.price === undefined || row.price === null
+    })
+    const pricedAssets = allocationData.length - missingPriceAssets.length
+    const hasPartialPriceData = pricedAssets > 0 && missingPriceAssets.length > 0
+    const partialPriceMessage = hasPartialPriceData
+        ? `Some asset quotes are unavailable or fallback-based. ${missingPriceAssets.length} asset${missingPriceAssets.length !== 1 ? 's are' : ' is'} missing fresh market data.`
+        : null
     const priceSource = hasLivePriceRows
-        ? formatPriceFeedSummary(priceBundle?.feedMeta, true, false)
+        ? formatPriceFeedSummary(feedMeta, true, false)
         : publicKey
             ? 'No price data'
             : 'Demo data'
-    const effectivePriceSource = hasPartialPriceData
-        ? 'Partial price data'
-        : priceSource
-    const feedMeta = priceBundle?.feedMeta
+    const effectivePriceSource = hasPartialPriceData ? 'Partial price data' : priceSource
     const showPriceQualityNote = !!(feedMeta?.degraded || feedMeta?.staleOrLimited || hasPartialPriceData)
-}
 
-try {
-    const result = await executeRebalanceMutation.mutateAsync()
-    alert(`Rebalance executed successfully! Gas used: ${result.result?.gasUsed || 'N/A'}`)
-} catch (error: any) {
-    console.error('Rebalance failed:', error)
-    const msg = error.message ?? 'Rebalance failed. Please try again.'
-    const isSlippage = typeof msg === 'string' && (msg.toLowerCase().includes('slippage') || msg.toLowerCase().includes('tolerance'))
-    alert(isSlippage ? `Slippage too high: ${msg}` : msg)
-}
+    const rebalanceTradeoffs = buildRebalanceConfirmationSummary({
+        slippageTolerancePercent: (portfolioData as { slippageTolerancePercent?: number })?.slippageTolerancePercent,
+        slippageTolerance: (portfolioData as { slippageTolerance?: number })?.slippageTolerance,
+        feedMeta,
+        hasPartialPriceData,
+        partialPriceMessage,
+        estimate: rebalanceEstimate,
+        hasHighGasWarning,
+    })
+
+    const exportFilenameBase = `portfolio_${publicKey ? publicKey.slice(0, 6) : 'demo'}_${new Date().toISOString()}`
+
+    const buildPortfolioExportRows = () => {
+        const rows = (allocationData || []).map((a: any) => {
+            const price = prices?.[a.name]?.price ?? ''
+            const change = prices?.[a.name]?.change ?? ''
+            return {
+                asset: a.name,
+                targetPct: a.value ?? '',
+                amount: a.amount ?? '',
+                priceUsd: price,
+                change24hPct: change
+            }
+        })
+        return rows
     }
 
-const estimateXlm = rebalanceEstimate?.gasEstimateXlm ?? 0
-const estimateUsd = rebalanceEstimate?.gasEstimateUsd ?? 0
-const hasHighGasWarning = rebalanceEstimate?.gasWarning || estimateXlm > 0.5
-
-const queryClient = useQueryClient()
-
-const refreshData = useCallback(async () => {
-    // Invalidate all relevant queries to force a refetch without a full page reload.
-    // This leverages TanStack Query's cache invalidation instead of the naive window.location.reload().
-    await Promise.all([
-        queryClient.invalidateQueries({ queryKey: portfolioKeys.all }),
-        queryClient.invalidateQueries({ queryKey: priceKeys.all }),
-    ])
-}, [queryClient])
-
-const retryPortfolioLoad = useCallback(async () => {
-    await Promise.all([
-        refetchPortfolios(),
-        refetchPortfolioDetails(),
-        refetchPrices(),
-    ])
-    await refreshData()
-}, [refetchPortfolioDetails, refetchPortfolios, refetchPrices, refreshData])
-
-// NEW: Demo reset functionality for local testing
-const [showDemoResetConfirm, setShowDemoResetConfirm] = useState(false)
-const [resettingDemo, setResettingDemo] = useState(false)
-
-const resetDemoPortfolio = useCallback(async () => {
-    if (publicKey) return // Only available in demo mode
-
-    setResettingDemo(true)
-    try {
-        // Clear any cached demo data and force refresh
-        await queryClient.invalidateQueries({ queryKey: portfolioKeys.all })
-        await queryClient.invalidateQueries({ queryKey: priceKeys.all })
-
-        // Small delay to show loading state
-        await new Promise(resolve => setTimeout(resolve, 500))
-
-        setShowDemoResetConfirm(false)
-    } catch (error) {
-        console.error('Demo reset failed:', error)
-        alert('Failed to reset demo portfolio. Please refresh the page.')
-    } finally {
-        setResettingDemo(false)
+    const exportPortfolioCSV = () => {
+        if (!portfolioData) return
+        void exportClientCsv({
+            rows: buildPortfolioExportRows(),
+            csvHeaders: ['asset', 'targetPct', 'amount', 'priceUsd', 'change24hPct'],
+            filenameBase: exportFilenameBase,
+            jsonPayload: {},
+        })
     }
-}, [publicKey, queryClient])
 
-const disconnectWallet = async () => {
-    if (publicKey) {
-        await authLogout(publicKey)
+    const exportPortfolioJSON = () => {
+        if (!portfolioData) return
+        void exportClientJson({
+            rows: [],
+            csvHeaders: [],
+            filenameBase: exportFilenameBase,
+            jsonPayload: {
+                exportedAt: new Date().toISOString(),
+                mode: publicKey ? 'wallet' : 'demo',
+                portfolio: portfolioData,
+                prices,
+            },
+        })
     }
-    StellarWallet.disconnect()
-    onNavigate('landing')
-}
 
-/** GDPR: Delete all user data from the server, then logout and go to landing */
-const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-const [deleting, setDeleting] = useState(false)
-const deleteMyData = async () => {
-    if (!publicKey) return
-    setDeleting(true)
-    try {
-        await api.delete(ENDPOINTS.USER_DATA_DELETE(publicKey))
-        await authLogout(publicKey)
-        StellarWallet.disconnect()
-        setShowDeleteConfirm(false)
-        onNavigate('landing')
-    } catch (e) {
-        console.error('Delete data failed', e)
-        alert(e instanceof Error ? e.message : 'Failed to delete data. Please try again.')
-    } finally {
-        setDeleting(false)
-    }
-}
-
-// Create allocation data from portfolio data
-const allocationData = portfolioData?.allocations?.map((alloc: any, index: number) => ({
-    name: alloc.asset,
-    value: alloc.target || alloc.percentage, // Handle both formats
-    amount: alloc.amount || 0,
-    color: ['#3B82F6', '#10B981', '#F59E0B', '#EF4444'][index] || '#6B7280'
-})) || []
-
-// If portfolio has allocations object instead of array, convert it
-if (portfolioData?.allocations && typeof portfolioData.allocations === 'object' && !Array.isArray(portfolioData.allocations)) {
-    const allocationsArray = Object.entries(portfolioData.allocations).map(([asset, percentage], index) => ({
-        name: asset,
-        value: percentage as number,
-        amount: (portfolioData.totalValue || 10000) * (percentage as number) / 100,
-        color: ['#3B82F6', '#10B981', '#F59E0B', '#EF4444'][index] || '#6B7280'
-    }))
-    allocationData.splice(0, allocationData.length, ...allocationsArray)
-}
-
-const missingPriceAssets = allocationData.filter((asset) => {
-    const row = prices[asset.name]
-    return !row || row.price === undefined || row.price === null
-})
-const pricedAssets = allocationData.length - missingPriceAssets.length
-const hasPartialPriceData = pricedAssets > 0 && missingPriceAssets.length > 0
-const partialPriceMessage = hasPartialPriceData
-    ? `Some asset quotes are unavailable or fallback-based. ${missingPriceAssets.length} asset${missingPriceAssets.length !== 1 ? 's are' : ' is'} missing fresh market data.`
-    : null
-
-// NEW: Export helpers (Portfolio CSV / JSON) - works in demo mode too
-const buildPortfolioExportRows = () => {
-    const rows = (allocationData || []).map((a: any) => {
-        const price = prices?.[a.name]?.price ?? ''
-        const change = prices?.[a.name]?.change ?? ''
-        return {
-            asset: a.name,
-            targetPct: a.value ?? '',
-            amount: a.amount ?? '',
-            priceUsd: price,
-            change24hPct: change
+    const exportFromApi = async (format: 'json' | 'csv' | 'pdf') => {
+        if (!portfolioData?.id || portfolioData.id === 'demo') {
+            alert('Connect your wallet and open a portfolio to export full data (JSON/CSV/PDF) from the server.')
+            return
         }
-    })
-    return rows
-}
-
-const exportPortfolioCSV = () => {
-    if (!portfolioData) return
-    const rows = buildPortfolioExportRows()
-    const csv = toCSV(rows, ['asset', 'targetPct', 'amount', 'priceUsd', 'change24hPct'])
-    const filename = `portfolio_${publicKey ? publicKey.slice(0, 6) : 'demo'}_${new Date().toISOString()}.csv`
-    downloadCSV(filename, csv)
-}
-
-const exportPortfolioJSON = () => {
-    if (!portfolioData) return
-    const filename = `portfolio_${publicKey ? publicKey.slice(0, 6) : 'demo'}_${new Date().toISOString()}.json`
-    downloadJSON(filename, {
-        exportedAt: new Date().toISOString(),
-        mode: publicKey ? 'wallet' : 'demo',
-        portfolio: portfolioData,
-        prices
-    })
-}
-
-/** Server-side export (full data + rebalance history) — use when connected with real portfolio */
-const exportFromApi = async (format: 'json' | 'csv' | 'pdf') => {
-    if (!portfolioData?.id || portfolioData.id === 'demo') {
-        alert('Connect your wallet and open a portfolio to export full data (JSON/CSV/PDF) from the server.')
-        return
+        await exportFromServer(portfolioData.id, format)
     }
-    try {
-        await downloadPortfolioExport(portfolioData.id, format)
-    } catch (e) {
-        console.error('Export failed', e)
-        alert(e instanceof Error ? e.message : 'Export failed. Please try again.')
+
+    const exportBusy = exportProgress.phase === 'preparing' || exportProgress.phase === 'downloading'
+
+    const performanceData = [
+        { date: '1/1', value: 10000 },
+        { date: '1/2', value: 10250 },
+        { date: '1/3', value: 10100 },
+        { date: '1/4', value: 10800 },
+        { date: '1/5', value: 11200 },
+        { date: '1/6', value: portfolioData?.totalValue || 10000 }
+    ]
+
+    const walletType = StellarWallet.getWalletType()
+    const contractAddress = 'CCQ4LISQJFTZJKQDRJHRLXQ2UML45GVXUECN5NGSQKAT55JKAK2JAX7I'
+
+    if (routeDataUnavailable) {
+        return (
+            <RouteErrorState
+                title="Portfolio data is unavailable"
+                message={
+                    portfoliosError instanceof Error
+                        ? portfoliosError.message
+                        : 'We could not load the portfolio list for this wallet.'
+                }
+                detail={
+                    detailsLoadError && detailsError instanceof Error
+                        ? `Latest portfolio details also failed to load: ${detailsError.message}`
+                        : pricesLoadError
+                            ? 'Price data failed to refresh. The retry action will attempt a full refetch.'
+                            : 'Retrying will refetch portfolio data and the latest price feed.'
+                }
+                onRetry={retryPortfolioLoad}
+                onBack={() => onNavigate('landing')}
+                retryLabel="Retry loading"
+                backLabel="Go to landing"
+            />
+        )
     }
-}
 
-const performanceData = [
-    { date: '1/1', value: 10000 },
-    { date: '1/2', value: 10250 },
-    { date: '1/3', value: 10100 },
-    { date: '1/4', value: 10800 },
-    { date: '1/5', value: 11200 },
-    { date: '1/6', value: portfolioData?.totalValue || 10000 }
-]
+    if (loading) {
+        return (
+            <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+                <div className="text-center">
+                    <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-500 mx-auto"></div>
+                    <p className="mt-4 text-gray-600 dark:text-gray-400">Loading portfolio data...</p>
+                </div>
+            </div>
+        )
+    }
 
-const walletType = StellarWallet.getWalletType()
-const contractAddress = 'CCQ4LISQJFTZJKQDRJHRLXQ2UML45GVXUECN5NGSQKAT55JKAK2JAX7I'
-
-if (routeDataUnavailable) {
     return (
-        <RouteErrorState
-            title="Portfolio data is unavailable"
-            message={
-                portfoliosError instanceof Error
-                    ? portfoliosError.message
-                    : 'We could not load the portfolio list for this wallet.'
-            }
-            detail={
-                detailsLoadError && detailsError instanceof Error
-                    ? `Latest portfolio details also failed to load: ${detailsError.message}`
-                    : pricesLoadError
-                        ? 'Price data failed to refresh. The retry action will attempt a full refetch.'
-                        : 'Retrying will refetch portfolio data and the latest price feed.'
-            }
-            onRetry={retryPortfolioLoad}
-            onBack={() => onNavigate('landing')}
-            retryLabel="Retry loading"
-            backLabel="Go to landing"
-        />
-    )
-}
-
-if (loading) {
-    return (
-        <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
-            <div className="text-center">
-                <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-500 mx-auto"></div>
-                <p className="mt-4 text-gray-600 dark:text-gray-400">Loading portfolio data...</p>
-            </div>
-        </div>
-    )
-}
-
-
-                                    >
-                                        <ExternalLink className="w-3 h-3" />
-                                    </a>
-                                </div>
-                            </div>
-                        ) : (
-                            <span className="text-sm bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-300 px-2 py-1 rounded mt-1 inline-block">
-                                Demo Mode - Connect wallet for full functionality
-                            </span>
-                        )}
-                    </div>
-                </div>
-
-                <div className="flex items-center space-x-4">
-                    <ThemeToggle />
-                    {/*  NEW: Export buttons — server-side (full data + history) when connected, client-side for demo */}
-                    <div className="flex items-center space-x-2">
-                        {publicKey && portfolioData?.id && portfolioData.id !== 'demo' ? (
-                            <>
-                                <button
-                                    onClick={() => exportFromApi('json')}
-                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors"
-                                >
-                                    Export JSON
-                                </button>
-                                <button
-                                    onClick={() => exportFromApi('csv')}
-                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors"
-                                >
-                                    Export CSV
-                                </button>
-                                <button
-                                    onClick={() => exportFromApi('pdf')}
-                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors"
-                                >
-                                    Export PDF
-                                </button>
-                            </>
-                        ) : (
-                            <>
-                                <button
-                                    onClick={exportPortfolioCSV}
-                                    disabled={!portfolioData}
-                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors disabled:opacity-50"
-                                >
-                                    Export CSV
-                                </button>
-                                <button
-                                    onClick={exportPortfolioJSON}
-                                    disabled={!portfolioData}
-                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors disabled:opacity-50"
-                                >
-                                    Export JSON
-                                </button>
-                                <span className="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">Connect wallet for full export (PDF + history)</span>
-                            </>
-                        )}
-                    </div>
-
-                    {publicKey ? (
-                        <>
-                            <button
-                                onClick={() => setShowDeleteConfirm(true)}
-                                className="text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 px-3 py-2 text-sm transition-colors flex items-center gap-1"
-                                title="Delete my data (GDPR)"
-                            >
-                                <Trash2 className="w-4 h-4" />
-                                Delete my data
-                            </button>
-                            <button
-                                onClick={() => onNavigate('setup')}
-                                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-                            >
-                                Create Portfolio
-                            </button>
-                            <button
-                                onClick={disconnectWallet}
-                                className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 px-3 py-2 text-sm transition-colors"
-                            >
-                                Disconnect
-                            </button>
-                        </>
-                    ) : (
-                        <>
-                            <button
-                                onClick={() => onNavigate('landing')}
-                                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-                            >
-                                Connect Wallet
-                            </button>
-                            {/* NEW: Demo reset button for local testing */}
-                            <button
-                                onClick={() => setShowDemoResetConfirm(true)}
-                                className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
-                                title="Reset demo portfolio to default state"
-                            >
-                                <RefreshCw className="w-4 h-4" />
-                                Reset Demo
-                            </button>
-                        </>
-                    )}
-                    <button
-                        onClick={refreshData}
-                        disabled={loading}
-                        className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
-                    >
-                        <RefreshCw className={`w-5 h-5 ${loading ? 'animate-spin' : ''}`} />
-                    </button>
-                </div>
-            </div>
-        </div>
-
-
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+            {/* Header */}
+            <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-6 py-4">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center">
                         <button
-                            onClick={() => setShowDeleteConfirm(false)}
-                            disabled={deleting}
-                            className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+                            onClick={() => onNavigate('landing')}
+                            className="mr-4 p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
                         >
-                            Cancel
+                            <ArrowLeft className="w-5 h-5" />
                         </button>
-                        <button
-                            onClick={deleteMyData}
-                            disabled={deleting}
-                            className="px-4 py-2 bg-red-600 hover:bg-red-700 disabled:bg-red-400 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
-                        >
-                            {deleting ? (
-                                <>
-                                    <RefreshCw className="w-4 h-4 animate-spin" />
-                                    Deleting...
-                                </>
-                            ) : (
-                                <>
-                                    <Trash2 className="w-4 h-4" />
-                                    Delete all my data
-                                </>
-                            )}
-                        </button>
-                    </div>
-                </div>
-            </div>
-        )}
-
-        {/* NEW: Demo reset confirmation modal */}
-        {showDemoResetConfirm && (
-            <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50 p-4">
-                <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-md w-full p-6">
-                    <div className="flex items-center gap-2 mb-4">
-                        <RefreshCw className="w-6 h-6 text-blue-500 flex-shrink-0" />
-                        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Reset Demo Portfolio</h2>
-                    </div>
-                    <p className="text-gray-600 dark:text-gray-400 text-sm mb-6">
-                        This will reset the demo portfolio to its default state with $10,000 total value and 40% XLM / 60% USDC allocation. Perfect for testing and screenshots.
-                    </p>
-                    <div className="flex justify-end gap-3">
-                        <button
-                            onClick={() => setShowDemoResetConfirm(false)}
-                            disabled={resettingDemo}
-                            className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
-                        >
-                            Cancel
-                        </button>
-                        <button
-                            onClick={resetDemoPortfolio}
-                            disabled={resettingDemo}
-                            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
-                        >
-                            {resettingDemo ? (
-                                <>
-                                    <RefreshCw className="w-4 h-4 animate-spin" />
-                                    Resetting...
-                                </>
-                            ) : (
-                                <>
-                                    <RefreshCw className="w-4 h-4" />
-                                    Reset Demo
-                                </>
-                            )}
-                        </button>
-                    </div>
-                </div>
-            </div>
-        )}
-
-        <div className="p-6 max-w-7xl mx-auto">
-            {/* Tab Navigation */}
-            <div className="mb-6 border-b border-gray-200 dark:border-gray-700">
-                <nav className="flex space-x-8">
-                    <button
-                        onClick={() => setActiveTab('overview')}
-                        className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'overview'
-                            ? 'border-blue-500 text-blue-600 dark:text-blue-400'
-                            : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
-                            }`}
-                    >
-                        Overview
-                    </button>
-                    <button
-                        onClick={() => setActiveTab('analytics')}
-                        className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'analytics'
-                            ? 'border-blue-500 text-blue-600 dark:text-blue-400'
-                            : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
-                            }`}
-                    >
-                        Analytics
-                    </button>
-                    <button
-                        onClick={() => setActiveTab('notifications')}
-                        className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'notifications'
-                            ? 'border-blue-500 text-blue-600 dark:text-blue-400'
-                            : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
-                            }`}
-                    >
-                        Notifications
-                    </button>
-
-                </nav>
-            </div>
-
-
-                                            <div className="w-32 h-4 bg-gray-300 dark:bg-gray-700 rounded" />
-                                            <div className="w-24 h-6 bg-gray-300 dark:bg-gray-700 rounded" />
-                                        </div>
+                        <div>
+                            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Portfolio Dashboard</h1>
+                            {publicKey ? (
+                                <div className="flex items-center space-x-4 mt-1">
+                                    <div className="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400">
+                                        <span className="capitalize font-medium">
+                                            {walletType} Wallet
+                                        </span>
+                                        <span>{publicKey.slice(0, 4)}...{publicKey.slice(-4)}</span>
                                     </div>
-                                    <div className="mb-4 space-y-2">
-                                        <div className="w-40 h-8 bg-gray-300 dark:bg-gray-700 rounded" />
-                                        <div className="w-32 h-4 bg-gray-300 dark:bg-gray-700 rounded" />
+                                    <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-500">
+                                        <span>Contract:</span>
+                                        <code className="bg-gray-100 dark:bg-gray-700 px-1 rounded">{contractAddress.slice(0, 4)}...{contractAddress.slice(-4)}</code>
+                                        <a
+                                            href={`https://stellar.expert/explorer/testnet/contract/${contractAddress}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-blue-600 hover:text-blue-700"
+                                        >
+                                            <ExternalLink className="w-3 h-3" />
+                                        </a>
                                     </div>
-                                    <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
                                 </div>
                             ) : (
-                                <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
-                                    <div className="flex items-center justify-between mb-6">
-                                        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Portfolio Value</h2>
-                                        <div className="flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400">
-                                            <span>Last updated: just now</span>
-                                            <span
-                                                className={`px-2 py-1 rounded text-xs ${feedMeta?.degraded || hasPartialPriceData
-                                                    ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200'
-                                                    : feedMeta?.staleOrLimited
-                                                        ? 'bg-slate-200 dark:bg-slate-700 text-slate-800 dark:text-slate-200'
-                                                        : hasLivePriceRows
-                                                            ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400'
-                                                            : 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400'
-                                                    }`}
-                                            >
-                                                {effectivePriceSource}
-                                            </span>
-                                        </div>
-                                    </div>
-                                    {showPriceQualityNote && (
-                                        <p className="mb-4 text-xs text-amber-800 dark:text-amber-200/90 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 rounded-lg px-3 py-2">
-                                            {feedMeta?.degraded
-                                                ? 'Displayed prices are synthetic or fallback — not primary market data.'
-                                                : hasPartialPriceData
-                                                    ? partialPriceMessage
-                                                    : 'Price feed may be stale or rate-limited; confirm against an exchange if trading.'}
-                                        </p>
-                                    )}
-                                    <div className="mb-4">
-                                        <div className="text-3xl font-bold text-gray-900 dark:text-white">
-                                            ${portfolioData?.totalValue?.toLocaleString() || '0'}
-                                        </div>
-                                        <div className="flex items-center mt-1">
-                                            <TrendingUp className="w-4 h-4 text-green-500 mr-1" />
-                                            <span className="text-green-500 font-medium">+{portfolioData?.dayChange || 0}%</span>
-                                            <span className="text-gray-500 dark:text-gray-400 ml-2">Today</span>
-                                        </div>
-                                    </div>
-                                    <div className="h-64">
-                                        <ResponsiveContainer width="100%" height="100%">
-                                            <LineChart data={performanceData}>
-                                                <CartesianGrid strokeDasharray="3 3" stroke={isDark ? '#374151' : '#f0f0f0'} />
-                                                <XAxis dataKey="date" stroke={isDark ? '#9CA3AF' : '#666'} />
-                                                <YAxis stroke={isDark ? '#9CA3AF' : '#666'} />
-                                                <Tooltip
-                                                    contentStyle={{
-                                                        backgroundColor: isDark ? '#1F2937' : '#fff',
-                                                        border: `1px solid ${isDark ? '#374151' : '#e5e7eb'}`,
-                                                        borderRadius: '8px',
-                                                        color: isDark ? '#F9FAFB' : '#111827'
-                                                    }}
-                                                />
-                                                <Line type="monotone" dataKey="value" stroke="#3B82F6" strokeWidth={3} />
-                                            </LineChart>
-                                        </ResponsiveContainer>
-                                    </div>
-                                </div>
+                                <span className="text-sm bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-300 px-2 py-1 rounded mt-1 inline-block">
+                                    Demo Mode - Connect wallet for full functionality
+                                </span>
                             )}
                         </div>
+                    </div>
 
-                        <div className="space-y-6">
-                            {/* Rebalance Alert */}
-                            {portfolioData?.needsRebalance && (
-                                <motion.div
-                                    initial={{ opacity: 0, scale: 0.95 }}
-                                    animate={{ opacity: 1, scale: 1 }}
-                                    className="bg-gradient-to-r from-orange-50 to-red-50 dark:from-orange-900/30 dark:to-red-900/30 border border-orange-200 dark:border-orange-800 rounded-xl p-6"
+                    <div className="flex items-center space-x-4">
+                        <ThemeToggle />
+                        <div className="flex flex-col items-end gap-1">
+                            <div className="flex items-center space-x-2">
+                                {publicKey && portfolioData?.id && portfolioData.id !== 'demo' ? (
+                                    <>
+                                        <button
+                                            type="button"
+                                            onClick={() => void exportFromApi('json')}
+                                            disabled={exportBusy}
+                                            className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors disabled:opacity-50"
+                                        >
+                                            Export JSON
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => void exportFromApi('csv')}
+                                            disabled={exportBusy}
+                                            className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors disabled:opacity-50"
+                                        >
+                                            Export CSV
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => void exportFromApi('pdf')}
+                                            disabled={exportBusy}
+                                            className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors disabled:opacity-50"
+                                        >
+                                            Export PDF
+                                        </button>
+                                    </>
+                                ) : (
+                                    <>
+                                        <button
+                                            type="button"
+                                            onClick={exportPortfolioCSV}
+                                            disabled={!portfolioData || exportBusy}
+                                            className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors disabled:opacity-50"
+                                        >
+                                            Export CSV
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={exportPortfolioJSON}
+                                            disabled={!portfolioData || exportBusy}
+                                            className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors disabled:opacity-50"
+                                        >
+                                            Export JSON
+                                        </button>
+                                        <span className="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">Connect wallet for full export (PDF + history)</span>
+                                    </>
+                                )}
+                            </div>
+                            {exportProgress.phase !== 'idle' ? (
+                                <div
+                                    className={`max-w-xs rounded-lg border px-3 py-2 text-xs ${
+                                        exportProgress.phase === 'error'
+                                            ? 'border-red-200 bg-red-50 text-red-900 dark:border-red-800 dark:bg-red-950/50 dark:text-red-100'
+                                            : exportProgress.phase === 'complete'
+                                              ? 'border-green-200 bg-green-50 text-green-900 dark:border-green-800 dark:bg-green-950/50 dark:text-green-100'
+                                              : 'border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950/50 dark:text-blue-100'
+                                    }`}
+                                    role="status"
+                                    aria-live="polite"
                                 >
-                                    <div className="flex items-center mb-3">
-                                        <AlertCircle className="w-5 h-5 text-orange-500 mr-2" />
-                                        <span className="font-medium text-orange-800 dark:text-orange-300">Rebalance Needed</span>
+                                    <div className="flex items-center justify-between gap-2">
+                                        <span>{exportProgress.label}</span>
+                                        {exportProgress.phase === 'error' || exportProgress.phase === 'complete' ? (
+                                            <button
+                                                type="button"
+                                                onClick={resetExportProgress}
+                                                className="font-medium underline"
+                                            >
+                                                Dismiss
+                                            </button>
+                                        ) : (
+                                            <RefreshCw className="h-3.5 w-3.5 animate-spin shrink-0" aria-hidden />
+                                        )}
                                     </div>
-                                    <p className="text-sm text-orange-700 dark:text-orange-400 mb-2">
-                                        Your portfolio has drifted from target allocation
-                                    </p>
-                                    <p className="text-sm text-orange-700 dark:text-orange-400 mb-2 font-medium">
-                                        Estimated gas: {estimateXlm.toFixed(2)} XLM (~${estimateUsd.toFixed(3)})
-                                    </p>
-                                    <p className="text-xs text-orange-600 dark:text-orange-400 mb-3">
-                                        {rebalanceEstimate?.tradeCount ?? 0} estimated trade{(rebalanceEstimate?.tradeCount ?? 0) === 1 ? '' : 's'} @ {(rebalanceEstimate?.gasPerTradeXlm ?? 0).toFixed(4)} XLM each
-                                    </p>
-                                    {hasHighGasWarning && (
-                                        <p className="text-xs text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900/40 rounded px-2 py-1 mb-3">
-                                            Warning: estimated gas is unusually high ({'>'} 0.5 XLM). Consider reducing trade count.
+                                    {exportProgress.detail ? (
+                                        <p className="mt-1 opacity-90">{exportProgress.detail}</p>
+                                    ) : null}
+                                </div>
+                            ) : null}
+                        </div>
+
+                        {publicKey ? (
+                            <>
+                                <button
+                                    onClick={() => setShowDeleteConfirm(true)}
+                                    className="text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 px-3 py-2 text-sm transition-colors flex items-center gap-1"
+                                    title="Delete my data (GDPR)"
+                                >
+                                    <Trash2 className="w-4 h-4" />
+                                    Delete my data
+                                </button>
+                                <button
+                                    onClick={() => onNavigate('setup')}
+                                    className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
+                                >
+                                    Create Portfolio
+                                </button>
+                                <button
+                                    onClick={disconnectWallet}
+                                    className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 px-3 py-2 text-sm transition-colors"
+                                >
+                                    Disconnect
+                                </button>
+                            </>
+                        ) : (
+                            <>
+                                <button
+                                    onClick={() => onNavigate('landing')}
+                                    className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
+                                >
+                                    Connect Wallet
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => setShowDemoResetConfirm(true)}
+                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
+                                    title="Reset demo portfolio to default state"
+                                >
+                                    <RefreshCw className="w-4 h-4" />
+                                    Reset Demo
+                                </button>
+                            </>
+                        )}
+                        <button
+                            onClick={refreshData}
+                            disabled={loading}
+                            className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
+                        >
+                            <RefreshCw className={`w-5 h-5 ${loading ? 'animate-spin' : ''}`} />
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            {showRebalanceConfirm ? (
+                <div
+                    className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50 p-4"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="rebalance-confirm-title"
+                >
+                    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-lg w-full p-6 max-h-[90vh] overflow-y-auto">
+                        <h2 id="rebalance-confirm-title" className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+                            Confirm rebalance
+                        </h2>
+                        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                            Review these tradeoffs before submitting on-chain trades.
+                        </p>
+                        <section className="mb-4">
+                            <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2">Slippage</h3>
+                            <ul className="list-disc pl-5 text-sm text-gray-700 dark:text-gray-300 space-y-1">
+                                {rebalanceTradeoffs.slippage.map((line) => (
+                                    <li key={line}>{line}</li>
+                                ))}
+                            </ul>
+                        </section>
+                        <section className="mb-4">
+                            <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2">Prices</h3>
+                            <ul className="list-disc pl-5 text-sm text-gray-700 dark:text-gray-300 space-y-1">
+                                {rebalanceTradeoffs.prices.map((line) => (
+                                    <li key={line}>{line}</li>
+                                ))}
+                            </ul>
+                        </section>
+                        <section className="mb-6">
+                            <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2">Risk</h3>
+                            <ul className="list-disc pl-5 text-sm text-gray-700 dark:text-gray-300 space-y-1">
+                                {rebalanceTradeoffs.risks.map((line) => (
+                                    <li key={line}>{line}</li>
+                                ))}
+                            </ul>
+                        </section>
+                        <div className="flex justify-end gap-3">
+                            <button
+                                type="button"
+                                onClick={() => setShowRebalanceConfirm(false)}
+                                disabled={executeRebalanceMutation.isPending}
+                                className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => void confirmRebalance()}
+                                disabled={executeRebalanceMutation.isPending}
+                                className="px-4 py-2 bg-orange-600 hover:bg-orange-700 disabled:bg-orange-400 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
+                            >
+                                {executeRebalanceMutation.isPending ? (
+                                    <>
+                                        <RefreshCw className="w-4 h-4 animate-spin" />
+                                        Rebalancing…
+                                    </>
+                                ) : (
+                                    'Confirm rebalance'
+                                )}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            ) : null}
+
+            {showDemoResetConfirm ? (
+                <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50 p-4">
+                    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-md w-full p-6">
+                        <div className="flex items-center gap-2 mb-4">
+                            <RefreshCw className="w-6 h-6 text-blue-500 flex-shrink-0" />
+                            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Reset Demo Portfolio</h2>
+                        </div>
+                        <p className="text-gray-600 dark:text-gray-400 text-sm mb-6">
+                            This resets the demo portfolio to its default $10,000 allocation (40% XLM / 60% USDC).
+                        </p>
+                        <div className="flex justify-end gap-3">
+                            <button
+                                type="button"
+                                onClick={() => setShowDemoResetConfirm(false)}
+                                disabled={resettingDemo}
+                                className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => void resetDemoPortfolio()}
+                                disabled={resettingDemo}
+                                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
+                            >
+                                {resettingDemo ? (
+                                    <>
+                                        <RefreshCw className="w-4 h-4 animate-spin" />
+                                        Resetting…
+                                    </>
+                                ) : (
+                                    'Reset Demo'
+                                )}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            ) : null}
+
+            {showDeleteConfirm && (
+                <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50 p-4">
+                    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-md w-full p-6">
+                        <div className="flex items-center gap-2 mb-4">
+                            <AlertCircle className="w-6 h-6 text-amber-500 flex-shrink-0" />
+                            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Delete my data</h2>
+                        </div>
+                        <p className="text-gray-600 dark:text-gray-400 text-sm mb-6">
+                            This will permanently delete your consent records, all portfolios, and rebalance history from our servers. You will be signed out. This action cannot be undone.
+                        </p>
+                        <div className="flex justify-end gap-3">
+                            <button
+                                onClick={() => setShowDeleteConfirm(false)}
+                                disabled={deleting}
+                                className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                onClick={deleteMyData}
+                                disabled={deleting}
+                                className="px-4 py-2 bg-red-600 hover:bg-red-700 disabled:bg-red-400 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
+                            >
+                                {deleting ? (
+                                    <>
+                                        <RefreshCw className="w-4 h-4 animate-spin" />
+                                        Deleting...
+                                    </>
+                                ) : (
+                                    <>
+                                        <Trash2 className="w-4 h-4" />
+                                        Delete all my data
+                                    </>
+                                )}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            <div className="p-6 max-w-7xl mx-auto">
+                {/* Tab Navigation */}
+                <div className="mb-6 border-b border-gray-200 dark:border-gray-700">
+                    <nav className="flex space-x-8">
+                        <button
+                            onClick={() => setActiveTab('overview')}
+                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'overview'
+                                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
+                                }`}
+                        >
+                            Overview
+                        </button>
+                        <button
+                            onClick={() => setActiveTab('analytics')}
+                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'analytics'
+                                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
+                                }`}
+                        >
+                            Analytics
+                        </button>
+                        <button
+                            onClick={() => setActiveTab('notifications')}
+                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'notifications'
+                                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
+                                }`}
+                        >
+                            Notifications
+                        </button>
+                       
+                    </nav>
+                </div>
+
+                {/* Debug Info */}
+                {(import.meta as any).env?.DEV && (
+                    <div className="bg-gray-100 dark:bg-gray-800 p-2 rounded mb-4 text-xs dark:text-gray-300">
+                        <div>Portfolio ID: {portfolioData?.id}</div>
+                        <div>Allocations: {JSON.stringify(allocationData)}</div>
+                        <div>Price Source: {effectivePriceSource}</div>
+                    </div>
+                )}
+
+                {activeTab === 'analytics' ? (
+                    <PerformanceChart portfolioId={portfolioData?.id || null} />
+                ) : activeTab === 'notifications' ? (
+                    <NotificationPreferences userId={publicKey || 'demo'} portfolioId={portfolioData?.id || null} />
+                ) :  (
+                    <>
+                        {/* Portfolio Overview */}
+                        <div className="grid lg:grid-cols-3 gap-6 mb-8">
+                            <div className="lg:col-span-2">
+                                {/* NEW: Portfolio Value Skeleton Loading State */}
+                                {loading ? (
+                                    <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm animate-pulse">
+                                        <div className="flex items-center justify-between mb-6">
+                                            <div className="w-32 h-6 bg-gray-300 dark:bg-gray-700 rounded" />
+                                            <div className="space-x-2 flex items-center">
+                                                <div className="w-32 h-4 bg-gray-300 dark:bg-gray-700 rounded" />
+                                                <div className="w-24 h-6 bg-gray-300 dark:bg-gray-700 rounded" />
+                                            </div>
+                                        </div>
+                                        <div className="mb-4 space-y-2">
+                                            <div className="w-40 h-8 bg-gray-300 dark:bg-gray-700 rounded" />
+                                            <div className="w-32 h-4 bg-gray-300 dark:bg-gray-700 rounded" />
+                                        </div>
+                                        <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+                                    </div>
+                                ) : (
+                                    <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
+                                        <div className="flex items-center justify-between mb-6">
+                                            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Portfolio Value</h2>
+                                            <div className="flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400">
+                                                <span>Last updated: just now</span>
+                                                <span
+                                                    className={`px-2 py-1 rounded text-xs ${
+                                                        feedMeta?.degraded || hasPartialPriceData
+                                                            ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200'
+                                                            : feedMeta?.staleOrLimited
+                                                              ? 'bg-slate-200 dark:bg-slate-700 text-slate-800 dark:text-slate-200'
+                                                              : hasLivePriceRows
+                                                                ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400'
+                                                                : 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400'
+                                                    }`}
+                                                >
+                                                    {effectivePriceSource}
+                                                </span>
+                                            </div>
+                                        </div>
+                                        {showPriceQualityNote ? (
+                                            <p className="mb-4 text-xs text-amber-800 dark:text-amber-200/90 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 rounded-lg px-3 py-2">
+                                                {feedMeta?.degraded
+                                                    ? 'Displayed prices are synthetic or fallback — not primary market data.'
+                                                    : hasPartialPriceData
+                                                      ? partialPriceMessage
+                                                      : 'Price feed may be stale or rate-limited; confirm against an exchange if trading.'}
+                                            </p>
+                                        ) : null}
+                                        <div className="mb-4">
+                                            <div className="text-3xl font-bold text-gray-900 dark:text-white">
+                                                ${portfolioData?.totalValue?.toLocaleString() || '0'}
+                                            </div>
+                                            <div className="flex items-center mt-1">
+                                                <TrendingUp className="w-4 h-4 text-green-500 mr-1" />
+                                                <span className="text-green-500 font-medium">+{portfolioData?.dayChange || 0}%</span>
+                                                <span className="text-gray-500 dark:text-gray-400 ml-2">Today</span>
+                                            </div>
+                                        </div>
+                                        <div className="h-64">
+                                            <ResponsiveContainer width="100%" height="100%">
+                                                <LineChart data={performanceData}>
+                                                    <CartesianGrid strokeDasharray="3 3" stroke={isDark ? '#374151' : '#f0f0f0'} />
+                                                    <XAxis dataKey="date" stroke={isDark ? '#9CA3AF' : '#666'} />
+                                                    <YAxis stroke={isDark ? '#9CA3AF' : '#666'} />
+                                                    <Tooltip
+                                                        contentStyle={{
+                                                            backgroundColor: isDark ? '#1F2937' : '#fff',
+                                                            border: `1px solid ${isDark ? '#374151' : '#e5e7eb'}`,
+                                                            borderRadius: '8px',
+                                                            color: isDark ? '#F9FAFB' : '#111827'
+                                                        }}
+                                                    />
+                                                    <Line type="monotone" dataKey="value" stroke="#3B82F6" strokeWidth={3} />
+                                                </LineChart>
+                                            </ResponsiveContainer>
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+
+                            <div className="space-y-6">
+                                {/* Rebalance Alert */}
+                                {portfolioData?.needsRebalance && (
+                                    <motion.div
+                                        initial={{ opacity: 0, scale: 0.95 }}
+                                        animate={{ opacity: 1, scale: 1 }}
+                                        className="bg-gradient-to-r from-orange-50 to-red-50 dark:from-orange-900/30 dark:to-red-900/30 border border-orange-200 dark:border-orange-800 rounded-xl p-6"
+                                    >
+                                        <div className="flex items-center mb-3">
+                                            <AlertCircle className="w-5 h-5 text-orange-500 mr-2" />
+                                            <span className="font-medium text-orange-800 dark:text-orange-300">Rebalance Needed</span>
+                                        </div>
+                                        <p className="text-sm text-orange-700 dark:text-orange-400 mb-2">
+                                            Your portfolio has drifted from target allocation
                                         </p>
-                                    )}
-                                    {(rebalanceEstimate?.breakdown?.length ?? 0) > 0 && (
-                                        <div className="text-xs text-orange-700 dark:text-orange-300 mb-3 space-y-1">
-                                            {rebalanceEstimate.breakdown.map((item: any) => (
-                                                <div key={item.tradeId} className="flex justify-between">
-                                                    <span>{item.tradeId}</span>
-                                                    <span>{Number(item.estimateXlm || 0).toFixed(4)} XLM</span>
+                                        <p className="text-sm text-orange-700 dark:text-orange-400 mb-2 font-medium">
+                                            Estimated gas: {estimateXlm.toFixed(2)} XLM (~${estimateUsd.toFixed(3)})
+                                        </p>
+                                        <p className="text-xs text-orange-600 dark:text-orange-400 mb-3">
+                                            {rebalanceEstimate?.tradeCount ?? 0} estimated trade{(rebalanceEstimate?.tradeCount ?? 0) === 1 ? '' : 's'} @ {(rebalanceEstimate?.gasPerTradeXlm ?? 0).toFixed(4)} XLM each
+                                        </p>
+                                        {hasHighGasWarning && (
+                                            <p className="text-xs text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900/40 rounded px-2 py-1 mb-3">
+                                                Warning: estimated gas is unusually high ({'>'} 0.5 XLM). Consider reducing trade count.
+                                            </p>
+                                        )}
+                                        {(rebalanceEstimate?.breakdown?.length ?? 0) > 0 && (
+                                            <div className="text-xs text-orange-700 dark:text-orange-300 mb-3 space-y-1">
+                                                {rebalanceEstimate.breakdown.map((item: any) => (
+                                                    <div key={item.tradeId} className="flex justify-between">
+                                                        <span>{item.tradeId}</span>
+                                                        <span>{Number(item.estimateXlm || 0).toFixed(4)} XLM</span>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        )}
+                                        {(portfolioData as any)?.slippageTolerancePercent != null && (
+                                            <p className="text-xs text-orange-600 dark:text-orange-400 mb-4">
+                                                Max slippage: {(portfolioData as any).slippageTolerancePercent}% — trades beyond this will be rejected
+                                            </p>
+                                        )}
+                                        <button
+                                            type="button"
+                                            onClick={requestRebalance}
+                                            disabled={executeRebalanceMutation.isPending || !publicKey || portfolioData?.id === 'demo'}
+                                            className="w-full bg-orange-500 hover:bg-orange-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 text-white py-2 px-4 rounded-lg font-medium transition-colors flex items-center justify-center"
+                                        >
+                                            {executeRebalanceMutation.isPending ? (
+                                                <>
+                                                    <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                                                    Rebalancing...
+                                                </>
+                                            ) : (
+                                                'Execute Rebalance'
+                                            )}
+                                        </button>
+                                        {(portfolioData as any)?.slippageTolerance != null && (
+                                            <p className="text-xs text-gray-600 dark:text-gray-400 mt-2 text-center">
+                                                Max slippage: {(portfolioData as any).slippageTolerance}% — trades above this will be rejected
+                                            </p>
+                                        )}
+                                        {(!publicKey || portfolioData?.id === 'demo') && (
+                                            <p className="text-xs text-orange-600 dark:text-orange-400 mt-2 text-center">
+                                                {!publicKey ? 'Connect wallet to execute rebalance' : 'Create a real portfolio to enable rebalancing'}
+                                            </p>
+                                        )}
+                                    </motion.div>
+                                )}
+
+                                {/* NEW: Allocation Chart Skeleton Loading State */}
+                                {loading ? (
+                                    <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
+                                        <div className="w-32 h-6 bg-gray-300 dark:bg-gray-700 rounded mb-4 animate-pulse" />
+                                        <div className="h-48 flex items-center justify-center mb-4">
+                                            <div className="w-40 h-40 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse" />
+                                        </div>
+                                        <div className="space-y-3">
+                                            {[1, 2, 3].map((i) => (
+                                                <div key={i} className="flex items-center justify-between animate-pulse">
+                                                    <div className="flex items-center space-x-2">
+                                                        <div className="w-3 h-3 rounded-full bg-gray-300 dark:bg-gray-700" />
+                                                        <div className="w-20 h-3 bg-gray-300 dark:bg-gray-700 rounded" />
+                                                    </div>
+                                                    <div className="w-12 h-3 bg-gray-300 dark:bg-gray-700 rounded" />
                                                 </div>
                                             ))}
                                         </div>
-                                    )}
-                                    {(portfolioData as any)?.slippageTolerancePercent != null && (
-                                        <p className="text-xs text-orange-600 dark:text-orange-400 mb-4">
-                                            Max slippage: {(portfolioData as any).slippageTolerancePercent}% — trades beyond this will be rejected
-                                        </p>
-                                    )}
-                                    <button
-                                        onClick={executeRebalance}
-                                        disabled={executeRebalanceMutation.isPending || !publicKey || portfolioData?.id === 'demo'}
-                                        className="w-full bg-orange-500 hover:bg-orange-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 text-white py-2 px-4 rounded-lg font-medium transition-colors flex items-center justify-center"
-                                    >
-                                        {executeRebalanceMutation.isPending ? (
-                                            <>
-                                                <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
-                                                Rebalancing...
-                                            </>
-                                        ) : (
-                                            'Execute Rebalance'
-                                        )}
-                                    </button>
-                                    {(portfolioData as any)?.slippageTolerance != null && (
-                                        <p className="text-xs text-gray-600 dark:text-gray-400 mt-2 text-center">
-                                            Max slippage: {(portfolioData as any).slippageTolerance}% — trades above this will be rejected
-                                        </p>
-                                    )}
-                                    {(!publicKey || portfolioData?.id === 'demo') && (
-                                        <p className="text-xs text-orange-600 dark:text-orange-400 mt-2 text-center">
-                                            {!publicKey ? 'Connect wallet to execute rebalance' : 'Create a real portfolio to enable rebalancing'}
-                                        </p>
-                                    )}
-                                </motion.div>
-                            )}
+                                    </div>
+                                ) : (
+                                    <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
+                                        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Allocation</h3>
+                                        <div className="h-48 flex items-center justify-center">
+                                            <ResponsiveContainer width="100%" height="100%">
+                                                <PieChart>
+                                                    <Pie
+                                                        data={allocationData}
+                                                        cx="50%"
+                                                        cy="50%"
+                                                        innerRadius={40}
+                                                        outerRadius={80}
+                                                        paddingAngle={2}
+                                                        dataKey="value"
+                                                    >
+                                                        {allocationData.map((entry: any, index: number) => (
+                                                            <Cell key={`cell-${index}`} fill={entry.color} />
+                                                        ))}
+                                                    </Pie>
+                                                </PieChart>
+                                            </ResponsiveContainer>
+                                        </div>
+                                        <div className="mt-4 space-y-2">
+                                            {allocationData.map((asset: any, index: number) => (
+                                                <div key={index} className="flex items-center justify-between">
+                                                    <div className="flex items-center">
+                                                        <div className="w-3 h-3 rounded-full mr-2" style={{ backgroundColor: asset.color }}></div>
+                                                        <span className="text-sm text-gray-600 dark:text-gray-400">{asset.name}</span>
+                                                    </div>
+                                                    <span className="text-sm font-semibold text-gray-900 dark:text-white">{asset.value.toFixed(1)}%</span>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
 
-                            {/* NEW: Allocation Chart Skeleton Loading State */}
+                        {/* Price Tracker */}
+                        <div className="mb-8">
+                            <PriceTracker />
+                        </div>
+
+                        {/* NEW: Asset Cards Skeleton Loading State */}
+                        <div className="grid lg:grid-cols-3 gap-6 mb-8">
                             {loading ? (
-                                <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
-                                    <div className="w-32 h-6 bg-gray-300 dark:bg-gray-700 rounded mb-4 animate-pulse" />
-                                    <div className="h-48 flex items-center justify-center mb-4">
-                                        <div className="w-40 h-40 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse" />
-                                    </div>
-                                    <div className="space-y-3">
-                                        {[1, 2, 3].map((i) => (
-                                            <div key={i} className="flex items-center justify-between animate-pulse">
-                                                <div className="flex items-center space-x-2">
-                                                    <div className="w-3 h-3 rounded-full bg-gray-300 dark:bg-gray-700" />
-                                                    <div className="w-20 h-3 bg-gray-300 dark:bg-gray-700 rounded" />
-                                                </div>
-                                                <div className="w-12 h-3 bg-gray-300 dark:bg-gray-700 rounded" />
-                                            </div>
-                                        ))}
-                                    </div>
-
+                                // Show skeleton cards while loading
+                                [1, 2, 3].map((i) => (
+                                    <AssetCard key={`skeleton-${i}`} isLoading={true} />
+                                ))
                             ) : (
-                                <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
-                                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Allocation</h3>
-                                    <div className="h-48 flex items-center justify-center">
-                                        <ResponsiveContainer width="100%" height="100%">
-                                            <PieChart>
-                                                <Pie
-                                                    data={allocationData}
-                                                    cx="50%"
-                                                    cy="50%"
-                                                    innerRadius={40}
-                                                    outerRadius={80}
-                                                    paddingAngle={2}
-                                                    dataKey="value"
-                                                >
-                                                    {allocationData.map((entry: any, index: number) => (
-                                                        <Cell key={`cell-${index}`} fill={entry.color} />
-                                                    ))}
-                                                </Pie>
-                                            </PieChart>
-                                        </ResponsiveContainer>
-                                    </div>
-                                    <div className="mt-4 space-y-2">
-                                        {allocationData.map((asset: any, index: number) => (
-                                            <div key={index} className="flex items-center justify-between">
-                                                <div className="flex items-center">
-                                                    <div className="w-3 h-3 rounded-full mr-2" style={{ backgroundColor: asset.color }}></div>
-                                                    <span className="text-sm text-gray-600 dark:text-gray-400">{asset.name}</span>
-                                                </div>
-                                                <span className="text-sm font-semibold text-gray-900 dark:text-white">{asset.value.toFixed(1)}%</span>
-                                            </div>
-                                        ))}
-                                    </div>
-                                </div>
+                                // Show actual asset cards when data is loaded
+                                allocationData.map((asset: any, index: number) => {
+                                    const row = prices[asset.name]
+                                    const priceCard = row
+                                        ? {
+                                              price: typeof row === 'number' ? row : row.price ?? null,
+                                              change: typeof row === 'number' ? 0 : row.change ?? null,
+                                              source:
+                                                  typeof row === 'object' && row !== null
+                                                      ? (row.source as string | undefined)
+                                                      : undefined,
+                                          }
+                                        : undefined
+                                    return <AssetCard key={index} asset={asset} price={priceCard} />
+                                })
                             )}
                         </div>
-                    </div>
 
-                    {/* Price Tracker */}
-                    <div className="mb-8">
-                        <PriceTracker />
-                    </div>
+                        {/* Rebalance History */}
+                        <RebalanceHistory portfolioId={portfolioData?.id || null} />
+                    </>
+                )}
+            </div>
 
-                    {/* NEW: Asset Cards Skeleton Loading State */}
-                    <div className="grid lg:grid-cols-3 gap-6 mb-8">
-                        {loading ? (
-                            // Show skeleton cards while loading
-                            [1, 2, 3].map((i) => (
-                                <AssetCard key={`skeleton-${i}`} isLoading={true} />
-                            ))
-                        ) : (
-                            // Show actual asset cards when data is loaded
-                            allocationData.map((asset: any, index: number) => {
-                                const row = prices[asset.name]
-                                const priceCard = row
-                                    ? {
-                                        price: typeof row === 'number' ? row : row.price ?? null,
-                                        change: typeof row === 'number' ? 0 : row.change ?? null,
-                                        source: typeof row === 'object' && row !== null ? (row.source as string | undefined) : undefined,
-                                        quoteAgeSeconds:
-                                            typeof row === 'object' && row !== null ? (row.quoteAgeSeconds as number | undefined) : undefined,
-                                        servedFromCache:
-                                            typeof row === 'object' && row !== null ? (row.servedFromCache as boolean | undefined) : undefined,
-                                        dataTier:
-                                            typeof row === 'object' && row !== null ? (row.dataTier as string | undefined) : undefined,
-                                    }
-                                    : undefined
-                                return <AssetCard key={index} asset={asset} price={priceCard} />
-                            })
-                        )}
-                    </div>
-
-                    {/* Rebalance History */}
-                    <RebalanceHistory portfolioId={portfolioData?.id || null} />
-                </>
-            )}
-        </div>
-
-        {/* NEW: Sticky Mobile Action Bar */}
-        <div className="mobile-action-bar fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 p-4 md:hidden z-40">
-            <div className="flex items-center justify-between max-w-sm mx-auto">
-                {/* Portfolio Value */}
-                <div className="text-center">
-                    <div className="text-xs text-gray-500 dark:text-gray-400">Total Value</div>
-                    <div className="text-lg font-bold text-gray-900 dark:text-white">
-                        ${portfolioData?.totalValue?.toLocaleString() || '10,000'}
-                    </div>
-                    <div className={`text-xs flex items-center justify-center gap-1 ${(portfolioData?.dayChange || 0) >= 0
-                        ? 'text-green-600 dark:text-green-400'
-                        : 'text-red-600 dark:text-red-400'
-                        }`}>
-                        {(portfolioData?.dayChange || 0) >= 0 ? (
-                            <TrendingUp className="w-3 h-3" />
-                        ) : (
-                            <TrendingUp className="w-3 h-3 rotate-180" />
-                        )}
-                        {Math.abs(portfolioData?.dayChange || 0.85).toFixed(2)}%
-                    </div>
-                </div>
-
-                {/* Action Buttons */}
-                <div className="flex items-center gap-2">
-                    {/* Rebalance Status & Action */}
-                    {portfolioData?.needsRebalance ? (
-                        <button
-                            onClick={executeRebalance}
-                            disabled={executeRebalanceMutation.isPending || portfolioData?.id === 'demo'}
-                            className="bg-orange-600 hover:bg-orange-700 disabled:bg-orange-400 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1"
-                        >
-                            {executeRebalanceMutation.isPending ? (
-                                <RefreshCw className="w-4 h-4 animate-spin" />
-                            ) : (
-                                <Zap className="w-4 h-4" />
-                            )}
-                            Rebalance
-                        </button>
-                    ) : (
-                        <div className="flex items-center gap-1 text-green-600 dark:text-green-400 text-sm">
-                            <CheckCircle className="w-4 h-4" />
-                            <span className="hidden sm:inline">Balanced</span>
+            <div className="mobile-action-bar fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 p-4 md:hidden z-40">
+                <div className="flex items-center justify-between max-w-sm mx-auto">
+                    <div className="text-center">
+                        <div className="text-xs text-gray-500 dark:text-gray-400">Total Value</div>
+                        <div className="text-lg font-bold text-gray-900 dark:text-white">
+                            ${portfolioData?.totalValue?.toLocaleString() || '10,000'}
                         </div>
-                    )}
-
-                    {/* Create Portfolio / Refresh */}
-                    {publicKey ? (
+                    </div>
+                    <div className="flex items-center gap-2">
+                        {portfolioData?.needsRebalance ? (
+                            <button
+                                type="button"
+                                onClick={requestRebalance}
+                                disabled={executeRebalanceMutation.isPending || portfolioData?.id === 'demo'}
+                                className="bg-orange-600 hover:bg-orange-700 disabled:bg-orange-400 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1"
+                            >
+                                {executeRebalanceMutation.isPending ? (
+                                    <RefreshCw className="w-4 h-4 animate-spin" />
+                                ) : (
+                                    <Zap className="w-4 h-4" />
+                                )}
+                                Rebalance
+                            </button>
+                        ) : (
+                            <div className="flex items-center gap-1 text-green-600 dark:text-green-400 text-sm">
+                                <CheckCircle className="w-4 h-4" />
+                                <span>Balanced</span>
+                            </div>
+                        )}
+                        {publicKey ? (
+                            <button
+                                type="button"
+                                onClick={() => onNavigate('setup')}
+                                className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
+                            >
+                                <Plus className="w-4 h-4" />
+                                New
+                            </button>
+                        ) : (
+                            <button
+                                type="button"
+                                onClick={() => setShowDemoResetConfirm(true)}
+                                className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm"
+                            >
+                                <RefreshCw className="w-4 h-4" />
+                            </button>
+                        )}
                         <button
-                            onClick={() => onNavigate('setup')}
-                            className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
+                            type="button"
+                            onClick={() => void refreshData()}
+                            disabled={loading}
+                            className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 disabled:opacity-50"
                         >
-                            <Plus className="w-4 h-4" />
-                            <span className="hidden sm:inline">New</span>
+                            <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
                         </button>
-                    ) : (
-                        <button
-                            onClick={() => setShowDemoResetConfirm(true)}
-                            className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
-                        >
-                            <RefreshCw className="w-4 h-4" />
-                            <span className="hidden sm:inline">Reset</span>
-                        </button>
-                    )}
-
-                    {/* Refresh Data */}
-                    <button
-                        onClick={refreshData}
-                        disabled={loading}
-                        className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
-                    >
-                        <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-                    </button>
+                    </div>
                 </div>
             </div>
+            <div className="h-20 md:hidden" />
         </div>
-
-        {/* Add bottom padding to main content to prevent overlap with mobile action bar */}
-        <div className="h-20 md:hidden"></div>
-    </div>
-)
+    )
 }
 
 export default Dashboard

--- a/frontend/src/components/PriceTracker.tsx
+++ b/frontend/src/components/PriceTracker.tsx
@@ -83,7 +83,7 @@ function qualityMessage(meta: PriceFeedClientMeta | undefined): string | null {
 const PriceTracker: React.FC<PriceTrackerProps> = ({ compact = false }) => {
     const { data: assetList = ['XLM', 'BTC', 'ETH', 'USDC'] } = useAssets()
     const { data: priceBundle, isLoading, error: queryError, refetch } = usePrices()
-    const { state: realtimeState } = useRealtimeConnection()
+    const { state: realtimeState, statusDetail, reconnectInfo } = useRealtimeConnection()
 
     const prices = useMemo(() => normalizePrices(priceBundle?.prices), [priceBundle?.prices])
     const feedMeta = priceBundle?.feedMeta
@@ -92,6 +92,17 @@ const PriceTracker: React.FC<PriceTrackerProps> = ({ compact = false }) => {
     const qualityHint = useMemo(() => qualityMessage(feedMeta), [feedMeta])
     const loading = isLoading
     const isConnected = realtimeState === 'connected'
+    const isPaused = realtimeState === 'paused'
+    const isReconnecting = realtimeState === 'reconnecting' || realtimeState === 'connecting'
+    const connectionLabel = isConnected
+        ? 'Connected'
+        : isPaused
+          ? 'Paused'
+          : isReconnecting
+            ? reconnectInfo
+                ? `Reconnecting (${reconnectInfo.attempt}/${reconnectInfo.maxAttempts})`
+                : 'Reconnecting'
+            : 'Disconnected'
     const error =
         queryError instanceof Error ? queryError.message : queryError ? String(queryError) : null
 
@@ -193,10 +204,25 @@ const PriceTracker: React.FC<PriceTrackerProps> = ({ compact = false }) => {
                         ) : (
                             <WifiOff className="w-4 h-4 text-red-500" />
                         )}
-                        <span className={`text-xs ${isConnected ? 'text-green-600' : 'text-red-600'}`}>
-                            {isConnected ? 'Connected' : 'Disconnected'}
+                        <span
+                            className={`text-xs ${
+                                isConnected
+                                    ? 'text-green-600'
+                                    : isPaused
+                                      ? 'text-slate-600 dark:text-slate-400'
+                                      : isReconnecting
+                                        ? 'text-amber-600'
+                                        : 'text-red-600'
+                            }`}
+                        >
+                            {connectionLabel}
                         </span>
                     </div>
+                    {statusDetail && !isConnected ? (
+                        <span className="text-[11px] text-gray-500 dark:text-gray-400 max-w-[12rem] truncate">
+                            {statusDetail}
+                        </span>
+                    ) : null}
                     {error && (
                         <div
                             className="text-xs text-red-500 bg-red-50 dark:bg-red-900/30 px-2 py-1 rounded cursor-pointer"
@@ -282,7 +308,11 @@ const PriceTracker: React.FC<PriceTrackerProps> = ({ compact = false }) => {
                         <div className="flex items-center">
                             <WifiOff className="w-4 h-4 text-yellow-600 dark:text-yellow-400 mr-2" />
                             <span className="text-sm text-yellow-800 dark:text-yellow-300">
-                                Connection lost. Showing last known prices.
+                                {isPaused
+                                    ? 'Live feed paused in the background. Showing last known prices.'
+                                    : isReconnecting
+                                      ? 'Reconnecting to live prices. Showing last known quotes until the socket is back.'
+                                      : 'Connection lost. Showing last known prices.'}
                             </span>
                         </div>
                         <button

--- a/frontend/src/components/RealtimeStatusBanner.test.tsx
+++ b/frontend/src/components/RealtimeStatusBanner.test.tsx
@@ -7,7 +7,11 @@ const mockReconnect = vi.fn();
 vi.mock("../context/RealtimeConnectionContext", () => ({
   useRealtimeConnection: () => ({
     state: mockStatus,
-    statusDetail: null,
+    statusDetail: mockStatus === "reconnecting" ? "Next retry in 2s (1/12)" : null,
+    reconnectInfo:
+      mockStatus === "reconnecting"
+        ? { attempt: 1, maxAttempts: 12, nextRetryMs: 2000 }
+        : null,
     reconnect: mockReconnect,
   }),
 }));
@@ -31,7 +35,16 @@ describe("RealtimeStatusBanner", () => {
     mockStatus = "reconnecting";
 
     render(<RealtimeStatusBanner />);
-    expect(screen.getByText(/reconnecting/i)).toBeInTheDocument();
+    expect(screen.getByText(/reconnecting \(1\/12\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/retrying in about 2s/i)).toBeInTheDocument();
+  });
+
+  it("shows paused state with resume action", () => {
+    mockStatus = "paused";
+
+    render(<RealtimeStatusBanner />);
+    expect(screen.getByText(/paused/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /resume/i })).toBeInTheDocument();
   });
 
   it("shows disconnected state and retry button", () => {

--- a/frontend/src/components/RealtimeStatusBanner.tsx
+++ b/frontend/src/components/RealtimeStatusBanner.tsx
@@ -1,8 +1,8 @@
 import { useRealtimeConnection } from '../context/RealtimeConnectionContext'
-import { Loader2, WifiOff, Radio } from 'lucide-react'
+import { Loader2, WifiOff, Radio, Pause } from 'lucide-react'
 
 export default function RealtimeStatusBanner() {
-    const { state, statusDetail, reconnect } = useRealtimeConnection()
+    const { state, statusDetail, reconnectInfo, reconnect } = useRealtimeConnection()
 
     if (state === 'connected') {
         return (
@@ -22,13 +22,24 @@ export default function RealtimeStatusBanner() {
         state === 'connecting'
             ? 'Connecting to live updates…'
             : state === 'reconnecting'
-              ? 'Reconnecting to live updates…'
-              : 'Live updates disconnected'
+              ? reconnectInfo
+                  ? `Reconnecting (${reconnectInfo.attempt}/${reconnectInfo.maxAttempts})…`
+                  : 'Reconnecting to live updates…'
+              : state === 'paused'
+                ? 'Live updates paused'
+                : 'Live updates disconnected'
 
     const barClass =
         state === 'disconnected'
             ? 'border-red-200 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950/60 dark:text-red-100'
-            : 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-800 dark:bg-amber-950/55 dark:text-amber-100'
+            : state === 'paused'
+              ? 'border-slate-200 bg-slate-50 text-slate-900 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100'
+              : 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-800 dark:bg-amber-950/55 dark:text-amber-100'
+
+    const retrySeconds =
+        reconnectInfo?.nextRetryMs != null
+            ? Math.max(1, Math.round(reconnectInfo.nextRetryMs / 1000))
+            : null
 
     return (
         <div
@@ -39,6 +50,8 @@ export default function RealtimeStatusBanner() {
             <div className="flex items-center gap-2">
                 {state === 'disconnected' ? (
                     <WifiOff className="h-4 w-4 shrink-0" aria-hidden />
+                ) : state === 'paused' ? (
+                    <Pause className="h-4 w-4 shrink-0" aria-hidden />
                 ) : (
                     <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden />
                 )}
@@ -46,15 +59,19 @@ export default function RealtimeStatusBanner() {
                     <div className="truncate font-medium">{label}</div>
                     {statusDetail ? (
                         <div className="truncate text-[11px] opacity-85">{statusDetail}</div>
+                    ) : retrySeconds != null && state === 'reconnecting' ? (
+                        <div className="truncate text-[11px] opacity-85">
+                            Retrying in about {retrySeconds}s
+                        </div>
                     ) : null}
                 </div>
-                {state === 'disconnected' ? (
+                {state === 'disconnected' || state === 'paused' ? (
                     <button
                         type="button"
                         onClick={() => reconnect()}
-                        className="ml-1 rounded-full bg-white/85 px-3 py-1 text-xs font-medium text-red-900 ring-1 ring-red-200 hover:bg-white dark:bg-red-900/40 dark:text-red-50 dark:ring-red-700"
+                        className="ml-1 rounded-full bg-white/85 px-3 py-1 text-xs font-medium ring-1 hover:bg-white dark:bg-black/20"
                     >
-                        Retry connection
+                        {state === 'paused' ? 'Resume' : 'Retry connection'}
                     </button>
                 ) : null}
             </div>

--- a/frontend/src/components/StartupSplash.test.tsx
+++ b/frontend/src/components/StartupSplash.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import StartupSplash from './StartupSplash'
+
+describe('StartupSplash', () => {
+    it('shows loading copy while readiness is in flight', () => {
+        render(<StartupSplash loading loadError={false} />)
+        expect(screen.getByText(/checking backend health/i)).toBeInTheDocument()
+        expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true')
+    })
+
+    it('shows warning copy after a failed readiness check', () => {
+        render(<StartupSplash loading={false} loadError />)
+        expect(screen.getByText(/warnings/i)).toBeInTheDocument()
+    })
+})

--- a/frontend/src/components/StartupSplash.tsx
+++ b/frontend/src/components/StartupSplash.tsx
@@ -1,0 +1,34 @@
+import { Loader2 } from 'lucide-react'
+
+type StartupSplashProps = {
+    loading: boolean
+    loadError: boolean
+}
+
+export default function StartupSplash({ loading, loadError }: StartupSplashProps) {
+    return (
+        <div
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-gray-50 dark:bg-gray-900"
+            role="status"
+            aria-live="polite"
+            aria-busy={loading}
+        >
+            <div className="mx-4 max-w-sm text-center">
+                <Loader2
+                    className={`mx-auto h-12 w-12 text-blue-600 dark:text-blue-400 ${loading ? 'animate-spin' : ''}`}
+                    aria-hidden
+                />
+                <h1 className="mt-6 text-lg font-semibold text-gray-900 dark:text-white">
+                    Stellar Portfolio Rebalancer
+                </h1>
+                <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                    {loading
+                        ? 'Checking backend health before opening your dashboard…'
+                        : loadError
+                          ? 'Backend health check finished with warnings. You can continue with limited features.'
+                          : 'Starting…'}
+                </p>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/context/RealtimeConnectionContext.tsx
+++ b/frontend/src/context/RealtimeConnectionContext.tsx
@@ -11,11 +11,13 @@ import { getWebSocketUrl } from '../config/api'
 import {
     RebalancerWSClient,
     type RealtimeConnectionState,
+    type RealtimeReconnectInfo,
 } from '../services/websocket.client'
 
 export type RealtimeConnectionContextValue = {
     state: RealtimeConnectionState
     statusDetail: string | null
+    reconnectInfo: RealtimeReconnectInfo | null
     reconnect: () => void
     disconnect: () => void
     send: (type: string, payload: unknown) => boolean
@@ -26,6 +28,7 @@ const RealtimeConnectionContext = createContext<RealtimeConnectionContextValue |
 export function RealtimeConnectionProvider({ children }: { children: React.ReactNode }) {
     const [state, setState] = useState<RealtimeConnectionState>('disconnected')
     const [statusDetail, setStatusDetail] = useState<string | null>(null)
+    const [reconnectInfo, setReconnectInfo] = useState<RealtimeReconnectInfo | null>(null)
     const clientRef = useRef<RebalancerWSClient | null>(null)
 
     useEffect(() => {
@@ -38,11 +41,19 @@ export function RealtimeConnectionProvider({ children }: { children: React.React
         const client = new RebalancerWSClient(getWebSocketUrl(), {
             onStateChange: setState,
             onStatusDetail: setStatusDetail,
+            onReconnectInfo: setReconnectInfo,
         })
         clientRef.current = client
         client.connect()
 
+        const onVisibility = () => {
+            client.setPaused(document.visibilityState === 'hidden')
+        }
+        document.addEventListener('visibilitychange', onVisibility)
+        onVisibility()
+
         return () => {
+            document.removeEventListener('visibilitychange', onVisibility)
             client.disconnect()
             clientRef.current = null
         }
@@ -61,8 +72,8 @@ export function RealtimeConnectionProvider({ children }: { children: React.React
     }, [])
 
     const value = useMemo(
-        () => ({ state, statusDetail, reconnect, disconnect, send }),
-        [state, statusDetail, reconnect, disconnect, send],
+        () => ({ state, statusDetail, reconnectInfo, reconnect, disconnect, send }),
+        [state, statusDetail, reconnectInfo, reconnect, disconnect, send],
     )
 
     return (

--- a/frontend/src/hooks/queries/usePortfolioQuery.test.ts
+++ b/frontend/src/hooks/queries/usePortfolioQuery.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { buildRebalanceConfirmationSummary } from './usePortfolioQuery'
+
+describe('buildRebalanceConfirmationSummary', () => {
+    it('includes slippage tolerance when configured', () => {
+        const summary = buildRebalanceConfirmationSummary({
+            slippageTolerancePercent: 2,
+            hasPartialPriceData: false,
+            partialPriceMessage: null,
+            estimate: { tradeCount: 1, gasEstimateXlm: 0.1, gasEstimateUsd: 0.02 },
+            hasHighGasWarning: false,
+        })
+        expect(summary.slippage.some((line) => line.includes('2%'))).toBe(true)
+        expect(summary.risks.some((line) => line.includes('network cost'))).toBe(true)
+    })
+
+    it('warns about stale or degraded prices', () => {
+        const summary = buildRebalanceConfirmationSummary({
+            feedMeta: {
+                provider: 'backend',
+                resolvedAtMs: Date.now(),
+                degraded: false,
+                staleOrLimited: true,
+                resolutionHint: 'cached_only',
+                assetsCount: 2,
+            },
+            hasPartialPriceData: false,
+            partialPriceMessage: null,
+            estimate: null,
+            hasHighGasWarning: false,
+        })
+        expect(summary.prices.some((line) => line.toLowerCase().includes('stale'))).toBe(true)
+    })
+})

--- a/frontend/src/hooks/queries/usePortfolioQuery.ts
+++ b/frontend/src/hooks/queries/usePortfolioQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { api, ENDPOINTS } from '../../config/api'
+import type { PriceFeedClientMeta } from './usePricesQuery'
 
 export const portfolioKeys = {
     all: ['portfolios'] as const,
@@ -7,6 +8,68 @@ export const portfolioKeys = {
     list: (address: string) => [...portfolioKeys.lists(), address] as const,
     details: () => [...portfolioKeys.all, 'detail'] as const,
     detail: (id: string) => [...portfolioKeys.details(), id] as const,
+}
+
+export type RebalanceConfirmationSummary = {
+    slippage: string[]
+    prices: string[]
+    risks: string[]
+}
+
+export function buildRebalanceConfirmationSummary(input: {
+    slippageTolerancePercent?: number | null
+    slippageTolerance?: number | null
+    feedMeta?: PriceFeedClientMeta
+    hasPartialPriceData: boolean
+    partialPriceMessage: string | null
+    estimate?: {
+        gasEstimateXlm?: number
+        gasEstimateUsd?: number
+        gasWarning?: boolean
+        tradeCount?: number
+    } | null
+    hasHighGasWarning: boolean
+}): RebalanceConfirmationSummary {
+    const slippage: string[] = []
+    const tolerance = input.slippageTolerancePercent ?? input.slippageTolerance
+    if (tolerance != null) {
+        slippage.push(
+            `Trades that move more than ${tolerance}% away from the quoted price will be rejected.`,
+        )
+    } else {
+        slippage.push('No slippage limit is set on this portfolio; large price moves during execution may cost more than expected.')
+    }
+    slippage.push('On-chain swaps can fill at worse prices than the dashboard quote when markets move quickly.')
+
+    const prices: string[] = []
+    if (input.feedMeta?.degraded) {
+        prices.push('Quotes are using synthetic or fallback data, not primary exchange prices.')
+    } else if (input.feedMeta?.staleOrLimited) {
+        prices.push('Quotes may be stale or served from cache after an upstream error or rate limit.')
+    }
+    if (input.hasPartialPriceData && input.partialPriceMessage) {
+        prices.push(input.partialPriceMessage)
+    }
+    if (prices.length === 0) {
+        prices.push('Rebalance sizing uses the latest price feed shown on this dashboard.')
+    }
+
+    const risks: string[] = []
+    const tradeCount = input.estimate?.tradeCount ?? 0
+    if (tradeCount > 0) {
+        risks.push(`About ${tradeCount} on-chain trade${tradeCount === 1 ? '' : 's'} may run in sequence; each needs network fees.`)
+    }
+    const xlm = input.estimate?.gasEstimateXlm ?? 0
+    const usd = input.estimate?.gasEstimateUsd ?? 0
+    if (xlm > 0) {
+        risks.push(`Estimated network cost: ${xlm.toFixed(4)} XLM (~$${usd.toFixed(3)}).`)
+    }
+    if (input.hasHighGasWarning) {
+        risks.push('Estimated gas is higher than usual; consider fewer trades or waiting for calmer network conditions.')
+    }
+    risks.push('Executed trades cannot be reversed from this app; review allocations before confirming.')
+
+    return { slippage, prices, risks }
 }
 
 export const useUserPortfolios = (address: string | null) => {
@@ -17,7 +80,7 @@ export const useUserPortfolios = (address: string | null) => {
             return res.portfolios
         },
         enabled: !!address,
-        staleTime: 60000, // 1 minute
+        staleTime: 60000,
     })
 }
 
@@ -26,7 +89,7 @@ export const usePortfolioDetails = (id: string | null) => {
         queryKey: portfolioKeys.detail(id || ''),
         queryFn: () => api.get<any>(ENDPOINTS.PORTFOLIO_DETAIL(id!)),
         enabled: !!id && id !== 'demo',
-        staleTime: 30000, // 30 seconds
+        staleTime: 30000,
     })
 }
 

--- a/frontend/src/hooks/usePortfolio.ts
+++ b/frontend/src/hooks/usePortfolio.ts
@@ -19,8 +19,16 @@
  * ```
  */
 
-import { useState, useEffect } from 'react'
-import { api, ENDPOINTS } from '../config/api'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { api, ENDPOINTS, downloadPortfolioExport } from '../config/api'
+import {
+    downloadCSV,
+    downloadJSON,
+    idleExportProgress,
+    runExportWithProgress,
+    toCSV,
+    type ExportProgressState,
+} from '../utils/export'
 
 interface PortfolioData {
     id: string
@@ -98,4 +106,115 @@ export const usePortfolio = (portfolioId?: string) => {
     }
 
     return { portfolio, loading, error, executeRebalance }
+}
+
+export type PortfolioExportClientPayload = {
+    rows: Record<string, unknown>[]
+    csvHeaders: string[]
+    filenameBase: string
+    jsonPayload: unknown
+}
+
+export function usePortfolioExport() {
+    const [exportProgress, setExportProgress] = useState<ExportProgressState>(idleExportProgress())
+    const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    const clearDismissTimer = () => {
+        if (dismissTimer.current) {
+            clearTimeout(dismissTimer.current)
+            dismissTimer.current = null
+        }
+    }
+
+    const resetExportProgress = useCallback(() => {
+        clearDismissTimer()
+        setExportProgress(idleExportProgress())
+    }, [])
+
+    const scheduleIdle = useCallback(() => {
+        clearDismissTimer()
+        dismissTimer.current = setTimeout(() => {
+            setExportProgress(idleExportProgress())
+        }, 4000)
+    }, [])
+
+    useEffect(() => () => clearDismissTimer(), [])
+
+    const exportClientCsv = useCallback(
+        async (payload: PortfolioExportClientPayload) => {
+            try {
+                await runExportWithProgress(
+                    {
+                        preparing: 'Preparing CSV export…',
+                        downloading: 'Building spreadsheet…',
+                        complete: 'CSV download started',
+                    },
+                    setExportProgress,
+                    async () => {
+                        const csv = toCSV(payload.rows, payload.csvHeaders)
+                        const filename = `${payload.filenameBase}.csv`
+                        downloadCSV(filename, csv)
+                    },
+                )
+                scheduleIdle()
+            } catch {
+                scheduleIdle()
+            }
+        },
+        [scheduleIdle],
+    )
+
+    const exportClientJson = useCallback(
+        async (payload: PortfolioExportClientPayload) => {
+            try {
+                await runExportWithProgress(
+                    {
+                        preparing: 'Preparing JSON export…',
+                        downloading: 'Serializing portfolio…',
+                        complete: 'JSON download started',
+                    },
+                    setExportProgress,
+                    async () => {
+                        const filename = `${payload.filenameBase}.json`
+                        downloadJSON(filename, payload.jsonPayload)
+                    },
+                )
+                scheduleIdle()
+            } catch {
+                scheduleIdle()
+            }
+        },
+        [scheduleIdle],
+    )
+
+    const exportFromServer = useCallback(
+        async (portfolioId: string, format: 'json' | 'csv' | 'pdf') => {
+            const formatLabel = format.toUpperCase()
+            try {
+                await runExportWithProgress(
+                    {
+                        preparing: `Requesting ${formatLabel} export…`,
+                        downloading: `Downloading ${formatLabel} file…`,
+                        complete: `${formatLabel} export ready`,
+                    },
+                    setExportProgress,
+                    async () => {
+                        await downloadPortfolioExport(portfolioId, format)
+                    },
+                )
+                scheduleIdle()
+            } catch {
+                scheduleIdle()
+            }
+        },
+        [scheduleIdle],
+    )
+
+    return {
+        exportProgress,
+        resetExportProgress,
+        exportClientCsv,
+        exportClientJson,
+        exportFromServer,
+    }
 }

--- a/frontend/src/hooks/useReadinessReport.test.ts
+++ b/frontend/src/hooks/useReadinessReport.test.ts
@@ -91,6 +91,7 @@ describe('useReadinessReport hook', () => {
         await waitFor(() => expect(result.current.loading).toBe(false))
         expect(result.current.report?.status).toBe('ready')
         expect(result.current.loadError).toBe(false)
+        expect(result.current.bootReady).toBe(true)
         expect(result.current.notices.filter(n => n.kind !== 'disabled')).toHaveLength(0)
     })
 

--- a/frontend/src/hooks/useReadinessReport.ts
+++ b/frontend/src/hooks/useReadinessReport.ts
@@ -209,5 +209,7 @@ export function useReadinessReport() {
         void load(ac.signal)
     }, [load])
 
-    return { report, notices, loadError, loading, refresh }
+    const bootReady = !loading
+
+    return { report, notices, loadError, loading, bootReady, refresh }
 }

--- a/frontend/src/services/websocket.client.ts
+++ b/frontend/src/services/websocket.client.ts
@@ -1,6 +1,12 @@
 import { WS_PROTOCOL_VERSION } from '../constants/wsProtocol'
 
-export type RealtimeConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting'
+export type RealtimeConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting' | 'paused'
+
+export type RealtimeReconnectInfo = {
+    attempt: number
+    maxAttempts: number
+    nextRetryMs: number
+}
 
 export type RebalancerWSOptions = {
     maxReconnectAttempts?: number
@@ -8,6 +14,7 @@ export type RebalancerWSOptions = {
     onStateChange?: (state: RealtimeConnectionState) => void
     onMessage?: (data: unknown) => void
     onStatusDetail?: (detail: string | null) => void
+    onReconnectInfo?: (info: RealtimeReconnectInfo | null) => void
 }
 
 const DEFAULT_MAX_ATTEMPTS = 12
@@ -21,10 +28,13 @@ export class RebalancerWSClient {
     private readonly onStateChange?: (state: RealtimeConnectionState) => void
     private readonly onMessage?: (data: unknown) => void
     private readonly onStatusDetail?: (detail: string | null) => void
+    private readonly onReconnectInfo?: (info: RealtimeReconnectInfo | null) => void
 
     private intentionalClose = false
+    private pausedByVisibility = false
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null
     private reconnectCycles = 0
+    private pendingRetryMs: number | null = null
 
     constructor(url: string, options: RebalancerWSOptions = {}) {
         this.url = url
@@ -33,6 +43,7 @@ export class RebalancerWSClient {
         this.onStateChange = options.onStateChange
         this.onMessage = options.onMessage
         this.onStatusDetail = options.onStatusDetail
+        this.onReconnectInfo = options.onReconnectInfo
     }
 
     private setState(state: RealtimeConnectionState): void {
@@ -44,10 +55,26 @@ export class RebalancerWSClient {
             clearTimeout(this.reconnectTimer)
             this.reconnectTimer = null
         }
+        this.pendingRetryMs = null
+        this.onReconnectInfo?.(null)
+    }
+
+    private emitReconnectInfo(delay: number): void {
+        this.pendingRetryMs = delay
+        this.onReconnectInfo?.({
+            attempt: this.reconnectCycles + 1,
+            maxAttempts: this.maxReconnectAttempts,
+            nextRetryMs: delay,
+        })
     }
 
     private scheduleReconnect(): void {
         this.clearReconnectTimer()
+        if (this.pausedByVisibility) {
+            this.onStatusDetail?.('Live updates paused while this tab is in the background.')
+            this.setState('paused')
+            return
+        }
         if (this.reconnectCycles >= this.maxReconnectAttempts) {
             this.onStatusDetail?.(
                 `Could not restore the live connection after ${this.maxReconnectAttempts} retries.`,
@@ -61,6 +88,8 @@ export class RebalancerWSClient {
         this.onStatusDetail?.(
             `Next retry in ${Math.round(delay / 1000)}s (${this.reconnectCycles + 1}/${this.maxReconnectAttempts})`,
         )
+        this.emitReconnectInfo(delay)
+        this.setState('reconnecting')
         this.reconnectTimer = setTimeout(() => {
             this.reconnectTimer = null
             this.reconnectCycles += 1
@@ -70,12 +99,20 @@ export class RebalancerWSClient {
 
     private openSocket(): void {
         if (this.intentionalClose) return
+        if (this.pausedByVisibility) {
+            this.setState('paused')
+            return
+        }
         if (this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING) {
             return
         }
 
         this.onStatusDetail?.(null)
         this.setState(this.reconnectCycles === 0 ? 'connecting' : 'reconnecting')
+        if (this.reconnectCycles > 0) {
+            const delay = this.pendingRetryMs ?? 1000
+            this.emitReconnectInfo(delay)
+        }
 
         try {
             this.ws = new WebSocket(this.url)
@@ -88,6 +125,7 @@ export class RebalancerWSClient {
         this.ws.onopen = () => {
             this.reconnectCycles = 0
             this.onStatusDetail?.(null)
+            this.onReconnectInfo?.(null)
             this.setState('connected')
         }
 
@@ -114,6 +152,25 @@ export class RebalancerWSClient {
         }
     }
 
+    setPaused(paused: boolean): void {
+        this.pausedByVisibility = paused
+        if (paused) {
+            this.clearReconnectTimer()
+            if (this.ws) {
+                this.ws.close()
+                this.ws = null
+            }
+            this.onStatusDetail?.('Live updates paused while this tab is in the background.')
+            this.setState('paused')
+            return
+        }
+        if (!this.intentionalClose && this.ws?.readyState !== WebSocket.OPEN) {
+            this.onStatusDetail?.(null)
+            this.reconnectCycles = 0
+            this.openSocket()
+        }
+    }
+
     connect(): void {
         this.intentionalClose = false
         this.reconnectCycles = 0
@@ -123,6 +180,7 @@ export class RebalancerWSClient {
 
     resume(): void {
         this.intentionalClose = false
+        this.pausedByVisibility = false
         this.reconnectCycles = 0
         this.onStatusDetail?.(null)
         this.clearReconnectTimer()

--- a/frontend/src/utils/export.test.ts
+++ b/frontend/src/utils/export.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { idleExportProgress, runExportWithProgress, toCSV } from './export'
+
+describe('export utils', () => {
+    it('builds csv with headers', () => {
+        const csv = toCSV([{ a: 1, b: 'x,y' }], ['a', 'b'])
+        expect(csv).toContain('a,b')
+        expect(csv).toContain('"x,y"')
+    })
+
+    it('reports progress phases through a successful export', async () => {
+        const phases: string[] = []
+        await runExportWithProgress(
+            {
+                preparing: 'prep',
+                downloading: 'down',
+                complete: 'done',
+            },
+            (state) => phases.push(state.phase),
+            async () => 'ok',
+        )
+        expect(phases).toEqual(['preparing', 'downloading', 'complete'])
+    })
+
+    it('sets error phase when export fails', async () => {
+        const onProgress = vi.fn()
+        await expect(
+            runExportWithProgress(
+                { preparing: 'p', downloading: 'd', complete: 'c' },
+                onProgress,
+                async () => {
+                    throw new Error('network down')
+                },
+            ),
+        ).rejects.toThrow('network down')
+        expect(onProgress).toHaveBeenCalledWith(
+            expect.objectContaining({ phase: 'error', detail: 'network down' }),
+        )
+    })
+
+    it('starts in idle', () => {
+        expect(idleExportProgress().phase).toBe('idle')
+    })
+})

--- a/frontend/src/utils/export.ts
+++ b/frontend/src/utils/export.ts
@@ -1,7 +1,7 @@
 
 export function downloadBlob(filename: string, blob: Blob) {
     const url = URL.createObjectURL(blob)
-    const a = document.createElement("a")
+    const a = document.createElement('a')
     a.href = url
     a.download = filename
     document.body.appendChild(a)
@@ -12,32 +12,63 @@ export function downloadBlob(filename: string, blob: Blob) {
 
 export function downloadJSON(filename: string, data: unknown) {
     const json = JSON.stringify(data, null, 2)
-    const blob = new Blob([json], { type: "application/json;charset=utf-8" })
+    const blob = new Blob([json], { type: 'application/json;charset=utf-8' })
     downloadBlob(filename, blob)
 }
 
+export type ExportPhase = 'idle' | 'preparing' | 'downloading' | 'complete' | 'error'
+
+export type ExportProgressState = {
+    phase: ExportPhase
+    label: string
+    detail?: string
+}
+
+export const idleExportProgress = (): ExportProgressState => ({
+    phase: 'idle',
+    label: '',
+})
+
+export async function runExportWithProgress<T>(
+    labels: { preparing: string; downloading: string; complete: string },
+    onProgress: (state: ExportProgressState) => void,
+    run: () => Promise<T>,
+): Promise<T> {
+    onProgress({ phase: 'preparing', label: labels.preparing })
+    await new Promise((r) => setTimeout(r, 0))
+    onProgress({ phase: 'downloading', label: labels.downloading })
+    try {
+        const result = await run()
+        onProgress({ phase: 'complete', label: labels.complete })
+        return result
+    } catch (e) {
+        const message = e instanceof Error ? e.message : 'Export failed'
+        onProgress({ phase: 'error', label: 'Export failed', detail: message })
+        throw e
+    }
+}
 
 export function toCSV<T extends Record<string, unknown>>(
     rows: T[],
-    headers?: string[]
+    headers?: string[],
 ) {
-    if (!rows.length) return ""
+    if (!rows.length) return ''
 
     const cols = headers ?? Object.keys(rows[0])
 
     const escape = (v: unknown) => {
-        const s = v === null || v === undefined ? "" : String(v)
+        const s = v === null || v === undefined ? '' : String(v)
         const needsQuotes = /[",\n]/.test(s)
         const escaped = s.replace(/"/g, '""')
         return needsQuotes ? `"${escaped}"` : escaped
     }
 
-    const head = cols.join(",")
-    const body = rows.map((r) => cols.map((c) => escape(r[c])).join(",")).join("\n")
+    const head = cols.join(',')
+    const body = rows.map((r) => cols.map((c) => escape(r[c])).join(',')).join('\n')
     return `${head}\n${body}\n`
 }
 
 export function downloadCSV(filename: string, csv: string) {
-    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" })
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
     downloadBlob(filename, blob)
 }


### PR DESCRIPTION
closes #507 
closes #516 
closes #512 
closes #513 

## Summary

This PR delivers four related frontend UX improvements in one pass and repairs a broken `Dashboard.tsx` on `main` (the component body was split/corrupted, which prevented the dashboard from compiling).

- **Rebalance confirmation** — Manual rebalance opens a confirmation step that explains slippage limits, price-feed quality (stale/degraded/partial quotes), and execution risk (gas, trade count) before the user confirms on-chain trades.
- **Startup boot splash** — A lightweight splash runs while the first backend readiness check completes, so the app does not jump straight into the dashboard before essential health signals are known.
- **Realtime connection status** — WebSocket reconnect attempt, backoff timing, and tab-pause state are surfaced through context so the status banner and price tracker can show connecting, reconnecting, paused, and disconnected states intentionally.
- **Export progress** — Portfolio exports (client-side and server-side) show preparing, downloading, complete, and error states instead of a silent download-only flow.

## Changes

| Area | Files |
|------|--------|
| Rebalance tradeoffs | `usePortfolioQuery.ts`, `Dashboard.tsx`, `PriceTracker.tsx` |
| Boot splash | `StartupSplash.tsx`, `App.tsx`, `useReadinessReport.ts` |
| Realtime UI | `websocket.client.ts`, `RealtimeConnectionContext.tsx`, `RealtimeStatusBanner.tsx`, `PriceTracker.tsx` |
| Export progress | `export.ts`, `usePortfolio.ts`, `Dashboard.tsx` |
| Dashboard repair | `Dashboard.tsx` |

## Test plan

- [ ] Start the app: splash appears briefly, then landing/dashboard renders after readiness resolves.
- [ ] Connect wallet with a portfolio that needs rebalance: **Execute Rebalance** opens the confirmation modal with slippage, price, and risk sections; **Confirm** runs the rebalance; **Cancel** closes without executing.
- [ ] Simulate WS loss or background the tab: live-updates banner shows reconnecting (attempt/backoff) or paused; **PriceTracker** reflects the same connection state.
- [ ] Export CSV/JSON in demo mode and JSON/CSV/PDF with a real portfolio: progress UI shows preparing → downloading → complete (or error with dismiss).
- [ ] Run unit tests: `cd frontend && npm test`

## Notes for reviewers

- `buildRebalanceConfirmationSummary()` centralizes copy for the rebalance modal so `Dashboard` stays readable.
- `usePortfolioExport()` is intended to support future async server export jobs without changing dashboard call sites again.
- No unrelated lockfile or docs changes included in this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup splash during boot
  * Portfolio export with progress (client/server; CSV/JSON/PDF)
  * Rebalance & demo/reset confirmation flows and GDPR delete action
  * More granular real-time status (paused/reconnecting) with retry info

* **Improvements**
  * Better pricing-quality messaging and rebalance summary details
  * Visibility-aware connection pause/resume and mobile action bar UX
  * Skeleton loading states and expanded dashboard tabs

* **Tests**
  * Added/updated tests for readiness, export, realtime banner, and splash UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->