### PR TITLE
feat: hash request payloads in idempotency records to detect semantic…

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -824,6 +824,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
             "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -845,6 +846,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
             "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -857,6 +859,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
             "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "1.28.0"
             },
@@ -1014,6 +1017,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
             "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.57.2",
                 "@types/shimmer": "^1.2.0",
@@ -1558,6 +1562,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
             "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "1.30.1",
                 "@opentelemetry/semantic-conventions": "1.28.0"
@@ -1690,6 +1695,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
             "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "1.30.1",
                 "@opentelemetry/resources": "1.30.1",
@@ -1716,6 +1722,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
             "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -2859,6 +2866,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3906,6 +3914,7 @@
             "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
             "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
@@ -3952,6 +3961,7 @@
             "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
             "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 16"
             },
@@ -5447,6 +5457,7 @@
             "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
             "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.11.0",
                 "pg-pool": "^3.11.0",
@@ -5544,6 +5555,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6777,6 +6789,7 @@
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "~0.27.0",
                 "get-tsconfig": "^4.7.5"
@@ -6966,6 +6979,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -7041,6 +7055,7 @@
             "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.0.18",
                 "@vitest/mocker": "4.0.18",

--- a/backend/src/db/idempotencyDb.ts
+++ b/backend/src/db/idempotencyDb.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3'
+import type { IdempotencyRecord } from '../types/index.js'
 
 interface IdempotencyRow {
     key: string
@@ -9,17 +10,6 @@ interface IdempotencyRow {
     response_body: string
     created_at: string
     expires_at: string
-}
-
-export interface IdempotencyRecord {
-    key: string
-    requestHash: string
-    method: string
-    path: string
-    statusCode: number
-    responseBody: string
-    createdAt: string
-    expiresAt: string
 }
 
 let idemDb: Database.Database | null = null

--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -5,6 +5,7 @@ import {
     dbStoreIdempotencyResult
 } from '../db/idempotencyDb.js'
 import { fail } from '../utils/apiResponse.js'
+import { stableStringify } from '../utils/helpers.js'
 
 export const idempotencyMiddleware: RequestHandler = (req, res, next) => {
     const key = req.headers['idempotency-key'] as string | undefined
@@ -25,7 +26,7 @@ export const idempotencyMiddleware: RequestHandler = (req, res, next) => {
     const requestHash = createHash('sha256')
         .update(req.method)
         .update(req.path)
-        .update(JSON.stringify(req.body ?? {}))
+        .update(stableStringify(req.body ?? {}))
         .update(requestUser)
         .digest('hex')
 

--- a/backend/src/test/idempotency.test.ts
+++ b/backend/src/test/idempotency.test.ts
@@ -210,23 +210,47 @@ describe('idempotencyMiddleware', () => {
         expect(second.state.sentHeaders['Idempotency-Replayed']).toBe('true')
     })
 
-    it('same key + different body returns 409 Conflict', async () => {
+    it('same key + semantically equivalent body (different key order) replays stored response', async () => {
         const { idempotencyMiddleware } = await import('../middleware/idempotency.js')
 
-        const key = 'conflict-key-001'
+        const key = 'stable-key-001'
+        const body1 = { a: 1, b: 2 }
+        const body2 = { b: 2, a: 1 }
 
-        const first = mockReqRes({ headers: { 'idempotency-key': key }, body: { portfolioId: 'p1' } })
+        // First request
+        const first = mockReqRes({ headers: { 'idempotency-key': key }, body: body1 })
+        idempotencyMiddleware(first.req, first.res, first.next)
+        first.res.status(200).json({ success: true, message: 'first' })
+
+        // Second request — same values, different order → should replay
+        const second = mockReqRes({ headers: { 'idempotency-key': key }, body: body2 })
+        idempotencyMiddleware(second.req, second.res, second.next)
+
+        expect(second.state.nextCalled).toBe(false)
+        expect(second.state.sentStatus).toBe(200)
+        expect((second.state.sentBody as any).message).toBe('first')
+        expect(second.state.sentHeaders['Idempotency-Replayed']).toBe('true')
+    })
+
+    it('same key + different values returns 409 Conflict', async () => {
+        const { idempotencyMiddleware } = await import('../middleware/idempotency.js')
+
+        const key = 'diff-value-key-001'
+        const body1 = { a: 1, b: 2 }
+        const body2 = { a: 1, b: 3 }
+
+        // First request
+        const first = mockReqRes({ headers: { 'idempotency-key': key }, body: body1 })
         idempotencyMiddleware(first.req, first.res, first.next)
         first.res.status(200).json({ success: true })
 
-        // Different payload → conflict
-        const second = mockReqRes({ headers: { 'idempotency-key': key }, body: { portfolioId: 'p-different' } })
+        // Different values → conflict
+        const second = mockReqRes({ headers: { 'idempotency-key': key }, body: body2 })
         idempotencyMiddleware(second.req, second.res, second.next)
 
         expect(second.state.nextCalled).toBe(false)
         expect(second.state.sentStatus).toBe(409)
         expect((second.state.sentBody as any).error.message).toMatch(/different request payload/)
-        expect((second.state.sentBody as any).error.details.idempotencyKey).toBe(key)
     })
 
     it('error responses (4xx) are also stored and replayed', async () => {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -309,3 +309,14 @@ export interface RebalanceRollback {
     rolledBackTrades: number
     failures: string[]
 }
+
+export interface IdempotencyRecord {
+    key: string
+    requestHash: string
+    method: string
+    path: string
+    statusCode: number
+    responseBody: string
+    createdAt: string
+    expiresAt: string
+}

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -18,3 +18,15 @@ export function parseOptionalBoolean(value: unknown): boolean | undefined {
     }
     return undefined;
 }
+
+export function stableStringify(obj: unknown): string {
+    if (obj === null || typeof obj !== 'object') {
+        return JSON.stringify(obj);
+    }
+    if (Array.isArray(obj)) {
+        return `[${obj.map(stableStringify).join(',')}]`;
+    }
+    const keys = Object.keys(obj).sort();
+    const entries = keys.map(key => `${JSON.stringify(key)}:${stableStringify((obj as any)[key])}`);
+    return `{${entries.join(',')}}`;
+}

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -21,7 +21,7 @@ export function parseOptionalBoolean(value: unknown): boolean | undefined {
 
 export function stableStringify(obj: unknown): string {
     if (obj === null || typeof obj !== 'object') {
-        return JSON.stringify(obj);
+        return JSON.stringify(obj) ?? 'null';
     }
     if (Array.isArray(obj)) {
         return `[${obj.map(stableStringify).join(',')}]`;


### PR DESCRIPTION
Closes #444 

 ## Changes Made:

  1. Type Migration: Moved IdempotencyRecord from backend/src/db/idempotencyDb.ts to backend/src/types/index.ts for better architectural consistency.
  2. Stable Hashing:
    - Implemented stableStringify in backend/src/utils/helpers.ts. This ensures that JSON objects are stringified consistently by sorting keys, making the
  hash resistant to differences in key order (semantic equivalence).
    - Updated backend/src/middleware/idempotency.ts to use stableStringify instead of JSON.stringify when calculating the requestHash.
  3. Verification:
    - Added new test cases in backend/src/test/idempotency.test.ts to verify:
        - Semantic Equivalence: Requests with the same payload but different key order are correctly identified as replays.
      - Value Mismatch: Requests with different values for the same keys are correctly rejected with a 409 Conflict.
    - Ran the test suite and confirmed that all 14 tests passed.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Idempotency checking now correctly recognizes request payloads as identical regardless of JSON property key ordering, ensuring proper request replay detection and conflict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->