### PR TITLE
feat: Bypass strict rate limits for internal health probes only

### DIFF
--- a/backend/src/http/corsSecurity.ts
+++ b/backend/src/http/corsSecurity.ts
@@ -1,6 +1,10 @@
 import type { CorsOptions } from 'cors'
 import type { Request, Response, NextFunction } from 'express'
 
+// Probe endpoints that must always pass through CORS checks regardless of
+// origin, since internal health checkers do not send an Origin header at all.
+const PROBE_PATHS = new Set(['/health', '/ready', '/readiness', '/metrics'])
+
 const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH', 'HEAD'] as const
 const ALLOWED_HEADERS = [
     'Content-Type',
@@ -25,6 +29,12 @@ export function enforceCorsOriginAllowlist(corsOrigins: string[]) {
     const allowedOrigins = new Set(corsOrigins)
 
     return (req: Request, res: Response, next: NextFunction): void => {
+        // Health probes never carry an Origin header and must not be blocked.
+        if (PROBE_PATHS.has(req.path)) {
+            next()
+            return
+        }
+
         const origin = req.headers.origin
         if (!origin || !hasAllowlist || allowedOrigins.has(origin)) {
             next()

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -1,10 +1,75 @@
 import { rateLimit, type Options } from "express-rate-limit";
 import { RedisStore } from "rate-limit-redis";
 import IORedis from "ioredis";
+import type { Request, Response, NextFunction } from "express";
 import { fail } from "../utils/apiResponse.js";
 import { logger } from "../utils/logger.js";
 import { rateLimitMonitor } from "../services/rateLimitMonitor.js";
 import { REDIS_URL, getCachedRedisAvailability } from "../queue/connection.js";
+
+// ── Health-probe bypass ──────────────────────────────────────────────────────
+// Probe paths that must never be subject to rate-limiting.
+const PROBE_PATHS = new Set(["/health", "/ready", "/readiness", "/metrics"]);
+
+// Loopback addresses accepted as "trusted" without a secret.
+const LOOPBACK = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1", "localhost"]);
+
+/**
+ * HEALTH_PROBE_SECRET — optional shared secret that external probes (e.g.
+ * Kubernetes liveness/readiness probes running outside the node) can present
+ * via the `X-Probe-Secret` request header to bypass rate limiting.
+ *
+ * Leave unset (or empty) to restrict the bypass to loopback-only.
+ */
+const PROBE_SECRET = process.env.HEALTH_PROBE_SECRET ?? "";
+
+/**
+ * Returns true when the request is a trusted internal health probe that should
+ * be exempt from ALL rate limiters.
+ *
+ * A request qualifies when:
+ *   1. The path is one of the known probe paths, AND
+ *   2. EITHER the source IP is a loopback address
+ *      OR a non-empty HEALTH_PROBE_SECRET is configured and the
+ *      `X-Probe-Secret` header matches it exactly.
+ *
+ * This keeps the bypass narrow: public traffic on probe paths still goes
+ * through normal rate limiting if it comes from a non-loopback IP without
+ * the secret.
+ */
+export function isTrustedHealthProbe(req: Request): boolean {
+  if (!PROBE_PATHS.has(req.path)) return false;
+
+  const ip = req.ip ?? req.socket?.remoteAddress ?? "";
+  if (LOOPBACK.has(ip)) {
+    logger.debug("[RATE-LIMIT] Probe bypass: loopback source", {
+      path: req.path,
+      ip,
+    });
+    return true;
+  }
+
+  if (PROBE_SECRET.length > 0) {
+    const supplied = req.headers["x-probe-secret"];
+    if (typeof supplied === "string" && supplied === PROBE_SECRET) {
+      logger.debug("[RATE-LIMIT] Probe bypass: valid X-Probe-Secret", {
+        path: req.path,
+        ip,
+      });
+      return true;
+    }
+
+    // Secret configured but header missing or wrong — fall through to normal
+    // rate limiting so public traffic on probe paths is not accidentally exempt.
+    logger.debug("[RATE-LIMIT] Probe bypass denied: secret mismatch", {
+      path: req.path,
+      ip,
+      headerPresent: "x-probe-secret" in req.headers,
+    });
+  }
+
+  return false;
+}
 
 // Rate limiting configuration from environment
 const GLOBAL_WINDOW_MS = Number(process.env.RATE_LIMIT_WINDOW_MS) || 60 * 1000;
@@ -117,19 +182,21 @@ function createKeyGenerator(prefix: string) {
   };
 }
 
-// Skip rate limiting for health checks and internal requests
+// ---------------------------------------------------------------------------
+// Legacy isProbePath kept for any external callers, but the authoritative
+// guard for rate-limit skipping is now isTrustedHealthProbe().
+// ---------------------------------------------------------------------------
+/** @internal Use isTrustedHealthProbe() in middleware skip functions. */
 function isProbePath(path: string): boolean {
-    return path === '/health' || path === '/ready' || path === '/readiness' || path === '/metrics'
+  return PROBE_PATHS.has(path);
 }
 
 function skipSuccessfulRequests(
-  req: import("express").Request,
-  res: import("express").Response,
+  req: Request,
+  res: Response,
 ): boolean {
-  // Skip health checks
-  if (isProbePath(req.path)) {
-    return true;
-  }
+  // Trusted health probes bypass all rate limiting.
+  if (isTrustedHealthProbe(req)) return true;
 
   // In test environment, don't skip any requests to ensure rate limiting works
   if (process.env.NODE_ENV === "test") {
@@ -162,7 +229,7 @@ export const burstProtectionLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: true,
   store: makeStore("burst"),
-  skip: (req) => isProbePath(req.path),
+  skip: (req) => isTrustedHealthProbe(req),
 });
 
 // Write operations rate limiter - stricter limits for mutating operations
@@ -174,6 +241,7 @@ export const writeRateLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: true,
   store: makeStore("write"),
+  skip: (req) => isTrustedHealthProbe(req),
 });
 
 // Write burst protection - prevent rapid write attempts
@@ -185,7 +253,7 @@ export const writeBurstLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: true,
   store: makeStore("write-burst"),
-  skip: (req) => isProbePath(req.path),
+  skip: (req) => isTrustedHealthProbe(req),
 });
 
 // Authentication rate limiter - protect login/refresh endpoints
@@ -197,7 +265,7 @@ export const authRateLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: true,
   store: makeStore("auth"),
-  skip: () => false,
+  skip: (req) => isTrustedHealthProbe(req),
 });
 
 // Critical operations rate limiter - for rebalancing and high-value operations
@@ -209,7 +277,7 @@ export const criticalRateLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: true,
   store: makeStore("critical"),
-  skip: () => false,
+  skip: (req) => isTrustedHealthProbe(req),
 });
 
 // Admin operations rate limiter - protect admin endpoints
@@ -221,7 +289,7 @@ export const adminRateLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: true,
   store: makeStore("admin"),
-  skip: () => false,
+  skip: (req) => isTrustedHealthProbe(req),
 });
 
 // Composite middleware for write operations (combines write + burst protection)

--- a/backend/src/monitoring/readiness.ts
+++ b/backend/src/monitoring/readiness.ts
@@ -280,11 +280,20 @@ export async function buildReadinessReport() {
     (check) => !check.required || check.status === "ready",
   );
 
+  // Surface probe-bypass config for ops visibility (secret value is NEVER
+  // included — only whether one is configured).
+  const probeBypass = {
+    probePaths: ["/health", "/ready", "/readiness", "/metrics"],
+    loopbackBypassEnabled: true,
+    secretConfigured: Boolean(process.env.HEALTH_PROBE_SECRET),
+  };
+
   const report = {
     status: ready ? "ready" : "not_ready",
     timestamp: new Date().toISOString(),
     uptimeSeconds: Math.round(process.uptime()),
     checks,
+    probeBypass,
   };
 
   if (cacheTtlMs > 0) {

--- a/backend/src/test/healthProbeBypass.test.ts
+++ b/backend/src/test/healthProbeBypass.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Health-probe rate-limit bypass tests — issue #464
+ *
+ * Verifies that trusted health probes (loopback IP or valid X-Probe-Secret)
+ * are exempt from ALL rate limiters and CORS origin checks, while public
+ * traffic on the same paths is NOT silently whitelisted.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import express, { type Request } from 'express'
+import request from 'supertest'
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal Express app that applies a single limiter to a
+// probe-path route so we can confirm bypass / no-bypass behaviour.
+// ---------------------------------------------------------------------------
+function buildProbeApp(
+    limiter: express.RequestHandler,
+    path: string = '/health',
+) {
+    const app = express()
+    // express-rate-limit reads req.ip; supertest sets ::1 (loopback) by default.
+    app.set('trust proxy', false)
+    app.get(path, limiter, (_req, res) => {
+        res.status(200).json({ ok: true })
+    })
+    return app
+}
+
+// ============================================================================
+// 1. isTrustedHealthProbe unit tests
+// ============================================================================
+describe('isTrustedHealthProbe()', () => {
+    beforeEach(() => {
+        vi.resetModules()
+    })
+
+    it('returns true for loopback ::1 on a probe path', async () => {
+        const { isTrustedHealthProbe } = await import('../middleware/rateLimit.js')
+        const req = {
+            path: '/health',
+            ip: '::1',
+            socket: {},
+            headers: {},
+        } as unknown as Request
+        expect(isTrustedHealthProbe(req)).toBe(true)
+    })
+
+    it('returns true for loopback 127.0.0.1 on /readiness', async () => {
+        const { isTrustedHealthProbe } = await import('../middleware/rateLimit.js')
+        const req = {
+            path: '/readiness',
+            ip: '127.0.0.1',
+            socket: {},
+            headers: {},
+        } as unknown as Request
+        expect(isTrustedHealthProbe(req)).toBe(true)
+    })
+
+    it('returns true for ::ffff:127.0.0.1 (IPv4-mapped loopback) on /ready', async () => {
+        const { isTrustedHealthProbe } = await import('../middleware/rateLimit.js')
+        const req = {
+            path: '/ready',
+            ip: '::ffff:127.0.0.1',
+            socket: {},
+            headers: {},
+        } as unknown as Request
+        expect(isTrustedHealthProbe(req)).toBe(true)
+    })
+
+    it('returns false for a non-loopback IP on /health with no secret configured', async () => {
+        vi.stubEnv('HEALTH_PROBE_SECRET', '')
+        vi.resetModules()
+        const { isTrustedHealthProbe } = await import('../middleware/rateLimit.js')
+        const req = {
+            path: '/health',
+            ip: '203.0.113.5',
+            socket: {},
+            headers: {},
+        } as unknown as Request
+        expect(isTrustedHealthProbe(req)).toBe(false)
+    })
+
+    it('returns true when X-Probe-Secret matches HEALTH_PROBE_SECRET from external IP', async () => {
+        vi.stubEnv('HEALTH_PROBE_SECRET', 'super-secret-probe')
+        vi.resetModules()
+        const { isTrustedHealthProbe } = await import('../middleware/rateLimit.js')
+        const req = {
+            path: '/ready',
+            ip: '10.0.0.5',
+            socket: {},
+            headers: { 'x-probe-secret': 'super-secret-probe' },
+        } as unknown as Request
+        expect(isTrustedHealthProbe(req)).toBe(true)
+    })
+
+    it('returns false when X-Probe-Secret is wrong', async () => {
+        vi.stubEnv('HEALTH_PROBE_SECRET', 'super-secret-probe')
+        vi.resetModules()
+        const { isTrustedHealthProbe } = await import('../middleware/rateLimit.js')
+        const req = {
+            path: '/ready',
+            ip: '10.0.0.5',
+            socket: {},
+            headers: { 'x-probe-secret': 'wrong-secret' },
+        } as unknown as Request
+        expect(isTrustedHealthProbe(req)).toBe(false)
+    })
+
+    it('returns false when the path is not a probe path, even from loopback', async () => {
+        const { isTrustedHealthProbe } = await import('../middleware/rateLimit.js')
+        const req = {
+            path: '/api/v1/portfolios',
+            ip: '127.0.0.1',
+            socket: {},
+            headers: {},
+        } as unknown as Request
+        expect(isTrustedHealthProbe(req)).toBe(false)
+    })
+
+    it('returns false when HEALTH_PROBE_SECRET is empty and header is present from external IP', async () => {
+        vi.stubEnv('HEALTH_PROBE_SECRET', '')
+        vi.resetModules()
+        const { isTrustedHealthProbe } = await import('../middleware/rateLimit.js')
+        const req = {
+            path: '/health',
+            ip: '198.51.100.1',
+            socket: {},
+            headers: { 'x-probe-secret': 'anything' },
+        } as unknown as Request
+        // No secret configured → external IP should not be bypassed
+        expect(isTrustedHealthProbe(req)).toBe(false)
+    })
+})
+
+// ============================================================================
+// 2. Rate-limiter skip on probe paths (integration-style via supertest)
+//    supertest uses loopback (::1) so bypass should always engage.
+// ============================================================================
+describe('Rate limiters: probe paths are skipped (loopback)', () => {
+    beforeEach(() => {
+        vi.stubEnv('RATE_LIMIT_WINDOW_MS', '60000')
+        vi.stubEnv('NODE_ENV', 'test')
+        vi.resetModules()
+    })
+
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    it('globalRateLimiter skips /health', async () => {
+        vi.stubEnv('RATE_LIMIT_MAX', '1')
+        vi.resetModules()
+        const { globalRateLimiter } = await import('../middleware/rateLimit.js')
+        const app = buildProbeApp(globalRateLimiter, '/health')
+        // First request uses the 1-request budget
+        await request(app).get('/health').expect(200)
+        // Second request must also pass because probes are skipped
+        const res = await request(app).get('/health').expect(200)
+        expect(res.body.ok).toBe(true)
+    })
+
+    it('writeRateLimiter skips /ready', async () => {
+        vi.stubEnv('RATE_LIMIT_WRITE_MAX', '1')
+        vi.resetModules()
+        const { writeRateLimiter } = await import('../middleware/rateLimit.js')
+        const app = buildProbeApp(writeRateLimiter, '/ready')
+        await request(app).get('/ready').expect(200)
+        await request(app).get('/ready').expect(200)
+    })
+
+    it('burstProtectionLimiter skips /readiness', async () => {
+        vi.stubEnv('RATE_LIMIT_BURST_MAX', '1')
+        vi.resetModules()
+        const { burstProtectionLimiter } = await import('../middleware/rateLimit.js')
+        const app = buildProbeApp(burstProtectionLimiter, '/readiness')
+        await request(app).get('/readiness').expect(200)
+        await request(app).get('/readiness').expect(200)
+    })
+
+    it('authRateLimiter skips /health', async () => {
+        vi.stubEnv('RATE_LIMIT_AUTH_MAX', '1')
+        vi.resetModules()
+        const { authRateLimiter } = await import('../middleware/rateLimit.js')
+        const app = buildProbeApp(authRateLimiter, '/health')
+        await request(app).get('/health').expect(200)
+        await request(app).get('/health').expect(200)
+    })
+
+    it('criticalRateLimiter skips /health', async () => {
+        vi.stubEnv('RATE_LIMIT_CRITICAL_MAX', '1')
+        vi.resetModules()
+        const { criticalRateLimiter } = await import('../middleware/rateLimit.js')
+        const app = buildProbeApp(criticalRateLimiter, '/health')
+        await request(app).get('/health').expect(200)
+        await request(app).get('/health').expect(200)
+    })
+
+    it('adminRateLimiter skips /health', async () => {
+        vi.stubEnv('RATE_LIMIT_AUTH_MAX', '1')
+        vi.resetModules()
+        const { adminRateLimiter } = await import('../middleware/rateLimit.js')
+        const app = buildProbeApp(adminRateLimiter, '/health')
+        await request(app).get('/health').expect(200)
+        await request(app).get('/health').expect(200)
+    })
+})
+
+// ============================================================================
+// 3. Rate limiter still enforces limits on non-probe paths
+// ============================================================================
+describe('Rate limiters: non-probe paths are NOT exempt', () => {
+    beforeEach(() => {
+        vi.stubEnv('NODE_ENV', 'test')
+        vi.resetModules()
+    })
+
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    it('writeRateLimiter throttles /api/v1/test after limit is reached', async () => {
+        vi.stubEnv('RATE_LIMIT_WINDOW_MS', '60000')
+        vi.stubEnv('RATE_LIMIT_WRITE_MAX', '1')
+        vi.resetModules()
+        const { writeRateLimiter } = await import('../middleware/rateLimit.js')
+        const app = express()
+        app.post('/api/v1/test', writeRateLimiter, (_req, res) => res.json({ ok: true }))
+
+        await request(app).post('/api/v1/test').expect(200)
+        const second = await request(app).post('/api/v1/test').expect(429)
+        expect(second.body.error?.code).toBe('RATE_LIMITED')
+    })
+})
+
+// ============================================================================
+// 4. CORS allowlist: probe paths bypass the origin check
+// ============================================================================
+describe('enforceCorsOriginAllowlist: probe path bypass', () => {
+    it('allows /health even when origin is not in the allowlist', async () => {
+        const { enforceCorsOriginAllowlist } = await import('../http/corsSecurity.js')
+        const app = express()
+        // Strict allowlist — only example.com
+        app.use(enforceCorsOriginAllowlist(['https://app.example.com']))
+        app.get('/health', (_req, res) => res.status(200).send('ok'))
+
+        // Request from an "evil" origin should still get through on /health
+        const res = await request(app)
+            .get('/health')
+            .set('Origin', 'https://evil.example.com')
+            .expect(200)
+        expect(res.text).toBe('ok')
+    })
+
+    it('allows /ready without any origin header', async () => {
+        const { enforceCorsOriginAllowlist } = await import('../http/corsSecurity.js')
+        const app = express()
+        app.use(enforceCorsOriginAllowlist(['https://app.example.com']))
+        app.get('/ready', (_req, res) => res.status(200).send('ok'))
+
+        await request(app).get('/ready').expect(200)
+    })
+
+    it('allows /readiness from any origin', async () => {
+        const { enforceCorsOriginAllowlist } = await import('../http/corsSecurity.js')
+        const app = express()
+        app.use(enforceCorsOriginAllowlist(['https://app.example.com']))
+        app.get('/readiness', (_req, res) => res.status(200).send('ok'))
+
+        await request(app)
+            .get('/readiness')
+            .set('Origin', 'https://monitoring.internal')
+            .expect(200)
+    })
+
+    it('still rejects unlisted origins on non-probe paths', async () => {
+        const { enforceCorsOriginAllowlist } = await import('../http/corsSecurity.js')
+        const app = express()
+        app.use(enforceCorsOriginAllowlist(['https://app.example.com']))
+        app.get('/api/v1/portfolios', (_req, res) => res.json({ ok: true }))
+
+        const res = await request(app)
+            .get('/api/v1/portfolios')
+            .set('Origin', 'https://evil.example.com')
+            .expect(403)
+        expect(res.body.error?.code).toBe('CORS_FORBIDDEN_ORIGIN')
+    })
+})
+
+// ============================================================================
+// 5. Readiness report includes probeBypass metadata
+// ============================================================================
+describe('buildReadinessReport: probeBypass metadata', () => {
+    beforeEach(() => {
+        vi.resetModules()
+
+        vi.doMock('../services/databaseService.js', () => ({
+            databaseService: {
+                getReadiness: vi.fn().mockReturnValue({ ready: true })
+            }
+        }))
+        vi.doMock('../queue/connection.js', () => ({
+            isRedisAvailable: vi.fn().mockResolvedValue(false)
+        }))
+        vi.doMock('../queue/queues.js', () => ({
+            QUEUE_NAMES: {
+                PORTFOLIO_CHECK: 'portfolio-check',
+                REBALANCE: 'rebalance',
+                ANALYTICS_SNAPSHOT: 'analytics-snapshot',
+            },
+            getPortfolioCheckQueue: vi.fn().mockReturnValue(null),
+            getRebalanceQueue: vi.fn().mockReturnValue(null),
+            getAnalyticsSnapshotQueue: vi.fn().mockReturnValue(null),
+        }))
+        vi.doMock('../queue/workers/portfolioCheckWorker.js', () => ({
+            getPortfolioCheckWorkerStatus: vi.fn().mockReturnValue({ started: false, ready: false })
+        }))
+        vi.doMock('../queue/workers/rebalanceWorker.js', () => ({
+            getRebalanceWorkerStatus: vi.fn().mockReturnValue({ started: false, ready: false })
+        }))
+        vi.doMock('../queue/workers/analyticsSnapshotWorker.js', () => ({
+            getAnalyticsSnapshotWorkerStatus: vi.fn().mockReturnValue({ started: false, ready: false })
+        }))
+        vi.doMock('../services/contractEventIndexer.js', () => ({
+            contractEventIndexerService: {
+                getStatus: vi.fn().mockReturnValue({
+                    enabled: false,
+                    running: false,
+                    pollIntervalMs: 15000,
+                    lastIngestedCount: 0,
+                    contractEventSchemaOk: true,
+                    consecutiveFailures: 0,
+                })
+            }
+        }))
+        vi.doMock('../services/runtimeServices.js', () => ({
+            autoRebalancer: {
+                getStatus: vi.fn().mockReturnValue({ isRunning: false, initialized: false })
+            }
+        }))
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        vi.unstubAllEnvs()
+    })
+
+    it('includes probeBypass with correct probe paths', async () => {
+        const { buildReadinessReport, clearReadinessCache } = await import('../monitoring/readiness.js')
+        clearReadinessCache()
+        const report = await buildReadinessReport() as Record<string, unknown>
+        const bypass = report.probeBypass as Record<string, unknown>
+
+        expect(bypass).toBeDefined()
+        expect(bypass.probePaths).toEqual(['/health', '/ready', '/readiness', '/metrics'])
+        expect(bypass.loopbackBypassEnabled).toBe(true)
+    })
+
+    it('reflects secretConfigured=false when HEALTH_PROBE_SECRET is unset', async () => {
+        delete process.env.HEALTH_PROBE_SECRET
+        const { buildReadinessReport, clearReadinessCache } = await import('../monitoring/readiness.js')
+        clearReadinessCache()
+        const report = await buildReadinessReport() as Record<string, unknown>
+        const bypass = report.probeBypass as Record<string, unknown>
+        expect(bypass.secretConfigured).toBe(false)
+    })
+
+    it('reflects secretConfigured=true when HEALTH_PROBE_SECRET is set', async () => {
+        vi.stubEnv('HEALTH_PROBE_SECRET', 'my-k8s-secret')
+        const { buildReadinessReport, clearReadinessCache } = await import('../monitoring/readiness.js')
+        clearReadinessCache()
+        const report = await buildReadinessReport() as Record<string, unknown>
+        const bypass = report.probeBypass as Record<string, unknown>
+        expect(bypass.secretConfigured).toBe(true)
+    })
+
+    it('does NOT include the secret value in the report', async () => {
+        vi.stubEnv('HEALTH_PROBE_SECRET', 'my-k8s-secret')
+        const { buildReadinessReport, clearReadinessCache } = await import('../monitoring/readiness.js')
+        clearReadinessCache()
+        const reportJson = JSON.stringify(await buildReadinessReport())
+        expect(reportJson).not.toContain('my-k8s-secret')
+    })
+})


### PR DESCRIPTION
Closes #464

## Problem

Health probes (`/health`, `/ready`, `/readiness`, `/metrics`) were subject
to the same rate limiters as regular user traffic. Under high load — or when
a limiter had a very small window — probes could get throttled and return 429,
causing Kubernetes (or any orchestrator) to mark the pod as unhealthy and
restart it unnecessarily.

Additionally, `authRateLimiter`, `criticalRateLimiter`, and `adminRateLimiter`
had `skip: () => false` hardcoded, meaning probe traffic on those paths had
**no** bypass path at all.

The CORS allowlist middleware also had no exemption for probe paths, so a
misconfigured `Origin` header on an internal checker could produce a 403.

## Solution

A narrow, auditable bypass — not a broad policy weakening.

### `isTrustedHealthProbe(req)` (new export)
Single source of truth. Returns `true` only when:
1. The request path is one of the four probe paths, **AND**
2. The source IP is a loopback address (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`)  
   **OR** `HEALTH_PROBE_SECRET` is configured and the `X-Probe-Secret` header
   matches it exactly.

External IPs without the secret are **not** bypassed — even on probe paths.

### Rate limiters (`rateLimit.ts`)
All six limiters (`global`, `burst`, `write`, `writeBurst`, `auth`, `critical`,
`admin`) now call `skip: (req) => isTrustedHealthProbe(req)`. Bypass decisions
are logged at `debug` level for auditability.

### CORS allowlist (`corsSecurity.ts`)
`enforceCorsOriginAllowlist` short-circuits before inspecting the `Origin`
header when the path is a probe endpoint. Internal health checkers never
send `Origin` and must not receive a 403.

### Readiness report (`readiness.ts`)
`buildReadinessReport` now includes a `probeBypass` field so ops can inspect
the active bypass configuration at runtime:

```json
{
  "probeBypass": {
    "probePaths": ["/health", "/ready", "/readiness", "/metrics"],
    "loopbackBypassEnabled": true,
    "secretConfigured": false
  }
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health check endpoints now bypass CORS origin enforcement
  * Health check endpoints now bypass rate limiting with loopback and secret-based authentication
  * Readiness reports now include probe bypass configuration details

* **Tests**
  * Added comprehensive test coverage for health probe bypass behavior across CORS, rate limiting, and readiness reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->