### PR TITLE
Add Stellar address authentication via challenge-response signature

### DIFF
--- a/backend/src/api/authRoutes.ts
+++ b/backend/src/api/authRoutes.ts
@@ -5,6 +5,7 @@ import {
     refreshTokens,
     logout
 } from '../services/authService.js'
+import { createChallenge, verifyChallenge, InvalidSignatureError } from '../services/stellarAuthService.js'
 import { requireJwt } from '../middleware/requireJwt.js'
 import { authRateLimiter } from '../middleware/rateLimit.js'
 import { ok, fail } from '../utils/apiResponse.js'
@@ -80,6 +81,60 @@ router.post('/logout-all', authRateLimiter, async (req: Request, res: Response) 
         await logout(undefined, address.trim())
         return ok(res, { message: 'Logged out' })
     } catch (error) {
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
+// ── Stellar challenge-response authentication ────────────────────────────────
+
+/**
+ * POST /api/auth/challenge
+ * Body: { address: string }  — Stellar G-address
+ * Returns: { nonce: string }  — sign this with your Stellar private key
+ */
+router.post('/challenge', authRateLimiter, (req: Request, res: Response) => {
+    try {
+        const address = req.body?.address
+        if (!address || typeof address !== 'string' || !address.trim()) {
+            return fail(res, 400, 'VALIDATION_ERROR', 'address is required')
+        }
+        const nonce = createChallenge(address.trim())
+        return ok(res, { nonce })
+    } catch (error) {
+        const msg = getErrorMessage(error)
+        if (msg.includes('Invalid Stellar address')) {
+            return fail(res, 400, 'VALIDATION_ERROR', msg)
+        }
+        return fail(res, 500, 'INTERNAL_ERROR', msg)
+    }
+})
+
+/**
+ * POST /api/auth/verify
+ * Body: { address: string, signature: string }
+ *   signature = base64(Keypair.sign(Buffer.from(nonce, 'utf8')))
+ * Returns: { accessToken, refreshToken, expiresIn, refreshExpiresIn }
+ *
+ * Example (curl):
+ *   nonce=$(curl -s -X POST .../auth/challenge -d '{"address":"G..."}' | jq -r .data.nonce)
+ *   sig=$(node -e "const {Keypair}=require('@stellar/stellar-sdk'); const kp=Keypair.fromSecret('S...'); console.log(kp.sign(Buffer.from('$nonce')).toString('base64'))")
+ *   curl -X POST .../auth/verify -d "{\"address\":\"G...\",\"signature\":\"$sig\"}"
+ */
+router.post('/verify', authRateLimiter, async (req: Request, res: Response) => {
+    try {
+        const { address, signature } = req.body ?? {}
+        if (!address || typeof address !== 'string') {
+            return fail(res, 400, 'VALIDATION_ERROR', 'address is required')
+        }
+        if (!signature || typeof signature !== 'string') {
+            return fail(res, 400, 'VALIDATION_ERROR', 'signature is required')
+        }
+        const tokens = await verifyChallenge(address.trim(), signature.trim())
+        return ok(res, tokens)
+    } catch (error) {
+        if (error instanceof InvalidSignatureError) {
+            return fail(res, 401, 'UNAUTHORIZED', error.message)
+        }
         return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
     }
 })

--- a/backend/src/services/stellarAuthService.ts
+++ b/backend/src/services/stellarAuthService.ts
@@ -1,0 +1,97 @@
+/**
+ * Stellar address authentication via challenge-response.
+ *
+ * Flow:
+ *   1. Client calls POST /auth/challenge with { address }
+ *   2. Server stores a random nonce keyed to the address (TTL: 5 min) and returns it
+ *   3. Client signs the nonce with their Stellar private key and sends the signature
+ *   4. Server verifies with Keypair.verify(), then issues JWT via authService
+ */
+import { Keypair } from '@stellar/stellar-sdk'
+import { randomBytes } from 'node:crypto'
+import { issueTokens } from './authService.js'
+import { logger } from '../utils/logger.js'
+
+const CHALLENGE_TTL_MS = 5 * 60 * 1000  // 5 minutes
+const CHALLENGE_CLEANUP_INTERVAL_MS = 60 * 1000  // GC every minute
+
+interface ChallengeEntry {
+    nonce: string
+    expiresAt: number
+}
+
+// In-memory nonce store — keyed by address.
+// One active challenge per address; requesting a new one invalidates the old one.
+const challenges = new Map<string, ChallengeEntry>()
+
+// Periodic GC of expired nonces
+setInterval(() => {
+    const now = Date.now()
+    for (const [addr, entry] of challenges) {
+        if (entry.expiresAt <= now) challenges.delete(addr)
+    }
+}, CHALLENGE_CLEANUP_INTERVAL_MS)
+
+function isValidStellarAddress(address: string): boolean {
+    try {
+        Keypair.fromPublicKey(address)
+        return true
+    } catch {
+        return false
+    }
+}
+
+export function createChallenge(address: string): string {
+    if (!isValidStellarAddress(address)) {
+        throw new Error('Invalid Stellar address')
+    }
+    const nonce = randomBytes(32).toString('hex')
+    challenges.set(address, { nonce, expiresAt: Date.now() + CHALLENGE_TTL_MS })
+    return nonce
+}
+
+export async function verifyChallenge(
+    address: string,
+    signature: string,
+): Promise<{ accessToken: string; refreshToken: string; expiresIn: number; refreshExpiresIn: number }> {
+    if (!isValidStellarAddress(address)) {
+        throw new InvalidSignatureError('Invalid Stellar address')
+    }
+
+    const entry = challenges.get(address)
+    if (!entry) {
+        throw new InvalidSignatureError('No active challenge for this address')
+    }
+    if (entry.expiresAt <= Date.now()) {
+        challenges.delete(address)
+        throw new InvalidSignatureError('Challenge expired')
+    }
+
+    const keypair = Keypair.fromPublicKey(address)
+    const nonceBuffer = Buffer.from(entry.nonce, 'utf8')
+    const sigBuffer = Buffer.from(signature, 'base64')
+
+    let valid: boolean
+    try {
+        valid = keypair.verify(nonceBuffer, sigBuffer)
+    } catch {
+        valid = false
+    }
+
+    if (!valid) {
+        logger.warn('[stellarAuth] Invalid signature', { address: address.slice(0, 8) + '...' })
+        throw new InvalidSignatureError('Signature verification failed')
+    }
+
+    // Consume the challenge — one-time use
+    challenges.delete(address)
+
+    return issueTokens(address)
+}
+
+export class InvalidSignatureError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'InvalidSignatureError'
+    }
+}

--- a/backend/src/test/stellarAuth.test.ts
+++ b/backend/src/test/stellarAuth.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Keypair } from '@stellar/stellar-sdk'
+
+// Mock authService so we don't need DB
+vi.mock('../services/authService.js', () => ({
+    issueTokens: vi.fn().mockResolvedValue({
+        accessToken: 'mock-access',
+        refreshToken: 'mock-refresh',
+        expiresIn: 900,
+        refreshExpiresIn: 604800,
+    }),
+}))
+
+import { createChallenge, verifyChallenge, InvalidSignatureError } from '../services/stellarAuthService.js'
+
+describe('Stellar address authentication (#886)', () => {
+    const keypair = Keypair.random()
+    const address = keypair.publicKey()
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('createChallenge returns a 64-char hex nonce for a valid Stellar address', () => {
+        const nonce = createChallenge(address)
+        expect(typeof nonce).toBe('string')
+        expect(nonce).toHaveLength(64)
+        expect(/^[0-9a-f]+$/.test(nonce)).toBe(true)
+    })
+
+    it('createChallenge throws for an invalid address', () => {
+        expect(() => createChallenge('not-a-stellar-address')).toThrow('Invalid Stellar address')
+    })
+
+    it('verifyChallenge issues tokens when signature is valid', async () => {
+        const nonce = createChallenge(address)
+        const signature = keypair.sign(Buffer.from(nonce, 'utf8')).toString('base64')
+
+        const tokens = await verifyChallenge(address, signature)
+
+        expect(tokens.accessToken).toBe('mock-access')
+        expect(tokens.refreshToken).toBe('mock-refresh')
+    })
+
+    it('verifyChallenge throws InvalidSignatureError when signature is wrong', async () => {
+        createChallenge(address)
+        const wrongSig = Buffer.alloc(64).toString('base64') // all-zero signature
+
+        await expect(verifyChallenge(address, wrongSig)).rejects.toBeInstanceOf(InvalidSignatureError)
+    })
+
+    it('verifyChallenge throws when no challenge exists for address', async () => {
+        const freshKeypair = Keypair.random()
+        const sig = freshKeypair.sign(Buffer.from('nonce', 'utf8')).toString('base64')
+        await expect(verifyChallenge(freshKeypair.publicKey(), sig)).rejects.toBeInstanceOf(InvalidSignatureError)
+    })
+
+    it('challenge is consumed after successful verification (one-time use)', async () => {
+        const nonce = createChallenge(address)
+        const signature = keypair.sign(Buffer.from(nonce, 'utf8')).toString('base64')
+
+        await verifyChallenge(address, signature)
+
+        // Second verify with same nonce must fail — challenge was deleted
+        await expect(verifyChallenge(address, signature)).rejects.toBeInstanceOf(InvalidSignatureError)
+    })
+})


### PR DESCRIPTION
## Summary

- Adds `POST /api/auth/challenge` — returns a one-time 32-byte hex nonce for a given Stellar G-address
- Adds `POST /api/auth/verify` — verifies `Keypair.sign(nonce)` signature and issues JWT
- Challenges expire after 5 minutes and are consumed on first successful verification
- Invalid signatures rejected with 401; expired/missing challenges rejected with 401
- 6 unit tests covering valid flow, invalid address, wrong signature, missing challenge, one-time-use

## Example usage

```bash
# 1. Get challenge nonce
nonce=$(curl -s -X POST http://localhost:3000/api/auth/challenge \
  -H 'Content-Type: application/json' \
  -d '{"address":"GABC..."}' | jq -r .data.nonce)

# 2. Sign nonce (Node.js)
sig=$(node -e "const {Keypair}=require('@stellar/stellar-sdk'); \
  const kp=Keypair.fromSecret('SABC...'); \
  console.log(kp.sign(Buffer.from('$nonce','utf8')).toString('base64'))")

# 3. Verify and receive JWT
curl -X POST http://localhost:3000/api/auth/verify \
  -H 'Content-Type: application/json' \
  -d "{\"address\":\"GABC...\",\"signature\":\"$sig\"}"
```

Closes #886