### PR TITLE
feat(frontend): portfolio clone, dev drawer, API probe, and price cac…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,8 @@ import {
     onAuthSessionExpired,
     onAuthSessionRestored,
 } from './services/authService'
+import DeveloperDrawer from './components/DeveloperDrawer'
+import { checkApiCompatibility, type ApiCompatibilityResult } from './config/apiCompatibility'
 
 function App() {
     const queryClient = useQueryClient()
@@ -35,12 +37,34 @@ function App() {
     const [sessionRecoverySource, setSessionRecoverySource] = useState<string | null>(null)
     const [isRecoveringSession, setIsRecoveringSession] = useState(false)
     const { notices, loadError, loading: readinessLoading } = useReadinessReport()
+    const [apiCompatibility, setApiCompatibility] = useState<ApiCompatibilityResult | null>(null)
+    const [apiCompatibilityDismissed, setApiCompatibilityDismissed] = useState(false)
+    const [apiCompatibilityLoading, setApiCompatibilityLoading] = useState(true)
 
     const showBackendBanner = loadError || notices.length > 0
-    const contentTopPad = showBackendBanner ? 'pt-14' : 'pt-4'
+    const showApiCompatibilityBanner =
+        !apiCompatibilityDismissed &&
+        apiCompatibility !== null &&
+        apiCompatibility.severity !== 'ok'
+    const contentTopPad =
+        showBackendBanner && showApiCompatibilityBanner
+            ? 'pt-28'
+            : showBackendBanner || showApiCompatibilityBanner
+              ? 'pt-14'
+              : 'pt-4'
 
     useEffect(() => {
         checkWalletConnection()
+    }, [])
+
+    useEffect(() => {
+        const controller = new AbortController()
+        setApiCompatibilityLoading(true)
+        void checkApiCompatibility(controller.signal).then((result) => {
+            setApiCompatibility(result)
+            setApiCompatibilityLoading(false)
+        })
+        return () => controller.abort()
     }, [])
 
     useEffect(() => {
@@ -212,6 +236,42 @@ function App() {
                 loading={readinessLoading}
                 belowRealtimeBar={false}
             />
+            {showApiCompatibilityBanner && apiCompatibility ? (
+                <div
+                    className={`fixed left-0 right-0 z-40 border-b px-4 py-3 text-sm ${
+                        showBackendBanner ? 'top-14' : 'top-0'
+                    } ${
+                        apiCompatibility.severity === 'error'
+                            ? 'border-red-200 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950/80 dark:text-red-100'
+                            : 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900 dark:bg-amber-950/80 dark:text-amber-100'
+                    }`}
+                    role="alert"
+                >
+                    <div className="mx-auto flex max-w-7xl items-start justify-between gap-4">
+                        <div>
+                            <p className="font-semibold">{apiCompatibility.title}</p>
+                            <p className="mt-1 opacity-90">{apiCompatibility.message}</p>
+                            <p className="mt-1 text-xs opacity-75">
+                                Target: {apiCompatibility.configuredOrigin}
+                                {apiCompatibility.configuredApiRoot}
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={() => setApiCompatibilityDismissed(true)}
+                            className="shrink-0 rounded px-2 py-1 text-xs font-medium hover:bg-black/5 dark:hover:bg-white/10"
+                        >
+                            Dismiss
+                        </button>
+                    </div>
+                </div>
+            ) : null}
+            {apiCompatibilityLoading && !apiCompatibility ? (
+                <span className="sr-only" role="status">
+                    Checking API configuration
+                </span>
+            ) : null}
+            <DeveloperDrawer publicKey={publicKey} />
             {sessionRecovery ? (
                 <div
                     className="fixed bottom-4 right-4 z-50 w-[min(24rem,calc(100vw-2rem))] rounded-2xl border border-amber-200 bg-amber-50 p-4 text-amber-950 shadow-xl dark:border-amber-900 dark:bg-amber-950/80 dark:text-amber-50"

--- a/frontend/src/components/Dashboard.test.tsx
+++ b/frontend/src/components/Dashboard.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import Dashboard from './Dashboard'
 
 const queryMocks = vi.hoisted(() => ({
@@ -97,6 +98,13 @@ class TestErrorBoundary extends React.Component<{ children: React.ReactNode }, {
     }
 }
 
+function renderDashboard(ui: React.ReactElement) {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
 describe('Dashboard', () => {
     beforeEach(() => {
         cleanup()
@@ -110,10 +118,53 @@ describe('Dashboard', () => {
     })
 
     it('renders onboarding CTA for an empty portfolio', async () => {
-        render(<Dashboard onNavigate={vi.fn()} publicKey="GABC1234TEST" />)
+        renderDashboard(<Dashboard onNavigate={vi.fn()} publicKey="GABC1234TEST" />)
 
         expect(await screen.findByRole('button', { name: /create portfolio/i })).toBeTruthy()
         expect(screen.getByText(/portfolio dashboard/i)).toBeTruthy()
+    })
+
+    it('offers clone as new when a saved portfolio is loaded', async () => {
+        queryMocks.useUserPortfolios.mockReturnValue({
+            data: [{
+                id: 'p-1',
+                totalValue: 5000,
+                threshold: 5,
+                slippageTolerance: 1,
+                strategy: 'threshold',
+                allocations: [
+                    { asset: 'XLM', target: 60, amount: 3000 },
+                    { asset: 'USDC', target: 40, amount: 2000 },
+                ]
+            }],
+            isLoading: false
+        })
+        queryMocks.usePortfolioDetails.mockReturnValue({
+            data: {
+                id: 'p-1',
+                threshold: 5,
+                slippageTolerance: 1,
+                strategy: 'threshold',
+                allocations: [
+                    { asset: 'XLM', target: 60 },
+                    { asset: 'USDC', target: 40 },
+                ],
+            },
+            isLoading: false,
+        })
+        queryMocks.usePrices.mockReturnValue({
+            data: {
+                prices: { XLM: { price: 0.12, change: 1.1 }, USDC: { price: 1, change: 0 } },
+                feedMeta: null
+            },
+            isLoading: false
+        })
+
+        const onNavigate = vi.fn()
+        renderDashboard(<Dashboard onNavigate={onNavigate} publicKey="GABC1234TEST" />)
+
+        fireEvent.click(await screen.findByRole('button', { name: /clone as new/i }))
+        expect(onNavigate).toHaveBeenCalledWith('setup')
     })
 
     it('renders asset cards when portfolio data is populated', async () => {
@@ -137,7 +188,7 @@ describe('Dashboard', () => {
             isLoading: false
         })
 
-        render(<Dashboard onNavigate={vi.fn()} publicKey="GABC1234TEST" />)
+        renderDashboard(<Dashboard onNavigate={vi.fn()} publicKey="GABC1234TEST" />)
 
         expect(await screen.findByText('Asset Card XLM')).toBeTruthy()
         expect(screen.getByText('Asset Card USDC')).toBeTruthy()
@@ -147,7 +198,7 @@ describe('Dashboard', () => {
         queryMocks.useUserPortfolios.mockReturnValue({ data: undefined, isLoading: true })
         queryMocks.usePrices.mockReturnValue({ data: undefined, isLoading: true })
 
-        render(<Dashboard onNavigate={vi.fn()} publicKey="GABC1234TEST" />)
+        renderDashboard(<Dashboard onNavigate={vi.fn()} publicKey="GABC1234TEST" />)
 
         expect(await screen.findByText(/loading portfolio data/i)).toBeTruthy()
     })
@@ -158,7 +209,7 @@ describe('Dashboard', () => {
             throw new Error('portfolio fetch failed')
         })
 
-        render(
+        renderDashboard(
             <TestErrorBoundary>
                 <Dashboard onNavigate={vi.fn()} publicKey="GABC1234TEST" />
             </TestErrorBoundary>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react'
 import { motion } from 'framer-motion'
 import { PieChart, Pie, Cell, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
-import { TrendingUp, AlertCircle, RefreshCw, ArrowLeft, ExternalLink, Trash2, Plus, CheckCircle, Zap } from 'lucide-react'
+import { TrendingUp, AlertCircle, RefreshCw, ArrowLeft, ExternalLink, Trash2, Plus, CheckCircle, Zap, Copy } from 'lucide-react'
 import ThemeToggle from './ThemeToggle'
 import { useTheme } from '../context/ThemeContext'
 import AssetCard from './AssetCard'
@@ -24,16 +24,17 @@ import RouteErrorState from './RouteErrorState'
 //  NEW: export utils (create frontend/src/utils/export.ts first)
 import { downloadCSV, downloadJSON, toCSV } from '../utils/export'
 import { downloadPortfolioExport } from '../config/api'
+import { buildPortfolioCloneDraft, savePortfolioCloneDraft } from '../utils/portfolioCloneDraft'
 
 interface DashboardProps {
     onNavigate: (view: string) => void
     publicKey: string | null
 }
 
-type DashboardPriceRow = { price?: number; change?: number;[key: string]: unknown }
+type DashboardPriceRow = { price?: number; change?: number; [key: string]: unknown }
 
 const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
-    const [activeTab, setActiveTab] = useState<'overview' | 'analytics' | 'notifications' | 'test-notifications'>('overview')
+    const [activeTab, setActiveTab] = useState<'overview' | 'analytics' | 'notifications'>('overview')
     const { isDark } = useTheme()
 
     // Query for user portfolios
@@ -105,767 +106,838 @@ const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
         !portfoliosLoading &&
         (!portfolios || portfolios.length === 0)
     )
+    const feedMeta = priceBundle?.feedMeta
+
+    const executeRebalance = async () => {
+        if (!portfolioData?.id || portfolioData.id === 'demo') {
+            alert('Rebalancing not available in demo mode. Please create a real portfolio.')
+            return
+        }
+
+        try {
+            const result = await executeRebalanceMutation.mutateAsync()
+            alert(`Rebalance executed successfully! Gas used: ${result.result?.gasUsed || 'N/A'}`)
+        } catch (error: any) {
+            console.error('Rebalance failed:', error)
+            const msg = error.message ?? 'Rebalance failed. Please try again.'
+            const isSlippage = typeof msg === 'string' && (msg.toLowerCase().includes('slippage') || msg.toLowerCase().includes('tolerance'))
+            alert(isSlippage ? `Slippage too high: ${msg}` : msg)
+        }
+    }
+
+    const estimateXlm = rebalanceEstimate?.gasEstimateXlm ?? 0
+    const estimateUsd = rebalanceEstimate?.gasEstimateUsd ?? 0
+    const hasHighGasWarning = rebalanceEstimate?.gasWarning || estimateXlm > 0.5
+
+    const queryClient = useQueryClient()
+
+    const refreshData = useCallback(async () => {
+        // Invalidate all relevant queries to force a refetch without a full page reload.
+        // This leverages TanStack Query's cache invalidation instead of the naive window.location.reload().
+        await Promise.all([
+            queryClient.invalidateQueries({ queryKey: portfolioKeys.all }),
+            queryClient.invalidateQueries({ queryKey: priceKeys.all }),
+        ])
+    }, [queryClient])
+
+    const retryPortfolioLoad = useCallback(async () => {
+        await Promise.all([
+            refetchPortfolios(),
+            refetchPortfolioDetails(),
+            refetchPrices(),
+        ])
+        await refreshData()
+    }, [refetchPortfolioDetails, refetchPortfolios, refetchPrices, refreshData])
+
+    // NEW: Demo reset functionality for local testing
+    const [showDemoResetConfirm, setShowDemoResetConfirm] = useState(false)
+    const [resettingDemo, setResettingDemo] = useState(false)
+    
+    const resetDemoPortfolio = useCallback(async () => {
+        if (publicKey) return // Only available in demo mode
+        
+        setResettingDemo(true)
+        try {
+            // Clear any cached demo data and force refresh
+            await queryClient.invalidateQueries({ queryKey: portfolioKeys.all })
+            await queryClient.invalidateQueries({ queryKey: priceKeys.all })
+            
+            // Small delay to show loading state
+            await new Promise(resolve => setTimeout(resolve, 500))
+            
+            setShowDemoResetConfirm(false)
+        } catch (error) {
+            console.error('Demo reset failed:', error)
+            alert('Failed to reset demo portfolio. Please refresh the page.')
+        } finally {
+            setResettingDemo(false)
+        }
+    }, [publicKey, queryClient])
+
+    const disconnectWallet = async () => {
+        if (publicKey) {
+            await authLogout(publicKey)
+        }
+        StellarWallet.disconnect()
+        onNavigate('landing')
+    }
+
+    /** GDPR: Delete all user data from the server, then logout and go to landing */
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+    const [deleting, setDeleting] = useState(false)
+    const deleteMyData = async () => {
+        if (!publicKey) return
+        setDeleting(true)
+        try {
+            await api.delete(ENDPOINTS.USER_DATA_DELETE(publicKey))
+            await authLogout(publicKey)
+            StellarWallet.disconnect()
+            setShowDeleteConfirm(false)
+            onNavigate('landing')
+        } catch (e) {
+            console.error('Delete data failed', e)
+            alert(e instanceof Error ? e.message : 'Failed to delete data. Please try again.')
+        } finally {
+            setDeleting(false)
+        }
+    }
+
+    // Create allocation data from portfolio data
+    const allocationData = portfolioData?.allocations?.map((alloc: any, index: number) => ({
+        name: alloc.asset,
+        value: alloc.target || alloc.percentage, // Handle both formats
+        amount: alloc.amount || 0,
+        color: ['#3B82F6', '#10B981', '#F59E0B', '#EF4444'][index] || '#6B7280'
+    })) || []
+
+    // If portfolio has allocations object instead of array, convert it
+    if (portfolioData?.allocations && typeof portfolioData.allocations === 'object' && !Array.isArray(portfolioData.allocations)) {
+        const allocationsArray = Object.entries(portfolioData.allocations).map(([asset, percentage], index) => ({
+            name: asset,
+            value: percentage as number,
+            amount: (portfolioData.totalValue || 10000) * (percentage as number) / 100,
+            color: ['#3B82F6', '#10B981', '#F59E0B', '#EF4444'][index] || '#6B7280'
+        }))
+        allocationData.splice(0, allocationData.length, ...allocationsArray)
+    }
+
+    const missingPriceAssets = allocationData.filter((asset) => {
+        const row = prices[asset.name]
+        return !row || row.price === undefined || row.price === null
+    })
+    const pricedAssets = allocationData.length - missingPriceAssets.length
+    const hasPartialPriceData = pricedAssets > 0 && missingPriceAssets.length > 0
+    const partialPriceMessage = hasPartialPriceData
+        ? `Some asset quotes are unavailable or fallback-based. ${missingPriceAssets.length} asset${missingPriceAssets.length !== 1 ? 's are' : ' is'} missing fresh market data.`
+        : null
     const priceSource = hasLivePriceRows
         ? formatPriceFeedSummary(priceBundle?.feedMeta, true, false)
         : publicKey
-            ? 'No price data'
-            : 'Demo data'
-    const effectivePriceSource = hasPartialPriceData
-        ? 'Partial price data'
-        : priceSource
-    const feedMeta = priceBundle?.feedMeta
+          ? 'No price data'
+          : 'Demo data'
+    const effectivePriceSource = hasPartialPriceData ? 'Partial price data' : priceSource
     const showPriceQualityNote = !!(feedMeta?.degraded || feedMeta?.staleOrLimited || hasPartialPriceData)
-}
 
-try {
-    const result = await executeRebalanceMutation.mutateAsync()
-    alert(`Rebalance executed successfully! Gas used: ${result.result?.gasUsed || 'N/A'}`)
-} catch (error: any) {
-    console.error('Rebalance failed:', error)
-    const msg = error.message ?? 'Rebalance failed. Please try again.'
-    const isSlippage = typeof msg === 'string' && (msg.toLowerCase().includes('slippage') || msg.toLowerCase().includes('tolerance'))
-    alert(isSlippage ? `Slippage too high: ${msg}` : msg)
-}
-    }
-
-const estimateXlm = rebalanceEstimate?.gasEstimateXlm ?? 0
-const estimateUsd = rebalanceEstimate?.gasEstimateUsd ?? 0
-const hasHighGasWarning = rebalanceEstimate?.gasWarning || estimateXlm > 0.5
-
-const queryClient = useQueryClient()
-
-const refreshData = useCallback(async () => {
-    // Invalidate all relevant queries to force a refetch without a full page reload.
-    // This leverages TanStack Query's cache invalidation instead of the naive window.location.reload().
-    await Promise.all([
-        queryClient.invalidateQueries({ queryKey: portfolioKeys.all }),
-        queryClient.invalidateQueries({ queryKey: priceKeys.all }),
-    ])
-}, [queryClient])
-
-const retryPortfolioLoad = useCallback(async () => {
-    await Promise.all([
-        refetchPortfolios(),
-        refetchPortfolioDetails(),
-        refetchPrices(),
-    ])
-    await refreshData()
-}, [refetchPortfolioDetails, refetchPortfolios, refetchPrices, refreshData])
-
-// NEW: Demo reset functionality for local testing
-const [showDemoResetConfirm, setShowDemoResetConfirm] = useState(false)
-const [resettingDemo, setResettingDemo] = useState(false)
-
-const resetDemoPortfolio = useCallback(async () => {
-    if (publicKey) return // Only available in demo mode
-
-    setResettingDemo(true)
-    try {
-        // Clear any cached demo data and force refresh
-        await queryClient.invalidateQueries({ queryKey: portfolioKeys.all })
-        await queryClient.invalidateQueries({ queryKey: priceKeys.all })
-
-        // Small delay to show loading state
-        await new Promise(resolve => setTimeout(resolve, 500))
-
-        setShowDemoResetConfirm(false)
-    } catch (error) {
-        console.error('Demo reset failed:', error)
-        alert('Failed to reset demo portfolio. Please refresh the page.')
-    } finally {
-        setResettingDemo(false)
-    }
-}, [publicKey, queryClient])
-
-const disconnectWallet = async () => {
-    if (publicKey) {
-        await authLogout(publicKey)
-    }
-    StellarWallet.disconnect()
-    onNavigate('landing')
-}
-
-/** GDPR: Delete all user data from the server, then logout and go to landing */
-const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-const [deleting, setDeleting] = useState(false)
-const deleteMyData = async () => {
-    if (!publicKey) return
-    setDeleting(true)
-    try {
-        await api.delete(ENDPOINTS.USER_DATA_DELETE(publicKey))
-        await authLogout(publicKey)
-        StellarWallet.disconnect()
-        setShowDeleteConfirm(false)
-        onNavigate('landing')
-    } catch (e) {
-        console.error('Delete data failed', e)
-        alert(e instanceof Error ? e.message : 'Failed to delete data. Please try again.')
-    } finally {
-        setDeleting(false)
-    }
-}
-
-// Create allocation data from portfolio data
-const allocationData = portfolioData?.allocations?.map((alloc: any, index: number) => ({
-    name: alloc.asset,
-    value: alloc.target || alloc.percentage, // Handle both formats
-    amount: alloc.amount || 0,
-    color: ['#3B82F6', '#10B981', '#F59E0B', '#EF4444'][index] || '#6B7280'
-})) || []
-
-// If portfolio has allocations object instead of array, convert it
-if (portfolioData?.allocations && typeof portfolioData.allocations === 'object' && !Array.isArray(portfolioData.allocations)) {
-    const allocationsArray = Object.entries(portfolioData.allocations).map(([asset, percentage], index) => ({
-        name: asset,
-        value: percentage as number,
-        amount: (portfolioData.totalValue || 10000) * (percentage as number) / 100,
-        color: ['#3B82F6', '#10B981', '#F59E0B', '#EF4444'][index] || '#6B7280'
-    }))
-    allocationData.splice(0, allocationData.length, ...allocationsArray)
-}
-
-const missingPriceAssets = allocationData.filter((asset) => {
-    const row = prices[asset.name]
-    return !row || row.price === undefined || row.price === null
-})
-const pricedAssets = allocationData.length - missingPriceAssets.length
-const hasPartialPriceData = pricedAssets > 0 && missingPriceAssets.length > 0
-const partialPriceMessage = hasPartialPriceData
-    ? `Some asset quotes are unavailable or fallback-based. ${missingPriceAssets.length} asset${missingPriceAssets.length !== 1 ? 's are' : ' is'} missing fresh market data.`
-    : null
-
-// NEW: Export helpers (Portfolio CSV / JSON) - works in demo mode too
-const buildPortfolioExportRows = () => {
-    const rows = (allocationData || []).map((a: any) => {
-        const price = prices?.[a.name]?.price ?? ''
-        const change = prices?.[a.name]?.change ?? ''
-        return {
-            asset: a.name,
-            targetPct: a.value ?? '',
-            amount: a.amount ?? '',
-            priceUsd: price,
-            change24hPct: change
+    const startClonePortfolio = () => {
+        if (!portfolioData || typeof portfolioData !== 'object') return
+        const draft = buildPortfolioCloneDraft(portfolioData as Record<string, unknown>)
+        if (!draft) {
+            alert('This portfolio cannot be cloned. Create or open a saved portfolio first.')
+            return
         }
-    })
-    return rows
-}
-
-const exportPortfolioCSV = () => {
-    if (!portfolioData) return
-    const rows = buildPortfolioExportRows()
-    const csv = toCSV(rows, ['asset', 'targetPct', 'amount', 'priceUsd', 'change24hPct'])
-    const filename = `portfolio_${publicKey ? publicKey.slice(0, 6) : 'demo'}_${new Date().toISOString()}.csv`
-    downloadCSV(filename, csv)
-}
-
-const exportPortfolioJSON = () => {
-    if (!portfolioData) return
-    const filename = `portfolio_${publicKey ? publicKey.slice(0, 6) : 'demo'}_${new Date().toISOString()}.json`
-    downloadJSON(filename, {
-        exportedAt: new Date().toISOString(),
-        mode: publicKey ? 'wallet' : 'demo',
-        portfolio: portfolioData,
-        prices
-    })
-}
-
-/** Server-side export (full data + rebalance history) — use when connected with real portfolio */
-const exportFromApi = async (format: 'json' | 'csv' | 'pdf') => {
-    if (!portfolioData?.id || portfolioData.id === 'demo') {
-        alert('Connect your wallet and open a portfolio to export full data (JSON/CSV/PDF) from the server.')
-        return
+        savePortfolioCloneDraft(draft)
+        onNavigate('setup')
     }
-    try {
-        await downloadPortfolioExport(portfolioData.id, format)
-    } catch (e) {
-        console.error('Export failed', e)
-        alert(e instanceof Error ? e.message : 'Export failed. Please try again.')
+
+    // NEW: Export helpers (Portfolio CSV / JSON) - works in demo mode too
+    const buildPortfolioExportRows = () => {
+        const rows = (allocationData || []).map((a: any) => {
+            const price = prices?.[a.name]?.price ?? ''
+            const change = prices?.[a.name]?.change ?? ''
+            return {
+                asset: a.name,
+                targetPct: a.value ?? '',
+                amount: a.amount ?? '',
+                priceUsd: price,
+                change24hPct: change
+            }
+        })
+        return rows
     }
-}
 
-const performanceData = [
-    { date: '1/1', value: 10000 },
-    { date: '1/2', value: 10250 },
-    { date: '1/3', value: 10100 },
-    { date: '1/4', value: 10800 },
-    { date: '1/5', value: 11200 },
-    { date: '1/6', value: portfolioData?.totalValue || 10000 }
-]
+    const exportPortfolioCSV = () => {
+        if (!portfolioData) return
+        const rows = buildPortfolioExportRows()
+        const csv = toCSV(rows, ['asset', 'targetPct', 'amount', 'priceUsd', 'change24hPct'])
+        const filename = `portfolio_${publicKey ? publicKey.slice(0, 6) : 'demo'}_${new Date().toISOString()}.csv`
+        downloadCSV(filename, csv)
+    }
 
-const walletType = StellarWallet.getWalletType()
-const contractAddress = 'CCQ4LISQJFTZJKQDRJHRLXQ2UML45GVXUECN5NGSQKAT55JKAK2JAX7I'
+    const exportPortfolioJSON = () => {
+        if (!portfolioData) return
+        const filename = `portfolio_${publicKey ? publicKey.slice(0, 6) : 'demo'}_${new Date().toISOString()}.json`
+        downloadJSON(filename, {
+            exportedAt: new Date().toISOString(),
+            mode: publicKey ? 'wallet' : 'demo',
+            portfolio: portfolioData,
+            prices
+        })
+    }
 
-if (routeDataUnavailable) {
-    return (
-        <RouteErrorState
-            title="Portfolio data is unavailable"
-            message={
-                portfoliosError instanceof Error
-                    ? portfoliosError.message
-                    : 'We could not load the portfolio list for this wallet.'
-            }
-            detail={
-                detailsLoadError && detailsError instanceof Error
-                    ? `Latest portfolio details also failed to load: ${detailsError.message}`
-                    : pricesLoadError
-                        ? 'Price data failed to refresh. The retry action will attempt a full refetch.'
-                        : 'Retrying will refetch portfolio data and the latest price feed.'
-            }
-            onRetry={retryPortfolioLoad}
-            onBack={() => onNavigate('landing')}
-            retryLabel="Retry loading"
-            backLabel="Go to landing"
-        />
-    )
-}
+    /** Server-side export (full data + rebalance history) — use when connected with real portfolio */
+    const exportFromApi = async (format: 'json' | 'csv' | 'pdf') => {
+        if (!portfolioData?.id || portfolioData.id === 'demo') {
+            alert('Connect your wallet and open a portfolio to export full data (JSON/CSV/PDF) from the server.')
+            return
+        }
+        try {
+            await downloadPortfolioExport(portfolioData.id, format)
+        } catch (e) {
+            console.error('Export failed', e)
+            alert(e instanceof Error ? e.message : 'Export failed. Please try again.')
+        }
+    }
 
-if (loading) {
-    return (
-        <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
-            <div className="text-center">
-                <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-500 mx-auto"></div>
-                <p className="mt-4 text-gray-600 dark:text-gray-400">Loading portfolio data...</p>
+    const performanceData = [
+        { date: '1/1', value: 10000 },
+        { date: '1/2', value: 10250 },
+        { date: '1/3', value: 10100 },
+        { date: '1/4', value: 10800 },
+        { date: '1/5', value: 11200 },
+        { date: '1/6', value: portfolioData?.totalValue || 10000 }
+    ]
+
+    const walletType = StellarWallet.getWalletType()
+    const contractAddress = 'CCQ4LISQJFTZJKQDRJHRLXQ2UML45GVXUECN5NGSQKAT55JKAK2JAX7I'
+
+    if (routeDataUnavailable) {
+        return (
+            <RouteErrorState
+                title="Portfolio data is unavailable"
+                message={
+                    portfoliosError instanceof Error
+                        ? portfoliosError.message
+                        : 'We could not load the portfolio list for this wallet.'
+                }
+                detail={
+                    detailsLoadError && detailsError instanceof Error
+                        ? `Latest portfolio details also failed to load: ${detailsError.message}`
+                        : pricesLoadError
+                          ? 'Price data failed to refresh. The retry action will attempt a full refetch.'
+                          : 'Retrying will refetch portfolio data and the latest price feed.'
+                }
+                onRetry={retryPortfolioLoad}
+                onBack={() => onNavigate('landing')}
+                retryLabel="Retry loading"
+                backLabel="Go to landing"
+            />
+        )
+    }
+
+    if (loading) {
+        return (
+            <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+                <div className="text-center">
+                    <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-500 mx-auto"></div>
+                    <p className="mt-4 text-gray-600 dark:text-gray-400">Loading portfolio data...</p>
+                </div>
             </div>
-        </div>
-    )
-}
+        )
+    }
 
+    return (
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+            {/* Header */}
+            <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-6 py-4">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center">
+                        <button
+                            onClick={() => onNavigate('landing')}
+                            className="mr-4 p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
+                        >
+                            <ArrowLeft className="w-5 h-5" />
+                        </button>
+                        <div>
+                            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Portfolio Dashboard</h1>
+                            {publicKey ? (
+                                <div className="flex items-center space-x-4 mt-1">
+                                    <div className="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400">
+                                        <span className="capitalize font-medium">
+                                            {walletType} Wallet
+                                        </span>
+                                        <span>{publicKey.slice(0, 4)}...{publicKey.slice(-4)}</span>
+                                    </div>
+                                    <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-500">
+                                        <span>Contract:</span>
+                                        <code className="bg-gray-100 dark:bg-gray-700 px-1 rounded">{contractAddress.slice(0, 4)}...{contractAddress.slice(-4)}</code>
+                                        <a
+                                            href={`https://stellar.expert/explorer/testnet/contract/${contractAddress}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-blue-600 hover:text-blue-700"
+                                        >
+                                            <ExternalLink className="w-3 h-3" />
+                                        </a>
+                                    </div>
+                                </div>
+                            ) : (
+                                <span className="text-sm bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-300 px-2 py-1 rounded mt-1 inline-block">
+                                    Demo Mode - Connect wallet for full functionality
+                                </span>
+                            )}
+                        </div>
+                    </div>
 
+                    <div className="flex items-center space-x-1 sm:space-x-4">
+                        <ThemeToggle />
+                        {/*  NEW: Export buttons — server-side (full data + history) when connected, client-side for demo */}
+                        <div className="hidden sm:flex items-center space-x-2">
+                            {publicKey && portfolioData?.id && portfolioData.id !== 'demo' ? (
+                                <>
+                                    <button
+                                        onClick={() => exportFromApi('json')}
+                                        className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors"
                                     >
-                                        <ExternalLink className="w-3 h-3" />
-                                    </a>
-                                </div>
-                            </div>
-                        ) : (
-                            <span className="text-sm bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-300 px-2 py-1 rounded mt-1 inline-block">
-                                Demo Mode - Connect wallet for full functionality
-                            </span>
-                        )}
-                    </div>
-                </div>
-
-                <div className="flex items-center space-x-4">
-                    <ThemeToggle />
-                    {/*  NEW: Export buttons — server-side (full data + history) when connected, client-side for demo */}
-                    <div className="flex items-center space-x-2">
-                        {publicKey && portfolioData?.id && portfolioData.id !== 'demo' ? (
-                            <>
-                                <button
-                                    onClick={() => exportFromApi('json')}
-                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors"
-                                >
-                                    Export JSON
-                                </button>
-                                <button
-                                    onClick={() => exportFromApi('csv')}
-                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors"
-                                >
-                                    Export CSV
-                                </button>
-                                <button
-                                    onClick={() => exportFromApi('pdf')}
-                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors"
-                                >
-                                    Export PDF
-                                </button>
-                            </>
-                        ) : (
-                            <>
-                                <button
-                                    onClick={exportPortfolioCSV}
-                                    disabled={!portfolioData}
-                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors disabled:opacity-50"
-                                >
-                                    Export CSV
-                                </button>
-                                <button
-                                    onClick={exportPortfolioJSON}
-                                    disabled={!portfolioData}
-                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors disabled:opacity-50"
-                                >
-                                    Export JSON
-                                </button>
-                                <span className="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">Connect wallet for full export (PDF + history)</span>
-                            </>
-                        )}
-                    </div>
-
-                    {publicKey ? (
-                        <>
-                            <button
-                                onClick={() => setShowDeleteConfirm(true)}
-                                className="text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 px-3 py-2 text-sm transition-colors flex items-center gap-1"
-                                title="Delete my data (GDPR)"
-                            >
-                                <Trash2 className="w-4 h-4" />
-                                Delete my data
-                            </button>
-                            <button
-                                onClick={() => onNavigate('setup')}
-                                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-                            >
-                                Create Portfolio
-                            </button>
-                            <button
-                                onClick={disconnectWallet}
-                                className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 px-3 py-2 text-sm transition-colors"
-                            >
-                                Disconnect
-                            </button>
-                        </>
-                    ) : (
-                        <>
-                            <button
-                                onClick={() => onNavigate('landing')}
-                                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-                            >
-                                Connect Wallet
-                            </button>
-                            {/* NEW: Demo reset button for local testing */}
-                            <button
-                                onClick={() => setShowDemoResetConfirm(true)}
-                                className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
-                                title="Reset demo portfolio to default state"
-                            >
-                                <RefreshCw className="w-4 h-4" />
-                                Reset Demo
-                            </button>
-                        </>
-                    )}
-                    <button
-                        onClick={refreshData}
-                        disabled={loading}
-                        className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
-                    >
-                        <RefreshCw className={`w-5 h-5 ${loading ? 'animate-spin' : ''}`} />
-                    </button>
-                </div>
-            </div>
-        </div>
-
-
-                        <button
-                            onClick={() => setShowDeleteConfirm(false)}
-                            disabled={deleting}
-                            className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
-                        >
-                            Cancel
-                        </button>
-                        <button
-                            onClick={deleteMyData}
-                            disabled={deleting}
-                            className="px-4 py-2 bg-red-600 hover:bg-red-700 disabled:bg-red-400 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
-                        >
-                            {deleting ? (
-                                <>
-                                    <RefreshCw className="w-4 h-4 animate-spin" />
-                                    Deleting...
+                                        Export JSON
+                                    </button>
+                                    <button
+                                        onClick={() => exportFromApi('csv')}
+                                        className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors"
+                                    >
+                                        Export CSV
+                                    </button>
+                                    <button
+                                        onClick={() => exportFromApi('pdf')}
+                                        className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors"
+                                    >
+                                        Export PDF
+                                    </button>
                                 </>
                             ) : (
                                 <>
-                                    <Trash2 className="w-4 h-4" />
-                                    Delete all my data
+                                    <button
+                                        onClick={exportPortfolioCSV}
+                                        disabled={!portfolioData}
+                                        className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors disabled:opacity-50"
+                                    >
+                                        Export CSV
+                                    </button>
+                                    <button
+                                        onClick={exportPortfolioJSON}
+                                        disabled={!portfolioData}
+                                        className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors disabled:opacity-50"
+                                    >
+                                        Export JSON
+                                    </button>
+                                    <span className="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">Connect wallet for full export (PDF + history)</span>
                                 </>
-                            )}
-                        </button>
-                    </div>
-                </div>
-            </div>
-        )}
-
-        {/* NEW: Demo reset confirmation modal */}
-        {showDemoResetConfirm && (
-            <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50 p-4">
-                <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-md w-full p-6">
-                    <div className="flex items-center gap-2 mb-4">
-                        <RefreshCw className="w-6 h-6 text-blue-500 flex-shrink-0" />
-                        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Reset Demo Portfolio</h2>
-                    </div>
-                    <p className="text-gray-600 dark:text-gray-400 text-sm mb-6">
-                        This will reset the demo portfolio to its default state with $10,000 total value and 40% XLM / 60% USDC allocation. Perfect for testing and screenshots.
-                    </p>
-                    <div className="flex justify-end gap-3">
-                        <button
-                            onClick={() => setShowDemoResetConfirm(false)}
-                            disabled={resettingDemo}
-                            className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
-                        >
-                            Cancel
-                        </button>
-                        <button
-                            onClick={resetDemoPortfolio}
-                            disabled={resettingDemo}
-                            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
-                        >
-                            {resettingDemo ? (
-                                <>
-                                    <RefreshCw className="w-4 h-4 animate-spin" />
-                                    Resetting...
-                                </>
-                            ) : (
-                                <>
-                                    <RefreshCw className="w-4 h-4" />
-                                    Reset Demo
-                                </>
-                            )}
-                        </button>
-                    </div>
-                </div>
-            </div>
-        )}
-
-        <div className="p-6 max-w-7xl mx-auto">
-            {/* Tab Navigation */}
-            <div className="mb-6 border-b border-gray-200 dark:border-gray-700">
-                <nav className="flex space-x-8">
-                    <button
-                        onClick={() => setActiveTab('overview')}
-                        className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'overview'
-                            ? 'border-blue-500 text-blue-600 dark:text-blue-400'
-                            : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
-                            }`}
-                    >
-                        Overview
-                    </button>
-                    <button
-                        onClick={() => setActiveTab('analytics')}
-                        className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'analytics'
-                            ? 'border-blue-500 text-blue-600 dark:text-blue-400'
-                            : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
-                            }`}
-                    >
-                        Analytics
-                    </button>
-                    <button
-                        onClick={() => setActiveTab('notifications')}
-                        className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'notifications'
-                            ? 'border-blue-500 text-blue-600 dark:text-blue-400'
-                            : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
-                            }`}
-                    >
-                        Notifications
-                    </button>
-
-                </nav>
-            </div>
-
-
-                                            <div className="w-32 h-4 bg-gray-300 dark:bg-gray-700 rounded" />
-                                            <div className="w-24 h-6 bg-gray-300 dark:bg-gray-700 rounded" />
-                                        </div>
-                                    </div>
-                                    <div className="mb-4 space-y-2">
-                                        <div className="w-40 h-8 bg-gray-300 dark:bg-gray-700 rounded" />
-                                        <div className="w-32 h-4 bg-gray-300 dark:bg-gray-700 rounded" />
-                                    </div>
-                                    <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
-                                </div>
-                            ) : (
-                                <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
-                                    <div className="flex items-center justify-between mb-6">
-                                        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Portfolio Value</h2>
-                                        <div className="flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400">
-                                            <span>Last updated: just now</span>
-                                            <span
-                                                className={`px-2 py-1 rounded text-xs ${feedMeta?.degraded || hasPartialPriceData
-                                                    ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200'
-                                                    : feedMeta?.staleOrLimited
-                                                        ? 'bg-slate-200 dark:bg-slate-700 text-slate-800 dark:text-slate-200'
-                                                        : hasLivePriceRows
-                                                            ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400'
-                                                            : 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400'
-                                                    }`}
-                                            >
-                                                {effectivePriceSource}
-                                            </span>
-                                        </div>
-                                    </div>
-                                    {showPriceQualityNote && (
-                                        <p className="mb-4 text-xs text-amber-800 dark:text-amber-200/90 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 rounded-lg px-3 py-2">
-                                            {feedMeta?.degraded
-                                                ? 'Displayed prices are synthetic or fallback — not primary market data.'
-                                                : hasPartialPriceData
-                                                    ? partialPriceMessage
-                                                    : 'Price feed may be stale or rate-limited; confirm against an exchange if trading.'}
-                                        </p>
-                                    )}
-                                    <div className="mb-4">
-                                        <div className="text-3xl font-bold text-gray-900 dark:text-white">
-                                            ${portfolioData?.totalValue?.toLocaleString() || '0'}
-                                        </div>
-                                        <div className="flex items-center mt-1">
-                                            <TrendingUp className="w-4 h-4 text-green-500 mr-1" />
-                                            <span className="text-green-500 font-medium">+{portfolioData?.dayChange || 0}%</span>
-                                            <span className="text-gray-500 dark:text-gray-400 ml-2">Today</span>
-                                        </div>
-                                    </div>
-                                    <div className="h-64">
-                                        <ResponsiveContainer width="100%" height="100%">
-                                            <LineChart data={performanceData}>
-                                                <CartesianGrid strokeDasharray="3 3" stroke={isDark ? '#374151' : '#f0f0f0'} />
-                                                <XAxis dataKey="date" stroke={isDark ? '#9CA3AF' : '#666'} />
-                                                <YAxis stroke={isDark ? '#9CA3AF' : '#666'} />
-                                                <Tooltip
-                                                    contentStyle={{
-                                                        backgroundColor: isDark ? '#1F2937' : '#fff',
-                                                        border: `1px solid ${isDark ? '#374151' : '#e5e7eb'}`,
-                                                        borderRadius: '8px',
-                                                        color: isDark ? '#F9FAFB' : '#111827'
-                                                    }}
-                                                />
-                                                <Line type="monotone" dataKey="value" stroke="#3B82F6" strokeWidth={3} />
-                                            </LineChart>
-                                        </ResponsiveContainer>
-                                    </div>
-                                </div>
                             )}
                         </div>
 
-                        <div className="space-y-6">
-                            {/* Rebalance Alert */}
-                            {portfolioData?.needsRebalance && (
-                                <motion.div
-                                    initial={{ opacity: 0, scale: 0.95 }}
-                                    animate={{ opacity: 1, scale: 1 }}
-                                    className="bg-gradient-to-r from-orange-50 to-red-50 dark:from-orange-900/30 dark:to-red-900/30 border border-orange-200 dark:border-orange-800 rounded-xl p-6"
+                        {publicKey ? (
+                            <>
+                                <button
+                                    onClick={() => setShowDeleteConfirm(true)}
+                                    className="text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 px-3 py-2 text-sm transition-colors flex items-center gap-1"
+                                    title="Delete my data (GDPR)"
                                 >
-                                    <div className="flex items-center mb-3">
-                                        <AlertCircle className="w-5 h-5 text-orange-500 mr-2" />
-                                        <span className="font-medium text-orange-800 dark:text-orange-300">Rebalance Needed</span>
+                                    <Trash2 className="w-4 h-4" />
+                                    Delete my data
+                                </button>
+                                {portfolioData?.id && portfolioData.id !== 'demo' ? (
+                                    <button
+                                        onClick={startClonePortfolio}
+                                        className="border border-blue-200 dark:border-blue-700 bg-blue-50 hover:bg-blue-100 dark:bg-blue-900/30 dark:hover:bg-blue-900/50 text-blue-800 dark:text-blue-200 px-4 py-2 rounded-lg transition-colors flex items-center gap-1"
+                                        title="Copy allocations into a new portfolio"
+                                    >
+                                        <Copy className="w-4 h-4" />
+                                        Clone as new
+                                    </button>
+                                ) : null}
+                                <button
+                                    onClick={() => onNavigate('setup')}
+                                    className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
+                                >
+                                    Create Portfolio
+                                </button>
+                                <button
+                                    onClick={disconnectWallet}
+                                    className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 px-3 py-2 text-sm transition-colors"
+                                >
+                                    Disconnect
+                                </button>
+                            </>
+                        ) : (
+                            <>
+                                <button
+                                    onClick={() => onNavigate('landing')}
+                                    className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
+                                >
+                                    Connect Wallet
+                                </button>
+                                {/* NEW: Demo reset button for local testing */}
+                                <button
+                                    onClick={() => setShowDemoResetConfirm(true)}
+                                    className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
+                                    title="Reset demo portfolio to default state"
+                                >
+                                    <RefreshCw className="w-4 h-4" />
+                                    Reset Demo
+                                </button>
+                            </>
+                        )}
+                        <button
+                            onClick={refreshData}
+                            disabled={loading}
+                            className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
+                        >
+                            <RefreshCw className={`w-5 h-5 ${loading ? 'animate-spin' : ''}`} />
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            {/* Delete my data confirmation modal */}
+            {showDeleteConfirm && (
+                <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50 p-4">
+                    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-md w-full p-6">
+                        <div className="flex items-center gap-2 mb-4">
+                            <AlertCircle className="w-6 h-6 text-amber-500 flex-shrink-0" />
+                            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Delete my data</h2>
+                        </div>
+                        <p className="text-gray-600 dark:text-gray-400 text-sm mb-6">
+                            This will permanently delete your consent records, all portfolios, and rebalance history from our servers. You will be signed out. This action cannot be undone.
+                        </p>
+                        <div className="flex justify-end gap-3">
+                            <button
+                                onClick={() => setShowDeleteConfirm(false)}
+                                disabled={deleting}
+                                className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                onClick={deleteMyData}
+                                disabled={deleting}
+                                className="px-4 py-2 bg-red-600 hover:bg-red-700 disabled:bg-red-400 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
+                            >
+                                {deleting ? (
+                                    <>
+                                        <RefreshCw className="w-4 h-4 animate-spin" />
+                                        Deleting...
+                                    </>
+                                ) : (
+                                    <>
+                                        <Trash2 className="w-4 h-4" />
+                                        Delete all my data
+                                    </>
+                                )}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* NEW: Demo reset confirmation modal */}
+            {showDemoResetConfirm && (
+                <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50 p-4">
+                    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-md w-full p-6">
+                        <div className="flex items-center gap-2 mb-4">
+                            <RefreshCw className="w-6 h-6 text-blue-500 flex-shrink-0" />
+                            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Reset Demo Portfolio</h2>
+                        </div>
+                        <p className="text-gray-600 dark:text-gray-400 text-sm mb-6">
+                            This will reset the demo portfolio to its default state with $10,000 total value and 40% XLM / 60% USDC allocation. Perfect for testing and screenshots.
+                        </p>
+                        <div className="flex justify-end gap-3">
+                            <button
+                                onClick={() => setShowDemoResetConfirm(false)}
+                                disabled={resettingDemo}
+                                className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                onClick={resetDemoPortfolio}
+                                disabled={resettingDemo}
+                                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
+                            >
+                                {resettingDemo ? (
+                                    <>
+                                        <RefreshCw className="w-4 h-4 animate-spin" />
+                                        Resetting...
+                                    </>
+                                ) : (
+                                    <>
+                                        <RefreshCw className="w-4 h-4" />
+                                        Reset Demo
+                                    </>
+                                )}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            <div className="p-4 sm:p-6 max-w-7xl mx-auto">
+                {/* Tab Navigation */}
+                <div className="mb-6 border-b border-gray-200 dark:border-gray-700">
+                    <nav className="flex space-x-8">
+                        <button
+                            onClick={() => setActiveTab('overview')}
+                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'overview'
+                                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
+                                }`}
+                        >
+                            Overview
+                        </button>
+                        <button
+                            onClick={() => setActiveTab('analytics')}
+                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'analytics'
+                                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
+                                }`}
+                        >
+                            Analytics
+                        </button>
+                        <button
+                            onClick={() => setActiveTab('notifications')}
+                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'notifications'
+                                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300'
+                                }`}
+                        >
+                            Notifications
+                        </button>
+                       
+                    </nav>
+                </div>
+
+                {activeTab === 'analytics' ? (
+                    <PerformanceChart portfolioId={portfolioData?.id || null} />
+                ) : activeTab === 'notifications' ? (
+                    <NotificationPreferences userId={publicKey || 'demo'} portfolioId={portfolioData?.id || null} />
+                ) :  (
+                    <>
+                        {/* Portfolio Overview */}
+                        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6 mb-8">
+                            <div className="lg:col-span-2">
+                                {/* NEW: Portfolio Value Skeleton Loading State */}
+                                {loading ? (
+                                    <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm animate-pulse">
+                                        <div className="flex items-center justify-between mb-6">
+                                            <div className="w-32 h-6 bg-gray-300 dark:bg-gray-700 rounded" />
+                                            <div className="space-x-2 flex items-center">
+                                                <div className="w-32 h-4 bg-gray-300 dark:bg-gray-700 rounded" />
+                                                <div className="w-24 h-6 bg-gray-300 dark:bg-gray-700 rounded" />
+                                            </div>
+                                        </div>
+                                        <div className="mb-4 space-y-2">
+                                            <div className="w-40 h-8 bg-gray-300 dark:bg-gray-700 rounded" />
+                                            <div className="w-32 h-4 bg-gray-300 dark:bg-gray-700 rounded" />
+                                        </div>
+                                        <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
                                     </div>
-                                    <p className="text-sm text-orange-700 dark:text-orange-400 mb-2">
-                                        Your portfolio has drifted from target allocation
-                                    </p>
-                                    <p className="text-sm text-orange-700 dark:text-orange-400 mb-2 font-medium">
-                                        Estimated gas: {estimateXlm.toFixed(2)} XLM (~${estimateUsd.toFixed(3)})
-                                    </p>
-                                    <p className="text-xs text-orange-600 dark:text-orange-400 mb-3">
-                                        {rebalanceEstimate?.tradeCount ?? 0} estimated trade{(rebalanceEstimate?.tradeCount ?? 0) === 1 ? '' : 's'} @ {(rebalanceEstimate?.gasPerTradeXlm ?? 0).toFixed(4)} XLM each
-                                    </p>
-                                    {hasHighGasWarning && (
-                                        <p className="text-xs text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900/40 rounded px-2 py-1 mb-3">
-                                            Warning: estimated gas is unusually high ({'>'} 0.5 XLM). Consider reducing trade count.
+                                ) : (
+                                    <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
+                                        <div className="flex items-center justify-between mb-6">
+                                            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Portfolio Value</h2>
+                                            <div className="flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400">
+                                                <span>Last updated: just now</span>
+                                                <span
+                                                    className={`px-2 py-1 rounded text-xs ${
+                                                        feedMeta?.degraded || hasPartialPriceData
+                                                            ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200'
+                                                            : feedMeta?.staleOrLimited
+                                                              ? 'bg-slate-200 dark:bg-slate-700 text-slate-800 dark:text-slate-200'
+                                                              : hasLivePriceRows
+                                                                ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400'
+                                                                : 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400'
+                                                    }`}
+                                                >
+                                                    {effectivePriceSource}
+                                                </span>
+                                            </div>
+                                        </div>
+                                        {showPriceQualityNote && (
+                                            <p className="mb-4 text-xs text-amber-800 dark:text-amber-200/90 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 rounded-lg px-3 py-2">
+                                                {feedMeta?.degraded
+                                                    ? 'Displayed prices are synthetic or fallback — not primary market data.'
+                                                    : hasPartialPriceData
+                                                      ? partialPriceMessage
+                                                      : 'Price feed may be stale or rate-limited; confirm against an exchange if trading.'}
+                                            </p>
+                                        )}
+                                        <div className="mb-4">
+                                            <div className="text-3xl font-bold text-gray-900 dark:text-white">
+                                                ${portfolioData?.totalValue?.toLocaleString() || '0'}
+                                            </div>
+                                            <div className="flex items-center mt-1">
+                                                <TrendingUp className="w-4 h-4 text-green-500 mr-1" />
+                                                <span className="text-green-500 font-medium">+{portfolioData?.dayChange || 0}%</span>
+                                                <span className="text-gray-500 dark:text-gray-400 ml-2">Today</span>
+                                            </div>
+                                        </div>
+                                        <div className="h-64">
+                                            <ResponsiveContainer width="100%" height="100%">
+                                                <LineChart data={performanceData}>
+                                                    <CartesianGrid strokeDasharray="3 3" stroke={isDark ? '#374151' : '#f0f0f0'} />
+                                                    <XAxis dataKey="date" stroke={isDark ? '#9CA3AF' : '#666'} />
+                                                    <YAxis stroke={isDark ? '#9CA3AF' : '#666'} />
+                                                    <Tooltip
+                                                        contentStyle={{
+                                                            backgroundColor: isDark ? '#1F2937' : '#fff',
+                                                            border: `1px solid ${isDark ? '#374151' : '#e5e7eb'}`,
+                                                            borderRadius: '8px',
+                                                            color: isDark ? '#F9FAFB' : '#111827'
+                                                        }}
+                                                    />
+                                                    <Line type="monotone" dataKey="value" stroke="#3B82F6" strokeWidth={3} />
+                                                </LineChart>
+                                            </ResponsiveContainer>
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+
+                            <div className="space-y-6">
+                                {/* Rebalance Alert */}
+                                {portfolioData?.needsRebalance && (
+                                    <motion.div
+                                        initial={{ opacity: 0, scale: 0.95 }}
+                                        animate={{ opacity: 1, scale: 1 }}
+                                        className="bg-gradient-to-r from-orange-50 to-red-50 dark:from-orange-900/30 dark:to-red-900/30 border border-orange-200 dark:border-orange-800 rounded-xl p-6"
+                                    >
+                                        <div className="flex items-center mb-3">
+                                            <AlertCircle className="w-5 h-5 text-orange-500 mr-2" />
+                                            <span className="font-medium text-orange-800 dark:text-orange-300">Rebalance Needed</span>
+                                        </div>
+                                        <p className="text-sm text-orange-700 dark:text-orange-400 mb-2">
+                                            Your portfolio has drifted from target allocation
                                         </p>
-                                    )}
-                                    {(rebalanceEstimate?.breakdown?.length ?? 0) > 0 && (
-                                        <div className="text-xs text-orange-700 dark:text-orange-300 mb-3 space-y-1">
-                                            {rebalanceEstimate.breakdown.map((item: any) => (
-                                                <div key={item.tradeId} className="flex justify-between">
-                                                    <span>{item.tradeId}</span>
-                                                    <span>{Number(item.estimateXlm || 0).toFixed(4)} XLM</span>
+                                        <p className="text-sm text-orange-700 dark:text-orange-400 mb-2 font-medium">
+                                            Estimated gas: {estimateXlm.toFixed(2)} XLM (~${estimateUsd.toFixed(3)})
+                                        </p>
+                                        <p className="text-xs text-orange-600 dark:text-orange-400 mb-3">
+                                            {rebalanceEstimate?.tradeCount ?? 0} estimated trade{(rebalanceEstimate?.tradeCount ?? 0) === 1 ? '' : 's'} @ {(rebalanceEstimate?.gasPerTradeXlm ?? 0).toFixed(4)} XLM each
+                                        </p>
+                                        {hasHighGasWarning && (
+                                            <p className="text-xs text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900/40 rounded px-2 py-1 mb-3">
+                                                Warning: estimated gas is unusually high ({'>'} 0.5 XLM). Consider reducing trade count.
+                                            </p>
+                                        )}
+                                        {(rebalanceEstimate?.breakdown?.length ?? 0) > 0 && (
+                                            <div className="text-xs text-orange-700 dark:text-orange-300 mb-3 space-y-1">
+                                                {rebalanceEstimate.breakdown.map((item: any) => (
+                                                    <div key={item.tradeId} className="flex justify-between">
+                                                        <span>{item.tradeId}</span>
+                                                        <span>{Number(item.estimateXlm || 0).toFixed(4)} XLM</span>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        )}
+                                        {(portfolioData as any)?.slippageTolerancePercent != null && (
+                                            <p className="text-xs text-orange-600 dark:text-orange-400 mb-4">
+                                                Max slippage: {(portfolioData as any).slippageTolerancePercent}% — trades beyond this will be rejected
+                                            </p>
+                                        )}
+                                        <button
+                                            onClick={executeRebalance}
+                                            disabled={executeRebalanceMutation.isPending || !publicKey || portfolioData?.id === 'demo'}
+                                            className="w-full bg-orange-500 hover:bg-orange-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 text-white py-2 px-4 rounded-lg font-medium transition-colors flex items-center justify-center"
+                                        >
+                                            {executeRebalanceMutation.isPending ? (
+                                                <>
+                                                    <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                                                    Rebalancing...
+                                                </>
+                                            ) : (
+                                                'Execute Rebalance'
+                                            )}
+                                        </button>
+                                        {(portfolioData as any)?.slippageTolerance != null && (
+                                            <p className="text-xs text-gray-600 dark:text-gray-400 mt-2 text-center">
+                                                Max slippage: {(portfolioData as any).slippageTolerance}% — trades above this will be rejected
+                                            </p>
+                                        )}
+                                        {(!publicKey || portfolioData?.id === 'demo') && (
+                                            <p className="text-xs text-orange-600 dark:text-orange-400 mt-2 text-center">
+                                                {!publicKey ? 'Connect wallet to execute rebalance' : 'Create a real portfolio to enable rebalancing'}
+                                            </p>
+                                        )}
+                                    </motion.div>
+                                )}
+
+                                {/* NEW: Allocation Chart Skeleton Loading State */}
+                                {loading ? (
+                                    <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
+                                        <div className="w-32 h-6 bg-gray-300 dark:bg-gray-700 rounded mb-4 animate-pulse" />
+                                        <div className="h-48 flex items-center justify-center mb-4">
+                                            <div className="w-40 h-40 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse" />
+                                        </div>
+                                        <div className="space-y-3">
+                                            {[1, 2, 3].map((i) => (
+                                                <div key={i} className="flex items-center justify-between animate-pulse">
+                                                    <div className="flex items-center space-x-2">
+                                                        <div className="w-3 h-3 rounded-full bg-gray-300 dark:bg-gray-700" />
+                                                        <div className="w-20 h-3 bg-gray-300 dark:bg-gray-700 rounded" />
+                                                    </div>
+                                                    <div className="w-12 h-3 bg-gray-300 dark:bg-gray-700 rounded" />
                                                 </div>
                                             ))}
                                         </div>
-                                    )}
-                                    {(portfolioData as any)?.slippageTolerancePercent != null && (
-                                        <p className="text-xs text-orange-600 dark:text-orange-400 mb-4">
-                                            Max slippage: {(portfolioData as any).slippageTolerancePercent}% — trades beyond this will be rejected
-                                        </p>
-                                    )}
-                                    <button
-                                        onClick={executeRebalance}
-                                        disabled={executeRebalanceMutation.isPending || !publicKey || portfolioData?.id === 'demo'}
-                                        className="w-full bg-orange-500 hover:bg-orange-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 text-white py-2 px-4 rounded-lg font-medium transition-colors flex items-center justify-center"
-                                    >
-                                        {executeRebalanceMutation.isPending ? (
-                                            <>
-                                                <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
-                                                Rebalancing...
-                                            </>
-                                        ) : (
-                                            'Execute Rebalance'
-                                        )}
-                                    </button>
-                                    {(portfolioData as any)?.slippageTolerance != null && (
-                                        <p className="text-xs text-gray-600 dark:text-gray-400 mt-2 text-center">
-                                            Max slippage: {(portfolioData as any).slippageTolerance}% — trades above this will be rejected
-                                        </p>
-                                    )}
-                                    {(!publicKey || portfolioData?.id === 'demo') && (
-                                        <p className="text-xs text-orange-600 dark:text-orange-400 mt-2 text-center">
-                                            {!publicKey ? 'Connect wallet to execute rebalance' : 'Create a real portfolio to enable rebalancing'}
-                                        </p>
-                                    )}
-                                </motion.div>
-                            )}
+                                    </div>
+                                ) : (
+                                    <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
+                                        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Allocation</h3>
+                                        <div className="h-48 flex items-center justify-center">
+                                            <ResponsiveContainer width="100%" height="100%">
+                                                <PieChart>
+                                                    <Pie
+                                                        data={allocationData}
+                                                        cx="50%"
+                                                        cy="50%"
+                                                        innerRadius={40}
+                                                        outerRadius={80}
+                                                        paddingAngle={2}
+                                                        dataKey="value"
+                                                    >
+                                                        {allocationData.map((entry: any, index: number) => (
+                                                            <Cell key={`cell-${index}`} fill={entry.color} />
+                                                        ))}
+                                                    </Pie>
+                                                </PieChart>
+                                            </ResponsiveContainer>
+                                        </div>
+                                        <div className="mt-4 space-y-2">
+                                            {allocationData.map((asset: any, index: number) => (
+                                                <div key={index} className="flex items-center justify-between">
+                                                    <div className="flex items-center">
+                                                        <div className="w-3 h-3 rounded-full mr-2" style={{ backgroundColor: asset.color }}></div>
+                                                        <span className="text-sm text-gray-600 dark:text-gray-400">{asset.name}</span>
+                                                    </div>
+                                                    <span className="text-sm font-semibold text-gray-900 dark:text-white">{asset.value.toFixed(1)}%</span>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
 
-                            {/* NEW: Allocation Chart Skeleton Loading State */}
+                        {/* Price Tracker */}
+                        <div className="mb-8">
+                            <PriceTracker />
+                        </div>
+
+                        {/* NEW: Asset Cards Skeleton Loading State */}
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 mb-8">
                             {loading ? (
-                                <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
-                                    <div className="w-32 h-6 bg-gray-300 dark:bg-gray-700 rounded mb-4 animate-pulse" />
-                                    <div className="h-48 flex items-center justify-center mb-4">
-                                        <div className="w-40 h-40 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse" />
-                                    </div>
-                                    <div className="space-y-3">
-                                        {[1, 2, 3].map((i) => (
-                                            <div key={i} className="flex items-center justify-between animate-pulse">
-                                                <div className="flex items-center space-x-2">
-                                                    <div className="w-3 h-3 rounded-full bg-gray-300 dark:bg-gray-700" />
-                                                    <div className="w-20 h-3 bg-gray-300 dark:bg-gray-700 rounded" />
-                                                </div>
-                                                <div className="w-12 h-3 bg-gray-300 dark:bg-gray-700 rounded" />
-                                            </div>
-                                        ))}
-                                    </div>
-
+                                // Show skeleton cards while loading
+                                [1, 2, 3].map((i) => (
+                                    <AssetCard key={`skeleton-${i}`} isLoading={true} />
+                                ))
                             ) : (
-                                <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
-                                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Allocation</h3>
-                                    <div className="h-48 flex items-center justify-center">
-                                        <ResponsiveContainer width="100%" height="100%">
-                                            <PieChart>
-                                                <Pie
-                                                    data={allocationData}
-                                                    cx="50%"
-                                                    cy="50%"
-                                                    innerRadius={40}
-                                                    outerRadius={80}
-                                                    paddingAngle={2}
-                                                    dataKey="value"
-                                                >
-                                                    {allocationData.map((entry: any, index: number) => (
-                                                        <Cell key={`cell-${index}`} fill={entry.color} />
-                                                    ))}
-                                                </Pie>
-                                            </PieChart>
-                                        </ResponsiveContainer>
-                                    </div>
-                                    <div className="mt-4 space-y-2">
-                                        {allocationData.map((asset: any, index: number) => (
-                                            <div key={index} className="flex items-center justify-between">
-                                                <div className="flex items-center">
-                                                    <div className="w-3 h-3 rounded-full mr-2" style={{ backgroundColor: asset.color }}></div>
-                                                    <span className="text-sm text-gray-600 dark:text-gray-400">{asset.name}</span>
-                                                </div>
-                                                <span className="text-sm font-semibold text-gray-900 dark:text-white">{asset.value.toFixed(1)}%</span>
-                                            </div>
-                                        ))}
-                                    </div>
-                                </div>
+                                // Show actual asset cards when data is loaded
+                                allocationData.map((asset: any, index: number) => {
+                                    const row = prices[asset.name]
+                                    const priceCard =
+                                        row?.price !== undefined
+                                            ? { price: row.price, change: row.change ?? 0 }
+                                            : undefined
+                                    return <AssetCard key={index} asset={asset} price={priceCard} />
+                                })
                             )}
                         </div>
-                    </div>
 
-                    {/* Price Tracker */}
-                    <div className="mb-8">
-                        <PriceTracker />
-                    </div>
+                        {/* Rebalance History */}
+                        <RebalanceHistory portfolioId={portfolioData?.id || null} />
+                    </>
+                )}
+            </div>
 
-                    {/* NEW: Asset Cards Skeleton Loading State */}
-                    <div className="grid lg:grid-cols-3 gap-6 mb-8">
-                        {loading ? (
-                            // Show skeleton cards while loading
-                            [1, 2, 3].map((i) => (
-                                <AssetCard key={`skeleton-${i}`} isLoading={true} />
-                            ))
-                        ) : (
-                            // Show actual asset cards when data is loaded
-                            allocationData.map((asset: any, index: number) => {
-                                const row = prices[asset.name]
-                                const priceCard = row
-                                    ? {
-                                        price: typeof row === 'number' ? row : row.price ?? null,
-                                        change: typeof row === 'number' ? 0 : row.change ?? null,
-                                        source: typeof row === 'object' && row !== null ? (row.source as string | undefined) : undefined,
-                                        quoteAgeSeconds:
-                                            typeof row === 'object' && row !== null ? (row.quoteAgeSeconds as number | undefined) : undefined,
-                                        servedFromCache:
-                                            typeof row === 'object' && row !== null ? (row.servedFromCache as boolean | undefined) : undefined,
-                                        dataTier:
-                                            typeof row === 'object' && row !== null ? (row.dataTier as string | undefined) : undefined,
-                                    }
-                                    : undefined
-                                return <AssetCard key={index} asset={asset} price={priceCard} />
-                            })
-                        )}
-                    </div>
-
-                    {/* Rebalance History */}
-                    <RebalanceHistory portfolioId={portfolioData?.id || null} />
-                </>
-            )}
-        </div>
-
-        {/* NEW: Sticky Mobile Action Bar */}
-        <div className="mobile-action-bar fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 p-4 md:hidden z-40">
-            <div className="flex items-center justify-between max-w-sm mx-auto">
-                {/* Portfolio Value */}
-                <div className="text-center">
-                    <div className="text-xs text-gray-500 dark:text-gray-400">Total Value</div>
-                    <div className="text-lg font-bold text-gray-900 dark:text-white">
-                        ${portfolioData?.totalValue?.toLocaleString() || '10,000'}
-                    </div>
-                    <div className={`text-xs flex items-center justify-center gap-1 ${(portfolioData?.dayChange || 0) >= 0
-                        ? 'text-green-600 dark:text-green-400'
-                        : 'text-red-600 dark:text-red-400'
+            {/* NEW: Sticky Mobile Action Bar */}
+            <div className="mobile-action-bar fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 p-4 md:hidden z-40">
+                <div className="flex items-center justify-between max-w-sm mx-auto">
+                    {/* Portfolio Value */}
+                    <div className="text-center">
+                        <div className="text-xs text-gray-500 dark:text-gray-400">Total Value</div>
+                        <div className="text-lg font-bold text-gray-900 dark:text-white">
+                            ${portfolioData?.totalValue?.toLocaleString() || '10,000'}
+                        </div>
+                        <div className={`text-xs flex items-center justify-center gap-1 ${
+                            (portfolioData?.dayChange || 0) >= 0 
+                                ? 'text-green-600 dark:text-green-400' 
+                                : 'text-red-600 dark:text-red-400'
                         }`}>
-                        {(portfolioData?.dayChange || 0) >= 0 ? (
-                            <TrendingUp className="w-3 h-3" />
-                        ) : (
-                            <TrendingUp className="w-3 h-3 rotate-180" />
-                        )}
-                        {Math.abs(portfolioData?.dayChange || 0.85).toFixed(2)}%
-                    </div>
-                </div>
-
-                {/* Action Buttons */}
-                <div className="flex items-center gap-2">
-                    {/* Rebalance Status & Action */}
-                    {portfolioData?.needsRebalance ? (
-                        <button
-                            onClick={executeRebalance}
-                            disabled={executeRebalanceMutation.isPending || portfolioData?.id === 'demo'}
-                            className="bg-orange-600 hover:bg-orange-700 disabled:bg-orange-400 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1"
-                        >
-                            {executeRebalanceMutation.isPending ? (
-                                <RefreshCw className="w-4 h-4 animate-spin" />
+                            {(portfolioData?.dayChange || 0) >= 0 ? (
+                                <TrendingUp className="w-3 h-3" />
                             ) : (
-                                <Zap className="w-4 h-4" />
+                                <TrendingUp className="w-3 h-3 rotate-180" />
                             )}
-                            Rebalance
-                        </button>
-                    ) : (
-                        <div className="flex items-center gap-1 text-green-600 dark:text-green-400 text-sm">
-                            <CheckCircle className="w-4 h-4" />
-                            <span className="hidden sm:inline">Balanced</span>
+                            {Math.abs(portfolioData?.dayChange || 0.85).toFixed(2)}%
                         </div>
-                    )}
+                    </div>
 
-                    {/* Create Portfolio / Refresh */}
-                    {publicKey ? (
-                        <button
-                            onClick={() => onNavigate('setup')}
-                            className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
-                        >
-                            <Plus className="w-4 h-4" />
-                            <span className="hidden sm:inline">New</span>
-                        </button>
-                    ) : (
-                        <button
-                            onClick={() => setShowDemoResetConfirm(true)}
-                            className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
-                        >
-                            <RefreshCw className="w-4 h-4" />
-                            <span className="hidden sm:inline">Reset</span>
-                        </button>
-                    )}
+                    {/* Action Buttons */}
+                    <div className="flex items-center gap-2">
+                        {/* Rebalance Status & Action */}
+                        {portfolioData?.needsRebalance ? (
+                            <button
+                                onClick={executeRebalance}
+                                disabled={executeRebalanceMutation.isPending || portfolioData?.id === 'demo'}
+                                className="bg-orange-600 hover:bg-orange-700 disabled:bg-orange-400 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1"
+                            >
+                                {executeRebalanceMutation.isPending ? (
+                                    <RefreshCw className="w-4 h-4 animate-spin" />
+                                ) : (
+                                    <Zap className="w-4 h-4" />
+                                )}
+                                Rebalance
+                            </button>
+                        ) : (
+                            <div className="flex items-center gap-1 text-green-600 dark:text-green-400 text-sm">
+                                <CheckCircle className="w-4 h-4" />
+                                <span className="hidden sm:inline">Balanced</span>
+                            </div>
+                        )}
 
-                    {/* Refresh Data */}
-                    <button
-                        onClick={refreshData}
-                        disabled={loading}
-                        className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
-                    >
-                        <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-                    </button>
+                        {/* Create Portfolio / Refresh */}
+                        {publicKey ? (
+                            <button
+                                onClick={() => onNavigate('setup')}
+                                className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
+                            >
+                                <Plus className="w-4 h-4" />
+                                <span className="hidden sm:inline">New</span>
+                            </button>
+                        ) : (
+                            <button
+                                onClick={() => setShowDemoResetConfirm(true)}
+                                className="border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
+                            >
+                                <RefreshCw className="w-4 h-4" />
+                                <span className="hidden sm:inline">Reset</span>
+                            </button>
+                        )}
+
+                        {/* Refresh Data */}
+                        <button
+                            onClick={refreshData}
+                            disabled={loading}
+                            className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
+                        >
+                            <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+                        </button>
+                    </div>
                 </div>
             </div>
-        </div>
 
-        {/* Add bottom padding to main content to prevent overlap with mobile action bar */}
-        <div className="h-20 md:hidden"></div>
-    </div>
-)
+            {/* Add bottom padding to main content to prevent overlap with mobile action bar */}
+            <div className="h-20 md:hidden"></div>
+        </div>
+    )
 }
 
 export default Dashboard

--- a/frontend/src/components/DeveloperDrawer.test.tsx
+++ b/frontend/src/components/DeveloperDrawer.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import DeveloperDrawer, { isDeveloperDrawerUnlocked, unlockDeveloperDrawer } from './DeveloperDrawer'
+
+vi.mock('../config/api', async () => {
+    const actual = await vi.importActual<typeof import('../config/api')>('../config/api')
+    return {
+        ...actual,
+        testBrowserPrices: vi.fn(async () => true),
+    }
+})
+
+vi.mock('../services/browserPriceService', () => ({
+    browserPriceService: {
+        getCacheInspectorEntries: vi.fn(() => [
+            {
+                key: 'prices',
+                assetCount: 2,
+                ageMs: 1000,
+                ttlRemainingMs: 59000,
+                resolutionHint: 'cached_only',
+                sources: ['reflector'],
+                cachedAtMs: Date.now() - 1000,
+            },
+        ]),
+        getCurrentPrices: vi.fn(async () => ({ prices: {}, feedMeta: {} })),
+        clearCache: vi.fn(),
+    },
+}))
+
+vi.mock('./NotificationTest', () => ({
+    NotificationTest: () => <div>Notification test panel</div>,
+}))
+
+describe('DeveloperDrawer', () => {
+    beforeEach(() => {
+        sessionStorage.clear()
+        vi.restoreAllMocks()
+    })
+
+    it('opens from the keyboard shortcut after unlock', () => {
+        unlockDeveloperDrawer()
+        render(<DeveloperDrawer publicKey="GTEST123" />)
+
+        fireEvent.keyDown(window, { key: 'D', ctrlKey: true, shiftKey: true })
+        expect(screen.getByRole('dialog', { name: /developer tools/i })).toBeTruthy()
+        expect(screen.getByText(/browser price cache/i)).toBeTruthy()
+        expect(screen.getByText('Notification test panel')).toBeTruthy()
+    })
+
+    it('starts locked outside development until explicitly unlocked', () => {
+        expect(isDeveloperDrawerUnlocked()).toBe(import.meta.env.DEV)
+    })
+})

--- a/frontend/src/components/DeveloperDrawer.tsx
+++ b/frontend/src/components/DeveloperDrawer.tsx
@@ -1,0 +1,252 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { Bug, ChevronDown, ChevronUp, RefreshCw, X } from 'lucide-react'
+import { API_CONFIG, testBrowserPrices } from '../config/api'
+import { API_RESOURCE_ROOT } from '../config/api'
+import { getFrontendDebugConfig } from '../utils/debug'
+import { browserPriceService, type BrowserPriceCacheEntry } from '../services/browserPriceService'
+import { NotificationTest } from './NotificationTest'
+
+const DRAWER_UNLOCK_KEY = 'developer-drawer-unlocked'
+
+export function isDeveloperDrawerUnlocked(): boolean {
+    if (typeof window === 'undefined') return false
+    if (getFrontendDebugConfig().isDevelopment) return true
+    return sessionStorage.getItem(DRAWER_UNLOCK_KEY) === 'true'
+}
+
+export function unlockDeveloperDrawer(): void {
+    sessionStorage.setItem(DRAWER_UNLOCK_KEY, 'true')
+}
+
+interface DeveloperDrawerProps {
+    publicKey: string | null
+}
+
+function formatAge(ms: number | undefined): string {
+    if (ms === undefined || !Number.isFinite(ms)) return '—'
+    if (ms < 1000) return `${Math.round(ms)}ms`
+    return `${(ms / 1000).toFixed(1)}s`
+}
+
+const DeveloperDrawer: React.FC<DeveloperDrawerProps> = ({ publicKey }) => {
+    const [open, setOpen] = useState(false)
+    const [unlocked, setUnlocked] = useState(isDeveloperDrawerUnlocked)
+    const [cacheEntries, setCacheEntries] = useState<BrowserPriceCacheEntry[]>([])
+    const [cacheLoading, setCacheLoading] = useState(false)
+    const [cacheError, setCacheError] = useState<string | null>(null)
+    const [browserPriceTestRunning, setBrowserPriceTestRunning] = useState(false)
+    const [browserPriceTestResult, setBrowserPriceTestResult] = useState<string | null>(null)
+    const debugConfig = getFrontendDebugConfig()
+
+    const refreshCacheInspector = useCallback(async () => {
+        setCacheLoading(true)
+        setCacheError(null)
+        try {
+            const entries = browserPriceService.getCacheInspectorEntries()
+            setCacheEntries(entries)
+            if (entries.length === 0) {
+                await browserPriceService.getCurrentPrices()
+                setCacheEntries(browserPriceService.getCacheInspectorEntries())
+            }
+        } catch (error) {
+            setCacheError(error instanceof Error ? error.message : 'Failed to load cache entries')
+            setCacheEntries([])
+        } finally {
+            setCacheLoading(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.ctrlKey && event.shiftKey && event.key.toLowerCase() === 'd') {
+                event.preventDefault()
+                unlockDeveloperDrawer()
+                setUnlocked(true)
+                setOpen((value) => !value)
+            }
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => window.removeEventListener('keydown', onKeyDown)
+    }, [])
+
+    useEffect(() => {
+        if (open) {
+            void refreshCacheInspector()
+        }
+    }, [open, refreshCacheInspector])
+
+    const runBrowserPriceTest = async () => {
+        setBrowserPriceTestRunning(true)
+        setBrowserPriceTestResult(null)
+        try {
+            const ok = await testBrowserPrices()
+            setBrowserPriceTestResult(ok ? 'Browser price connection OK' : 'Browser price test failed')
+        } catch (error) {
+            setBrowserPriceTestResult(
+                error instanceof Error ? error.message : 'Browser price test failed',
+            )
+        } finally {
+            setBrowserPriceTestRunning(false)
+        }
+    }
+
+    if (!unlocked) {
+        return (
+            <button
+                type="button"
+                aria-label="Unlock developer tools"
+                title="Developer tools (Ctrl+Shift+D)"
+                onClick={() => {
+                    unlockDeveloperDrawer()
+                    setUnlocked(true)
+                    setOpen(true)
+                }}
+                className="fixed bottom-3 left-3 z-40 h-2 w-2 rounded-full bg-transparent hover:bg-gray-400/30 dark:hover:bg-gray-500/30 focus-visible:ring-2 focus-visible:ring-blue-500"
+            />
+        )
+    }
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={() => setOpen((value) => !value)}
+                aria-expanded={open}
+                aria-controls="developer-drawer-panel"
+                className="fixed bottom-4 left-4 z-40 flex items-center gap-2 rounded-full border border-gray-300 bg-white px-3 py-2 text-xs font-medium text-gray-700 shadow-md hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+            >
+                <Bug className="h-4 w-4" />
+                Dev tools
+                {open ? <ChevronDown className="h-3 w-3" /> : <ChevronUp className="h-3 w-3" />}
+            </button>
+
+            {open ? (
+                <div
+                    id="developer-drawer-panel"
+                    role="dialog"
+                    aria-label="Developer tools"
+                    className="fixed bottom-16 left-4 z-40 flex max-h-[min(70vh,32rem)] w-[min(24rem,calc(100vw-2rem))] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+                >
+                    <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+                        <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Developer tools</h2>
+                        <button
+                            type="button"
+                            onClick={() => setOpen(false)}
+                            aria-label="Close developer tools"
+                            className="rounded p-1 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+                        >
+                            <X className="h-4 w-4" />
+                        </button>
+                    </div>
+
+                    <div className="flex-1 space-y-4 overflow-y-auto p-4 text-xs text-gray-700 dark:text-gray-300">
+                        <section>
+                            <h3 className="mb-2 font-medium text-gray-900 dark:text-white">API target</h3>
+                            <dl className="space-y-1">
+                                <div className="flex justify-between gap-2">
+                                    <dt>Origin</dt>
+                                    <dd className="text-right break-all">{API_CONFIG.BASE_URL}</dd>
+                                </div>
+                                <div className="flex justify-between gap-2">
+                                    <dt>Resource root</dt>
+                                    <dd>{API_RESOURCE_ROOT}</dd>
+                                </div>
+                                <div className="flex justify-between gap-2">
+                                    <dt>Debug logs</dt>
+                                    <dd>{debugConfig.enableApiDebugLogs ? 'on' : 'off'}</dd>
+                                </div>
+                                <div className="flex justify-between gap-2">
+                                    <dt>Browser prices</dt>
+                                    <dd>{API_CONFIG.USE_BROWSER_PRICES ? 'on' : 'off'}</dd>
+                                </div>
+                            </dl>
+                            <button
+                                type="button"
+                                onClick={() => void runBrowserPriceTest()}
+                                disabled={browserPriceTestRunning}
+                                className="mt-2 rounded border border-gray-300 px-2 py-1 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:hover:bg-gray-800"
+                            >
+                                {browserPriceTestRunning ? 'Testing…' : 'Test browser prices'}
+                            </button>
+                            {browserPriceTestResult ? (
+                                <p className="mt-1 text-gray-600 dark:text-gray-400">{browserPriceTestResult}</p>
+                            ) : null}
+                        </section>
+
+                        <section>
+                            <div className="mb-2 flex items-center justify-between">
+                                <h3 className="font-medium text-gray-900 dark:text-white">Browser price cache</h3>
+                                <button
+                                    type="button"
+                                    onClick={() => void refreshCacheInspector()}
+                                    disabled={cacheLoading}
+                                    className="inline-flex items-center gap-1 rounded border border-gray-300 px-2 py-1 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:hover:bg-gray-800"
+                                >
+                                    <RefreshCw className={`h-3 w-3 ${cacheLoading ? 'animate-spin' : ''}`} />
+                                    Refresh
+                                </button>
+                            </div>
+                            {cacheError ? (
+                                <p className="text-red-600 dark:text-red-400" role="alert">
+                                    {cacheError}
+                                </p>
+                            ) : null}
+                            {cacheLoading && cacheEntries.length === 0 ? (
+                                <p className="text-gray-500 dark:text-gray-400">Loading cache…</p>
+                            ) : null}
+                            {!cacheLoading && cacheEntries.length === 0 ? (
+                                <p className="text-gray-500 dark:text-gray-400">No cached price buckets yet.</p>
+                            ) : null}
+                            {cacheEntries.length > 0 ? (
+                                <ul className="space-y-2">
+                                    {cacheEntries.map((entry) => (
+                                        <li
+                                            key={entry.key}
+                                            className="rounded border border-gray-200 p-2 dark:border-gray-700"
+                                        >
+                                            <div className="flex justify-between gap-2 font-medium">
+                                                <span>{entry.key}</span>
+                                                <span>{entry.assetCount} assets</span>
+                                            </div>
+                                            <div className="mt-1 space-y-0.5 text-gray-600 dark:text-gray-400">
+                                                <div>Freshness: {formatAge(entry.ageMs)}</div>
+                                                <div>TTL remaining: {formatAge(entry.ttlRemainingMs)}</div>
+                                                <div>Hint: {entry.resolutionHint}</div>
+                                                <div>Sources: {entry.sources.join(', ') || '—'}</div>
+                                            </div>
+                                        </li>
+                                    ))}
+                                </ul>
+                            ) : null}
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    browserPriceService.clearCache()
+                                    setCacheEntries([])
+                                }}
+                                className="mt-2 rounded border border-gray-300 px-2 py-1 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-800"
+                            >
+                                Clear cache
+                            </button>
+                        </section>
+
+                        {publicKey ? (
+                            <section>
+                                <h3 className="mb-2 font-medium text-gray-900 dark:text-white">
+                                    Notification tests
+                                </h3>
+                                <NotificationTest userId={publicKey} />
+                            </section>
+                        ) : (
+                            <p className="text-gray-500 dark:text-gray-400">
+                                Connect a wallet to run notification delivery tests.
+                            </p>
+                        )}
+                    </div>
+                </div>
+            ) : null}
+        </>
+    )
+}
+
+export default DeveloperDrawer

--- a/frontend/src/components/PortfolioSetup.test.tsx
+++ b/frontend/src/components/PortfolioSetup.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import PortfolioSetup from './PortfolioSetup'
 import { api } from '../config/api'
+import { clearPortfolioCloneDraft, savePortfolioCloneDraft } from '../utils/portfolioCloneDraft'
 
 // Strip framer-motion animation props so they don't hit the real DOM
 const stripMotionProps = ({ initial, animate, exit, transition, variants, layout, layoutId, ...rest }: any) => rest
@@ -23,6 +24,20 @@ vi.mock('../hooks/mutations/usePortfolioMutations', () => ({
     useCreatePortfolioMutation: () => ({
         mutateAsync: mockMutateAsync,
         isPending: false,
+    }),
+}))
+
+const mockAssets = [
+    { symbol: 'XLM', displayName: 'XLM', searchText: 'xlm' },
+    { symbol: 'USDC', displayName: 'USDC', searchText: 'usdc' },
+    { symbol: 'BTC', displayName: 'BTC', searchText: 'btc' },
+    { symbol: 'ETH', displayName: 'ETH', searchText: 'eth' },
+]
+
+vi.mock('../hooks/queries/useAssetsQuery', () => ({
+    useAssets: () => ({
+        data: mockAssets,
+        isLoading: false,
     }),
 }))
 
@@ -53,8 +68,8 @@ describe('PortfolioSetup allocation validation', () => {
     beforeEach(() => {
         cleanup()
         vi.clearAllMocks()
+        clearPortfolioCloneDraft()
         mockMutateAsync.mockResolvedValue({})
-        // Return empty assets so the component falls back to DEFAULT_ASSET_OPTIONS
         vi.spyOn(api, 'get').mockResolvedValue({ assets: [] } as any)
     })
 
@@ -226,6 +241,38 @@ describe('PortfolioSetup allocation validation', () => {
     })
 
     // ── Submit button state ───────────────────────────────────────────────────
+
+    describe('portfolio clone draft', () => {
+        it('prefills setup from a saved clone draft and saves as a new portfolio', async () => {
+            savePortfolioCloneDraft({
+                sourcePortfolioId: 'p-source',
+                sourceLabel: 'Source',
+                allocations: [
+                    { asset: 'BTC', percentage: 70 },
+                    { asset: 'ETH', percentage: 30 },
+                ],
+                threshold: 8,
+                slippageTolerance: 2,
+                strategy: 'volatility',
+                strategyConfig: { volatilityThresholdPct: 12 },
+                createdAt: new Date().toISOString(),
+            })
+
+            renderSetup('GTESTCLONE')
+            expect(screen.getByText(/cloning portfolio source/i)).toBeTruthy()
+            expect(screen.getByRole('button', { name: /save as new portfolio/i })).toBeTruthy()
+
+            fireEvent.click(screen.getByRole('button', { name: /save as new portfolio/i }))
+            expect(mockMutateAsync).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    threshold: 8,
+                    slippageTolerance: 2,
+                    strategy: 'volatility',
+                    allocations: { BTC: 70, ETH: 30 },
+                }),
+            )
+        })
+    })
 
     describe('submit button state', () => {
         it('calls mutateAsync when form is valid and submit is clicked', async () => {

--- a/frontend/src/components/PortfolioSetup.tsx
+++ b/frontend/src/components/PortfolioSetup.tsx
@@ -29,7 +29,12 @@ import AssetSelector from "./AssetSelector"; // NEW: Enhanced asset selector wit
 
 // TanStack Query Mutations
 import { useCreatePortfolioMutation } from "../hooks/mutations/usePortfolioMutations";
-import { useAssets } from "../hooks/queries/useAssetsQuery"; // NEW: Use enhanced assets query
+import { useAssets } from "../hooks/queries/useAssetsQuery";
+import {
+  clearPortfolioCloneDraft,
+  loadPortfolioCloneDraft,
+  type PortfolioCloneDraft,
+} from "../utils/portfolioCloneDraft";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -160,13 +165,28 @@ const PortfolioSetup: React.FC<PortfolioSetupProps> = ({
   const [savedTemplates, setSavedTemplates] = useState<PortfolioTemplate[]>(() =>
     loadSavedTemplates(publicKey || "")
   );
+  const [cloneDraft, setCloneDraft] = useState<PortfolioCloneDraft | null>(() =>
+    loadPortfolioCloneDraft(),
+  );
 
-  // NEW: Use enhanced assets query
-  const { data: assets = [], isLoading: assetsLoading } = useAssets()
+  const { data: assets = [] } = useAssets()
 
   useEffect(() => {
     setSavedTemplates(loadSavedTemplates(publicKey || ""));
   }, [publicKey]);
+
+  useEffect(() => {
+    const draft = loadPortfolioCloneDraft();
+    if (!draft) return
+
+    setCloneDraft(draft);
+    setAllocations(draft.allocations.map((row) => ({ ...row })));
+    setThreshold(draft.threshold);
+    setSlippageTolerance(draft.slippageTolerance);
+    setStrategy(draft.strategy || "threshold");
+    setStrategyConfig(draft.strategyConfig ?? {});
+    setSelectedTemplateId("custom");
+  }, []);
 
   const getRiskLevelLabel = (level: RiskLevel): string => {
     switch (level) {
@@ -370,6 +390,8 @@ const PortfolioSetup: React.FC<PortfolioSetupProps> = ({
           Object.keys(strategyConfig).length > 0 ? strategyConfig : undefined,
       });
 
+      clearPortfolioCloneDraft();
+      setCloneDraft(null);
       setSuccess(true);
       setTimeout(() => onNavigate("dashboard"), 2000);
     } catch (err) {
@@ -431,6 +453,31 @@ const PortfolioSetup: React.FC<PortfolioSetupProps> = ({
             </div>
           )}
         </div>
+
+        {cloneDraft ? (
+          <div className="bg-indigo-50 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-800 rounded-lg p-4 mb-6">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h4 className="text-indigo-900 dark:text-indigo-200 font-medium">
+                  Cloning portfolio {cloneDraft.sourceLabel ?? cloneDraft.sourcePortfolioId}
+                </h4>
+                <p className="text-indigo-800 dark:text-indigo-300 text-sm mt-1">
+                  Allocations and rebalance settings are pre-filled. Saving creates a new portfolio and does not change the original.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  clearPortfolioCloneDraft();
+                  setCloneDraft(null);
+                }}
+                className="self-start rounded-lg border border-indigo-300 dark:border-indigo-700 px-3 py-2 text-sm text-indigo-900 dark:text-indigo-100 hover:bg-indigo-100 dark:hover:bg-indigo-900/50"
+              >
+                Discard clone
+              </button>
+            </div>
+          </div>
+        ) : null}
 
         {/* ── Demo mode information banner ── */}
         {isDemoMode && (
@@ -986,6 +1033,8 @@ const PortfolioSetup: React.FC<PortfolioSetupProps> = ({
                    <Zap className="w-4 h-4 mr-2 animate-spin" />
                    Creating...
                  </>
+               ) : cloneDraft ? (
+                 "Save as new portfolio"
                ) : (
                  "Create Portfolio"
                )}
@@ -1035,7 +1084,7 @@ const PortfolioSetup: React.FC<PortfolioSetupProps> = ({
 
               {/* Create Portfolio Button */}
               <button
-                onClick={handleSubmit}
+                onClick={createPortfolio}
                 disabled={hasAnyFieldError || !isValidTotal || createPortfolioMutation.isPending}
                 className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1"
               >

--- a/frontend/src/config/apiCompatibility.test.ts
+++ b/frontend/src/config/apiCompatibility.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { checkApiCompatibility } from './apiCompatibility'
+
+describe('checkApiCompatibility', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    it('reports ok when the v1 envelope probe succeeds', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => ({
+                ok: true,
+                status: 200,
+                headers: new Headers({ 'content-type': 'application/json' }),
+                json: async () => ({
+                    success: true,
+                    data: { strategies: [] },
+                    error: null,
+                    timestamp: new Date().toISOString(),
+                }),
+            })),
+        )
+
+        const result = await checkApiCompatibility()
+        expect(result.severity).toBe('ok')
+    })
+
+    it('flags non-json responses as an API target mismatch', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => ({
+                ok: true,
+                status: 200,
+                headers: new Headers({ 'content-type': 'text/html' }),
+                json: async () => ({}),
+            })),
+        )
+
+        const result = await checkApiCompatibility()
+        expect(result.severity).toBe('error')
+        expect(result.title).toMatch(/mismatch/i)
+    })
+
+    it('flags missing envelopes as incompatible', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => ({
+                ok: true,
+                status: 200,
+                headers: new Headers({ 'content-type': 'application/json' }),
+                json: async () => ({ strategies: [] }),
+            })),
+        )
+
+        const result = await checkApiCompatibility()
+        expect(result.severity).toBe('error')
+        expect(result.message).toMatch(/envelope/i)
+    })
+})

--- a/frontend/src/config/apiCompatibility.ts
+++ b/frontend/src/config/apiCompatibility.ts
@@ -1,0 +1,146 @@
+import { API_CONFIG } from './api'
+import { getApiResourceRoot } from './apiVersion'
+
+export type ApiCompatibilitySeverity = 'ok' | 'warning' | 'error'
+
+export interface ApiCompatibilityResult {
+    severity: ApiCompatibilitySeverity
+    title: string
+    message: string
+    configuredOrigin: string
+    configuredApiRoot: string
+    probedUrl?: string
+    httpStatus?: number
+    details?: string
+}
+
+function isEnvelopeBody(body: unknown): boolean {
+    if (!body || typeof body !== 'object') return false
+    const record = body as Record<string, unknown>
+    return typeof record.success === 'boolean' && ('data' in record || 'error' in record)
+}
+
+export async function checkApiCompatibility(
+    signal?: AbortSignal,
+): Promise<ApiCompatibilityResult> {
+    const configuredOrigin = API_CONFIG.BASE_URL.replace(/\/$/, '')
+    const configuredApiRoot = getApiResourceRoot()
+    const probePath = `${configuredApiRoot}/strategies`
+    const probedUrl = `${configuredOrigin}${probePath}`
+
+    try {
+        const response = await fetch(probedUrl, {
+            method: 'GET',
+            headers: { Accept: 'application/json' },
+            mode: 'cors',
+            credentials: 'omit',
+            signal,
+        })
+
+        const contentType = response.headers.get('content-type') ?? ''
+        if (!contentType.includes('application/json')) {
+            return {
+                severity: 'error',
+                title: 'API target mismatch',
+                message:
+                    'The configured API origin did not return JSON. Check VITE_API_URL and that the backend is running.',
+                configuredOrigin,
+                configuredApiRoot,
+                probedUrl,
+                httpStatus: response.status,
+                details: `Content-Type: ${contentType || 'unknown'}`,
+            }
+        }
+
+        const body: unknown = await response.json()
+        const usesLegacyRoot = configuredApiRoot === '/api'
+        const hasDeprecation = response.headers.has('deprecation')
+
+        if (!isEnvelopeBody(body)) {
+            return {
+                severity: 'error',
+                title: 'Unexpected API response shape',
+                message:
+                    'The backend response is missing the standard success/data envelope. Your API version or origin may be wrong.',
+                configuredOrigin,
+                configuredApiRoot,
+                probedUrl,
+                httpStatus: response.status,
+            }
+        }
+
+        if (!usesLegacyRoot && hasDeprecation) {
+            return {
+                severity: 'warning',
+                title: 'API version mismatch',
+                message:
+                    'The app is configured for /api/v1 but the server responded with legacy deprecation headers.',
+                configuredOrigin,
+                configuredApiRoot,
+                probedUrl,
+                httpStatus: response.status,
+            }
+        }
+
+        if (usesLegacyRoot && !hasDeprecation && response.ok) {
+            return {
+                severity: 'warning',
+                title: 'Legacy API surface in use',
+                message:
+                    'VITE_USE_LEGACY_API is enabled. Consider switching to /api/v1 before the legacy routes are removed.',
+                configuredOrigin,
+                configuredApiRoot,
+                probedUrl,
+                httpStatus: response.status,
+            }
+        }
+
+        if (!response.ok) {
+            const envelope = body as { error?: { message?: string } }
+            return {
+                severity: 'warning',
+                title: 'API probe returned an error',
+                message:
+                    envelope.error?.message ??
+                    `The compatibility probe returned HTTP ${response.status}.`,
+                configuredOrigin,
+                configuredApiRoot,
+                probedUrl,
+                httpStatus: response.status,
+            }
+        }
+
+        return {
+            severity: 'ok',
+            title: 'API configuration looks compatible',
+            message: `Connected to ${configuredOrigin}${configuredApiRoot}.`,
+            configuredOrigin,
+            configuredApiRoot,
+            probedUrl,
+            httpStatus: response.status,
+        }
+    } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+            return {
+                severity: 'ok',
+                title: 'API compatibility check skipped',
+                message: 'Startup probe was cancelled.',
+                configuredOrigin,
+                configuredApiRoot,
+                probedUrl,
+            }
+        }
+
+        return {
+            severity: 'error',
+            title: 'Cannot reach configured API',
+            message:
+                error instanceof Error
+                    ? error.message
+                    : 'Network error while probing the configured API origin.',
+            configuredOrigin,
+            configuredApiRoot,
+            probedUrl,
+        }
+    }
+}

--- a/frontend/src/hooks/mutations/usePortfolioMutations.ts
+++ b/frontend/src/hooks/mutations/usePortfolioMutations.ts
@@ -4,6 +4,14 @@ import { portfolioKeys } from '../queries/usePortfolioQuery'
 import { historyKeys } from '../queries/useHistoryQuery'
 import { analyticsKeys } from '../queries/useAnalyticsQuery'
 
+export {
+    buildPortfolioCloneDraft,
+    savePortfolioCloneDraft,
+    loadPortfolioCloneDraft,
+    clearPortfolioCloneDraft,
+} from '../../utils/portfolioCloneDraft'
+export type { PortfolioCloneDraft } from '../../utils/portfolioCloneDraft'
+
 export interface MutationFailureInfo {
     message: string
     retryable: boolean

--- a/frontend/src/services/browserPriceService.test.ts
+++ b/frontend/src/services/browserPriceService.test.ts
@@ -101,6 +101,23 @@ describe('browserPriceService', () => {
     expect(fetch).toHaveBeenCalledTimes(2)
   })
 
+  it('exposes cache inspector metadata for developer tools', async () => {
+    const mockData = { prices: { XLM: { price: 0.10, timestamp: Date.now() / 1000, source: 'reflector' } } }
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockData,
+    } as Response)
+
+    await browserPriceService.getCurrentPrices()
+    const entries = browserPriceService.getCacheInspectorEntries()
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.key).toBe('prices')
+    expect(entries[0]?.assetCount).toBe(1)
+    expect(entries[0]?.sources).toContain('reflector')
+  })
+
   it('serves stale cache when fetch fails and cache exists', async () => {
     const mockData = { prices: { XLM: { price: 0.10, timestamp: Date.now() / 1000 } } }
     

--- a/frontend/src/services/browserPriceService.ts
+++ b/frontend/src/services/browserPriceService.ts
@@ -31,6 +31,16 @@ export interface BrowserPricesPayload {
     feedMeta: BrowserPriceFeedMeta
 }
 
+export interface BrowserPriceCacheEntry {
+    key: string
+    assetCount: number
+    ageMs: number
+    ttlRemainingMs: number
+    resolutionHint: BrowserPriceFeedMeta['resolutionHint']
+    sources: string[]
+    cachedAtMs: number
+}
+
 class BrowserPriceService {
     private cache: Map<string, { data: BrowserPricesMap; timestamp: number }> = new Map()
     private readonly CACHE_DURATION = 60000
@@ -305,6 +315,36 @@ class BrowserPriceService {
                 dataTier: 'synthetic_fallback'
             }
         }
+    }
+
+    getCacheInspectorEntries(): BrowserPriceCacheEntry[] {
+        const now = Date.now()
+        return Array.from(this.cache.entries()).map(([key, bucket]) => {
+            const ageMs = now - bucket.timestamp
+            const sources = [
+                ...new Set(
+                    Object.values(bucket.data)
+                        .map((row) => row.source)
+                        .filter(Boolean),
+                ),
+            ]
+            const resolutionHint: BrowserPriceFeedMeta['resolutionHint'] =
+                ageMs >= this.CACHE_DURATION
+                    ? 'error_recovery_cache'
+                    : sources.includes('fallback_browser')
+                      ? 'synthetic_fallback'
+                      : 'cached_only'
+
+            return {
+                key,
+                assetCount: Object.keys(bucket.data).length,
+                ageMs,
+                ttlRemainingMs: Math.max(0, this.CACHE_DURATION - ageMs),
+                resolutionHint,
+                sources,
+                cachedAtMs: bucket.timestamp,
+            }
+        })
     }
 
     clearCache(): void {

--- a/frontend/src/utils/portfolioCloneDraft.test.ts
+++ b/frontend/src/utils/portfolioCloneDraft.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+    buildPortfolioCloneDraft,
+    clearPortfolioCloneDraft,
+    loadPortfolioCloneDraft,
+    savePortfolioCloneDraft,
+} from './portfolioCloneDraft'
+
+describe('portfolioCloneDraft', () => {
+    beforeEach(() => {
+        sessionStorage.clear()
+    })
+
+    it('builds a draft from array allocations', () => {
+        const draft = buildPortfolioCloneDraft({
+            id: 'portfolio-1',
+            threshold: 7,
+            slippageTolerance: 2,
+            strategy: 'periodic',
+            allocations: [
+                { asset: 'XLM', target: 60 },
+                { asset: 'USDC', target: 40 },
+            ],
+        })
+
+        expect(draft).toMatchObject({
+            sourcePortfolioId: 'portfolio-1',
+            allocations: [
+                { asset: 'XLM', percentage: 60 },
+                { asset: 'USDC', percentage: 40 },
+            ],
+            threshold: 7,
+            slippageTolerance: 2,
+            strategy: 'periodic',
+            strategyConfig: {},
+        })
+    })
+
+    it('persists and reloads drafts from session storage', () => {
+        const draft = buildPortfolioCloneDraft({
+            id: 'portfolio-2',
+            allocations: { BTC: 100 },
+            threshold: 5,
+            slippageTolerance: 1,
+            strategy: 'threshold',
+        })
+        expect(draft).not.toBeNull()
+        savePortfolioCloneDraft(draft!)
+        expect(loadPortfolioCloneDraft()?.sourcePortfolioId).toBe('portfolio-2')
+        clearPortfolioCloneDraft()
+        expect(loadPortfolioCloneDraft()).toBeNull()
+    })
+})

--- a/frontend/src/utils/portfolioCloneDraft.ts
+++ b/frontend/src/utils/portfolioCloneDraft.ts
@@ -1,0 +1,90 @@
+export interface PortfolioCloneAllocation {
+    asset: string
+    percentage: number
+}
+
+export interface PortfolioCloneDraft {
+    sourcePortfolioId: string
+    sourceLabel?: string
+    allocations: PortfolioCloneAllocation[]
+    threshold: number
+    slippageTolerance: number
+    strategy: string
+    strategyConfig: Record<string, number>
+    createdAt: string
+}
+
+const CLONE_DRAFT_KEY = 'portfolio-clone-draft'
+
+export function savePortfolioCloneDraft(draft: PortfolioCloneDraft): void {
+    sessionStorage.setItem(CLONE_DRAFT_KEY, JSON.stringify(draft))
+}
+
+export function loadPortfolioCloneDraft(): PortfolioCloneDraft | null {
+    try {
+        const raw = sessionStorage.getItem(CLONE_DRAFT_KEY)
+        if (!raw) return null
+        const parsed = JSON.parse(raw) as PortfolioCloneDraft
+        if (!parsed?.sourcePortfolioId || !Array.isArray(parsed.allocations)) return null
+        return parsed
+    } catch {
+        return null
+    }
+}
+
+export function clearPortfolioCloneDraft(): void {
+    sessionStorage.removeItem(CLONE_DRAFT_KEY)
+}
+
+function normalizeAllocations(portfolio: Record<string, unknown>): PortfolioCloneAllocation[] {
+    const raw = portfolio.allocations
+    if (Array.isArray(raw)) {
+        return raw
+            .map((row) => {
+                const entry = row as Record<string, unknown>
+                const asset = String(entry.asset ?? entry.name ?? '')
+                const percentage = Number(entry.target ?? entry.percentage ?? entry.value ?? 0)
+                if (!asset) return null
+                return { asset, percentage }
+            })
+            .filter((row): row is PortfolioCloneAllocation => row !== null)
+    }
+    if (raw && typeof raw === 'object') {
+        return Object.entries(raw as Record<string, number>).map(([asset, percentage]) => ({
+            asset,
+            percentage: Number(percentage),
+        }))
+    }
+    return []
+}
+
+export function buildPortfolioCloneDraft(portfolio: Record<string, unknown>): PortfolioCloneDraft | null {
+    const id = typeof portfolio.id === 'string' ? portfolio.id : null
+    if (!id || id === 'demo') return null
+
+    const allocations = normalizeAllocations(portfolio)
+    if (allocations.length === 0) return null
+
+    const threshold = Number(portfolio.threshold ?? portfolio.rebalanceThreshold ?? 5)
+    const slippageTolerance = Number(
+        portfolio.slippageTolerance ??
+            portfolio.slippageTolerancePercent ??
+            1,
+    )
+    const strategy = typeof portfolio.strategy === 'string' ? portfolio.strategy : 'threshold'
+    const strategyConfig =
+        portfolio.strategyConfig && typeof portfolio.strategyConfig === 'object'
+            ? (portfolio.strategyConfig as Record<string, number>)
+            : {}
+
+    return {
+        sourcePortfolioId: id,
+        sourceLabel: typeof portfolio.name === 'string' ? portfolio.name : id.slice(0, 8),
+        allocations,
+        threshold: Number.isFinite(threshold) ? threshold : 5,
+        slippageTolerance: Number.isFinite(slippageTolerance) ? slippageTolerance : 1,
+        strategy,
+        strategyConfig,
+        createdAt: new Date().toISOString(),
+    }
+}


### PR DESCRIPTION
closes #514 
closes #511 
closes #509 
closes #508 

## Summary

This PR delivers four related frontend improvements in one pass:

1. **Portfolio clone** — Start from an existing portfolio instead of rebuilding allocations from scratch. Dashboard exposes **Clone as new**; setup is pre-filled via a session draft and always creates a **new** portfolio (the source is unchanged).
2. **Developer drawer** — Debug affordances (API target info, browser price test, notification tests, price cache inspector) live in a gated drawer instead of the main UI. Unlock with **Ctrl+Shift+D** or the subtle control at the bottom-left; in development the drawer is easier to reach.
3. **API compatibility warning** — On startup, the app probes the configured API (`/strategies`) and shows a dismissible banner when the origin or response shape (JSON envelope, legacy vs v1) looks misconfigured.
4. **Browser price cache inspector** — Developers can inspect cached price buckets (freshness, TTL remaining, sources, resolution hint) from the dev drawer.

Also restores a valid `Dashboard.tsx` on `main`, which had a syntax-breaking regression (broken `executeRebalance` / incomplete JSX).

## Changes

| Area | Files |
|------|--------|
| Clone flow | `portfolioCloneDraft.ts`, `Dashboard.tsx`, `PortfolioSetup.tsx`, `usePortfolioMutations.ts` |
| Dev drawer | `DeveloperDrawer.tsx`, `App.tsx` |
| API probe | `apiCompatibility.ts`, `App.tsx` |
| Price cache | `browserPriceService.ts`, `DeveloperDrawer.tsx` |
| Tests | `*.test.ts(x)` for the paths above |

## How it works

### Clone as new
- User clicks **Clone as new** on the dashboard (real portfolios only, not demo).
- Allocations, threshold, slippage, and strategy are stored in `sessionStorage` and applied on the setup screen.
- Banner explains that saving creates a new portfolio; **Discard clone** clears the draft.
- Submit uses the existing create-portfolio mutation (no backend clone endpoint required).

### Developer tools
- Removed the inline DEV debug panel from the dashboard overview.
- Drawer sections: API configuration, browser price connection test, cache inspector, notification tests (when a wallet is connected).

### API compatibility
- Probes `{VITE_API_URL}{API_RESOURCE_ROOT}/strategies`.
- Flags non-JSON responses, missing `success`/`data` envelope, deprecation headers on v1, and unreachable origins.

## Test plan

- [ ] Connect wallet, open a portfolio on the dashboard, click **Clone as new**.
- [ ] Confirm setup shows the clone banner, correct allocations/settings, and **Save as new portfolio** creates a new portfolio (original unchanged).
- [ ] Click **Discard clone** and confirm the form resets away from clone mode.
- [ ] Press **Ctrl+Shift+D** (or use the bottom-left unlock control) and open the dev drawer.
- [ ] Refresh the price cache inspector; confirm entries show age, TTL, and sources; **Clear cache** works.
- [ ] With a connected wallet, run a notification test from the drawer.
- [ ] Set `VITE_API_URL` to an invalid host (or wrong API version) and confirm the compatibility banner appears; **Dismiss** hides it.
- [ ] Run frontend tests: `cd frontend && npm test -- --run` (Node **≥ 20.19** recommended).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portfolio cloning with draft persistence for easy replication
  * Export portfolio allocations to CSV and JSON formats
  * Demo portfolio reset functionality with confirmation
  * API compatibility check at startup with informational banner
  * Enhanced mobile interface with persistent action bar for quick access to key actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->