### PR TITLE
Add Redis-based demo session store with 1-hour TTL

### DIFF
--- a/backend/src/demo/demoSessionMiddleware.ts
+++ b/backend/src/demo/demoSessionMiddleware.ts
@@ -1,0 +1,52 @@
+/**
+ * Express middleware that loads (or creates) a demo session from Redis.
+ * Attaches session to req.demoSession.
+ * Only active when DEMO_MODE=true.
+ *
+ * The client passes a session token in X-Demo-Session.
+ * If the header is missing, a 400 is returned for demo-only endpoints.
+ */
+import type { Request, Response, NextFunction } from 'express'
+import { getDemoSession, saveDemoSession, touchDemoSession } from './demoSessionStore.js'
+import type { DemoSession } from './demoSessionStore.js'
+import { fail } from '../utils/apiResponse.js'
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace Express {
+        interface Request {
+            demoSession?: DemoSession
+            demoSessionToken?: string
+        }
+    }
+}
+
+export async function loadDemoSession(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const token = req.headers['x-demo-session'] as string | undefined
+    if (!token || !token.trim()) {
+        fail(res, 400, 'VALIDATION_ERROR', 'X-Demo-Session header is required in demo mode')
+        return
+    }
+
+    const trimmed = token.trim()
+    let session = await getDemoSession(trimmed)
+
+    if (!session) {
+        // Auto-create a new session on first access
+        session = { createdAt: new Date().toISOString() }
+        await saveDemoSession(trimmed, session)
+    } else {
+        // Refresh TTL on every access
+        await touchDemoSession(trimmed)
+    }
+
+    req.demoSession = session
+    req.demoSessionToken = trimmed
+    next()
+}
+
+export async function saveDemoSessionFromReq(req: Request): Promise<void> {
+    if (req.demoSessionToken && req.demoSession) {
+        await saveDemoSession(req.demoSessionToken, req.demoSession)
+    }
+}

--- a/backend/src/demo/demoSessionStore.ts
+++ b/backend/src/demo/demoSessionStore.ts
@@ -1,0 +1,82 @@
+/**
+ * Redis-based session store for demo mode.
+ *
+ * Demo sessions are identified by a session key passed in the X-Demo-Session header.
+ * Each session holds an isolated demo portfolio keyed to that session only.
+ * Sessions expire after 1 hour (TTL enforced by Redis).
+ *
+ * Usage:
+ *   const sessionKey = req.headers['x-demo-session'] as string
+ *   const session = await getDemoSession(sessionKey)
+ *   session.portfolio = { ... }
+ *   await saveDemoSession(sessionKey, session)
+ */
+import { REDIS_URL } from '../queue/connection.js'
+import { logger } from '../utils/logger.js'
+import type { Redis } from 'ioredis'
+
+const SESSION_TTL_SECONDS = 60 * 60   // 1 hour
+const KEY_PREFIX = 'demo:session:'
+
+export interface DemoSession {
+    createdAt: string
+    portfolio?: Record<string, unknown>
+    [key: string]: unknown
+}
+
+let redis: Redis | null = null
+
+async function getRedis(): Promise<Redis | null> {
+    if (redis) return redis
+    try {
+        const { default: IORedis } = await import('ioredis')
+        const client = new IORedis(REDIS_URL, {
+            maxRetriesPerRequest: 1,
+            enableReadyCheck: false,
+            lazyConnect: true,
+        })
+        await client.connect()
+        redis = client
+        return redis
+    } catch (err) {
+        logger.warn('[demoSession] Redis unavailable — demo sessions will not persist', {
+            error: err instanceof Error ? err.message : String(err),
+        })
+        return null
+    }
+}
+
+function sessionKey(token: string): string {
+    return `${KEY_PREFIX}${token}`
+}
+
+export async function getDemoSession(token: string): Promise<DemoSession | null> {
+    const client = await getRedis()
+    if (!client) return null
+    const raw = await client.get(sessionKey(token))
+    if (!raw) return null
+    try {
+        return JSON.parse(raw) as DemoSession
+    } catch {
+        return null
+    }
+}
+
+export async function saveDemoSession(token: string, session: DemoSession): Promise<void> {
+    const client = await getRedis()
+    if (!client) return
+    await client.setex(sessionKey(token), SESSION_TTL_SECONDS, JSON.stringify(session))
+}
+
+export async function deleteDemoSession(token: string): Promise<void> {
+    const client = await getRedis()
+    if (!client) return
+    await client.del(sessionKey(token))
+}
+
+export async function touchDemoSession(token: string): Promise<boolean> {
+    const client = await getRedis()
+    if (!client) return false
+    const result = await client.expire(sessionKey(token), SESSION_TTL_SECONDS)
+    return result === 1
+}

--- a/backend/src/test/demoSession.test.ts
+++ b/backend/src/test/demoSession.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock ioredis
+const mockGet = vi.fn()
+const mockSetex = vi.fn()
+const mockDel = vi.fn()
+const mockExpire = vi.fn()
+const mockConnect = vi.fn()
+
+vi.mock('ioredis', () => ({
+    default: vi.fn().mockImplementation(() => ({
+        get: mockGet,
+        setex: mockSetex,
+        del: mockDel,
+        expire: mockExpire,
+        connect: mockConnect,
+    })),
+}))
+
+vi.mock('../queue/connection.js', () => ({ REDIS_URL: 'redis://localhost:6379' }))
+
+// Re-import after mocks
+const { getDemoSession, saveDemoSession, deleteDemoSession, touchDemoSession } = await import('../demo/demoSessionStore.js')
+
+describe('Demo session store (#889)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockConnect.mockResolvedValue(undefined)
+    })
+
+    it('getDemoSession returns null when key does not exist', async () => {
+        mockGet.mockResolvedValue(null)
+        const session = await getDemoSession('missing-token')
+        expect(session).toBeNull()
+    })
+
+    it('getDemoSession returns parsed session when key exists', async () => {
+        const data = { createdAt: '2024-01-01T00:00:00.000Z', portfolio: { XLM: 100 } }
+        mockGet.mockResolvedValue(JSON.stringify(data))
+        const session = await getDemoSession('my-token')
+        expect(session).toEqual(data)
+    })
+
+    it('saveDemoSession writes JSON with 1-hour TTL', async () => {
+        mockSetex.mockResolvedValue('OK')
+        const session = { createdAt: '2024-01-01T00:00:00.000Z' }
+        await saveDemoSession('my-token', session)
+        expect(mockSetex).toHaveBeenCalledWith(
+            'demo:session:my-token',
+            3600,
+            JSON.stringify(session),
+        )
+    })
+
+    it('deleteDemoSession removes the key', async () => {
+        mockDel.mockResolvedValue(1)
+        await deleteDemoSession('my-token')
+        expect(mockDel).toHaveBeenCalledWith('demo:session:my-token')
+    })
+
+    it('touchDemoSession refreshes TTL and returns true when key exists', async () => {
+        mockExpire.mockResolvedValue(1)
+        const result = await touchDemoSession('my-token')
+        expect(result).toBe(true)
+        expect(mockExpire).toHaveBeenCalledWith('demo:session:my-token', 3600)
+    })
+
+    it('touchDemoSession returns false when key does not exist', async () => {
+        mockExpire.mockResolvedValue(0)
+        const result = await touchDemoSession('nonexistent')
+        expect(result).toBe(false)
+    })
+})


### PR DESCRIPTION
## Summary

- Adds `src/demo/demoSessionStore.ts`: get/save/delete/touch sessions backed by Redis with 1-hour TTL
- Adds `src/demo/demoSessionMiddleware.ts`: Express middleware that loads session from `X-Demo-Session` header, auto-creates on first access, refreshes TTL on each request
- Sessions are isolated per token — demo data does not bleed between users
- Expired sessions cleaned automatically by Redis TTL — no cron job needed
- 6 unit tests covering null-miss, parse, TTL write, delete, touch-exists, touch-missing

## Test plan

- [ ] `npm test` — demoSession tests pass
- [ ] `X-Demo-Session: my-token` → session created in Redis with 3600s TTL
- [ ] Page refresh with same token → same portfolio data returned
- [ ] After 1 hour → Redis evicts key, next request creates fresh session

Closes #889