### PR TITLE
feat: Add support for PostgreSQL full-text search on portfolio names

### DIFF
--- a/backend/src/api/portfolios.routes.ts
+++ b/backend/src/api/portfolios.routes.ts
@@ -36,13 +36,27 @@ function mapRebalanceOptions(body: any): ExecuteRebalanceOptions {
 
 export const portfoliosRouter = Router()
 
+portfoliosRouter.get('/portfolios', async (req: Request, res: Response) => {
+    try {
+        const search = req.query.search as string || ''
+        const limit = parseInt(req.query.limit as string) || 20
+        const offset = parseInt(req.query.offset as string) || 0
+
+        const portfolios = await portfolioStorage.searchPortfolios(search, limit, offset)
+        return ok(res, { portfolios, limit, offset })
+    } catch (error) {
+        logger.error('[ERROR] Search portfolios failed', { error: getErrorObject(error) })
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
 const stellarService = new StellarService()
 const reflectorService = new ReflectorService()
 const featureFlags = getFeatureFlags()
 
 portfoliosRouter.post('/portfolio', validateRequest(createPortfolioSchema), async (req: Request, res: Response) => {
     try {
-        const { userAddress, allocations, threshold, slippageTolerance, strategy, strategyConfig } = req.body
+        const { userAddress, allocations, threshold, slippageTolerance, strategy, strategyConfig, name, description } = req.body
 
         const slippageTolerancePercent = slippageTolerance ?? 1
         const portfolioId = await stellarService.createPortfolio(
@@ -51,7 +65,9 @@ portfoliosRouter.post('/portfolio', validateRequest(createPortfolioSchema), asyn
             threshold,
             slippageTolerancePercent,
             strategy ?? 'threshold',
-            strategyConfig ?? {}
+            strategyConfig ?? {},
+            name,
+            description
         )
         const mode = featureFlags.demoMode ? 'demo' : 'onchain'
         return ok(res, {

--- a/backend/src/api/validation.ts
+++ b/backend/src/api/validation.ts
@@ -15,6 +15,8 @@ const strictBoolean = z.preprocess((val) => {
 // Schema for POST /portfolio
 export const createPortfolioSchema = z.object({
     userAddress: z.string().min(1, "userAddress is required"),
+    name: z.string().max(256, "name is too long").optional(),
+    description: z.string().max(2000, "description is too long").optional(),
     allocations: z.record(z.string(), z.number().min(0).max(100)).refine(
         (allocations) => {
             const total = Object.values(allocations).reduce((sum, val) => sum + val, 0);

--- a/backend/src/db/migrations/012_portfolio_search.down.sql
+++ b/backend/src/db/migrations/012_portfolio_search.down.sql
@@ -1,0 +1,8 @@
+-- Migration: 012_portfolio_search (down)
+-- Description: Rollback for portfolio search changes.
+-- Rollback for: 012_portfolio_search.up.sql
+
+DROP INDEX IF EXISTS idx_portfolios_search_vector;
+ALTER TABLE portfolios DROP COLUMN IF EXISTS search_vector;
+ALTER TABLE portfolios DROP COLUMN IF EXISTS description;
+ALTER TABLE portfolios DROP COLUMN IF EXISTS name;

--- a/backend/src/db/migrations/012_portfolio_search.up.sql
+++ b/backend/src/db/migrations/012_portfolio_search.up.sql
@@ -1,0 +1,16 @@
+-- Migration: 012_portfolio_search (up)
+-- Description: Add name, description, and full-text search capability to portfolios.
+-- Rollback: See 012_portfolio_search.down.sql
+
+ALTER TABLE portfolios ADD COLUMN name VARCHAR(256);
+ALTER TABLE portfolios ADD COLUMN description TEXT;
+
+-- Add a generated tsvector column for fast full-text search
+ALTER TABLE portfolios
+  ADD COLUMN search_vector tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(description, '')), 'B')
+  ) STORED;
+
+CREATE INDEX idx_portfolios_search_vector ON portfolios USING GIN (search_vector);

--- a/backend/src/db/portfolioDb.ts
+++ b/backend/src/db/portfolioDb.ts
@@ -4,6 +4,8 @@ import { ConflictError } from '../types/index.js'
 export interface PortfolioRow {
     id: string
     user_address: string
+    name?: string
+    description?: string
     allocations: Record<string, number>
     threshold: number
     slippage_tolerance?: number
@@ -20,6 +22,8 @@ function rowToPortfolio(r: PortfolioRow) {
     return {
         id: r.id,
         userAddress: r.user_address,
+        name: r.name,
+        description: r.description,
         allocations: r.allocations || {},
         threshold: r.threshold,
         slippageTolerance: r.slippage_tolerance != null ? Number(r.slippage_tolerance) : 1,
@@ -42,12 +46,14 @@ export async function dbCreatePortfolio(
     totalValue: number,
     slippageTolerance: number = 1,
     strategy: string = 'threshold',
-    strategyConfig: Record<string, unknown> = {}
+    strategyConfig: Record<string, unknown> = {},
+    name?: string,
+    description?: string
 ) {
     await query(
-        `INSERT INTO portfolios (id, user_address, allocations, threshold, slippage_tolerance, balances, total_value, created_at, last_rebalance, version, strategy, strategy_config)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), 1, $8, $9)`,
-        [id, userAddress, JSON.stringify(allocations), threshold, slippageTolerance, JSON.stringify(balances), totalValue, strategy, JSON.stringify(strategyConfig)]
+        `INSERT INTO portfolios (id, user_address, allocations, threshold, slippage_tolerance, balances, total_value, created_at, last_rebalance, version, strategy, strategy_config, name, description)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), 1, $8, $9, $10, $11)`,
+        [id, userAddress, JSON.stringify(allocations), threshold, slippageTolerance, JSON.stringify(balances), totalValue, strategy, JSON.stringify(strategyConfig), name, description]
     )
 }
 
@@ -90,6 +96,8 @@ export async function dbUpdatePortfolio(
     id: string,
     updates: { 
         userAddress?: string;
+        name?: string;
+        description?: string;
         allocations?: Record<string, number>;
         threshold?: number;
         balances?: Record<string, number>; 
@@ -104,6 +112,14 @@ export async function dbUpdatePortfolio(
     if (updates.userAddress !== undefined) {
         sets.push(`user_address = $${i++}`)
         values.push(updates.userAddress)
+    }
+    if (updates.name !== undefined) {
+        sets.push(`name = $${i++}`)
+        values.push(updates.name)
+    }
+    if (updates.description !== undefined) {
+        sets.push(`description = $${i++}`)
+        values.push(updates.description)
     }
     if (updates.allocations !== undefined) {
         sets.push(`allocations = $${i++}`)
@@ -167,4 +183,23 @@ export async function dbUpdatePortfolio(
 export async function dbDeletePortfolio(id: string) {
     const result = await query('DELETE FROM portfolios WHERE id = $1', [id])
     return (result.rowCount ?? 0) > 0
+}
+
+export async function dbSearchPortfolios(searchQuery: string, limit: number, offset: number) {
+    if (!searchQuery) {
+        const result = await query<PortfolioRow>(
+            'SELECT * FROM portfolios ORDER BY created_at DESC LIMIT $1 OFFSET $2',
+            [limit, offset]
+        )
+        return result.rows.map(rowToPortfolio)
+    }
+
+    const result = await query<PortfolioRow>(
+        `SELECT * FROM portfolios 
+         WHERE search_vector @@ plainto_tsquery('english', $1)
+         ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC, created_at DESC
+         LIMIT $2 OFFSET $3`,
+        [searchQuery, limit, offset]
+    )
+    return result.rows.map(rowToPortfolio)
 }

--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -150,6 +150,8 @@ PRAGMA foreign_keys = ON;
 CREATE TABLE IF NOT EXISTS portfolios (
     id            TEXT PRIMARY KEY,
     user_address  TEXT NOT NULL,
+    name          TEXT,
+    description   TEXT,
     allocations   TEXT NOT NULL,
     threshold     REAL NOT NULL,
     slippage_tolerance_percent REAL NOT NULL DEFAULT 1,
@@ -624,6 +626,18 @@ export class DatabaseService {
         "[DB] Migration: added slippage_tolerance_percent column to portfolios",
       );
     }
+    if (!cols.some((c) => c.name === "name")) {
+      this.db.exec(
+        "ALTER TABLE portfolios ADD COLUMN name TEXT",
+      );
+      logger.info("[DB] Migration: added name column to portfolios");
+    }
+    if (!cols.some((c) => c.name === "description")) {
+      this.db.exec(
+        "ALTER TABLE portfolios ADD COLUMN description TEXT",
+      );
+      logger.info("[DB] Migration: added description column to portfolios");
+    }
     if (!cols.some((c) => c.name === "strategy")) {
       this.db.exec(
         "ALTER TABLE portfolios ADD COLUMN strategy TEXT NOT NULL DEFAULT 'threshold'",
@@ -894,13 +908,15 @@ export class DatabaseService {
             .prepare(
               `
                     UPDATE portfolios
-                    SET user_address = ?, allocations = ?, threshold = ?, balances = ?,
+                    SET user_address = ?, name = ?, description = ?, allocations = ?, threshold = ?, balances = ?,
                         total_value = ?, last_rebalance = ?, version = version + 1
                     WHERE id = ? AND version = ?
                 `,
             )
             .run(
               merged.userAddress,
+              merged.name ?? null,
+              merged.description ?? null,
               JSON.stringify(merged.allocations),
               merged.threshold,
               JSON.stringify(merged.balances),
@@ -959,6 +975,34 @@ export class DatabaseService {
         return rows.map(rowToPortfolio);
       } catch (err) {
         throw new Error(`Failed to retrieve all portfolios: ${err}`);
+      }
+    });
+  }
+
+  searchPortfolios(searchQuery: string, limit: number, offset: number): Portfolio[] {
+    return this._withTiming("searchPortfolios", () => {
+      try {
+        if (!searchQuery) {
+          const rows = this.db
+            .prepare<[number, number], PortfolioRow>(
+              "SELECT * FROM portfolios ORDER BY created_at DESC LIMIT ? OFFSET ?"
+            )
+            .all(limit, offset);
+          return rows.map(rowToPortfolio);
+        }
+
+        const likeQuery = `%${searchQuery}%`;
+        const rows = this.db
+          .prepare<[string, string, number, number], PortfolioRow>(
+            `SELECT * FROM portfolios 
+             WHERE name LIKE ? OR description LIKE ? 
+             ORDER BY created_at DESC 
+             LIMIT ? OFFSET ?`
+          )
+          .all(likeQuery, likeQuery, limit, offset);
+        return rows.map(rowToPortfolio);
+      } catch (err) {
+        throw new Error(`Failed to search portfolios: ${err}`);
       }
     });
   }

--- a/backend/src/services/portfolioStorage.ts
+++ b/backend/src/services/portfolioStorage.ts
@@ -36,12 +36,16 @@ export class PortfolioStorage {
     async createPortfolio(
         userAddress: string,
         allocations: Record<string, number>,
-        threshold: number
+        threshold: number,
+        name?: string,
+        description?: string
     ): Promise<string> {
         const id = randomUUID()
         const portfolio: Portfolio = {
             id,
             userAddress,
+            name,
+            description,
             allocations,
             threshold,
             balances: {},
@@ -51,7 +55,7 @@ export class PortfolioStorage {
             version: 1
         }
         if (isDbConfigured()) {
-            await portfolioDb.dbCreatePortfolio(id, userAddress, allocations, threshold, {}, 0)
+            await portfolioDb.dbCreatePortfolio(id, userAddress, allocations, threshold, {}, 0, 1, 'threshold', {}, name, description)
         }
         this.cacheSet(portfolio)
         return id
@@ -62,13 +66,17 @@ export class PortfolioStorage {
         allocations: Record<string, number>,
         threshold: number,
         currentBalances: Record<string, number>,
-        slippageTolerance: number = 1
+        slippageTolerance: number = 1,
+        name?: string,
+        description?: string
     ): Promise<string> {
         const id = randomUUID()
         const totalValue = Object.values(currentBalances).reduce((sum, bal) => sum + bal, 0)
         const portfolio: Portfolio = {
             id,
             userAddress,
+            name,
+            description,
             allocations,
             threshold,
             slippageTolerance: clampSlippageTolerance(slippageTolerance),
@@ -86,7 +94,11 @@ export class PortfolioStorage {
                 threshold,
                 currentBalances,
                 totalValue,
-                portfolio.slippageTolerance ?? 1
+                portfolio.slippageTolerance ?? 1,
+                'threshold',
+                {},
+                name,
+                description
             )
         }
         this.cacheSet(portfolio)
@@ -120,16 +132,37 @@ export class PortfolioStorage {
         if (isDbConfigured()) {
             const ok = await portfolioDb.dbUpdatePortfolio(id, {
                 userAddress: updates.userAddress,
+                name: updates.name,
+                description: updates.description,
                 allocations: updates.allocations,
                 threshold: updates.threshold,
                 balances: updates.balances,
                 totalValue: updates.totalValue,
                 lastRebalance: updates.lastRebalance
             }, expectedVersion)
-            if (!ok && (updates.balances ?? updates.totalValue ?? updates.lastRebalance)) return false
+            if (!ok && (updates.balances ?? updates.totalValue ?? updates.lastRebalance ?? updates.name ?? updates.description)) return false
         }
         this.cacheSet(updated)
         return true
+    }
+
+    async searchPortfolios(searchQuery: string, limit: number, offset: number): Promise<Portfolio[]> {
+        if (isDbConfigured()) {
+            const list = await portfolioDb.dbSearchPortfolios(searchQuery, limit, offset)
+            if (useCache) list.forEach(p => this.portfolios.set(p.id, p))
+            return list
+        }
+        
+        let all = Array.from(this.portfolios.values())
+        if (searchQuery) {
+            const q = searchQuery.toLowerCase()
+            all = all.filter(p => 
+                (p.name && p.name.toLowerCase().includes(q)) || 
+                (p.description && p.description.toLowerCase().includes(q))
+            )
+        }
+        all.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        return all.slice(offset, offset + limit)
     }
 
     async getAllPortfolios(): Promise<Portfolio[]> {

--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -91,13 +91,15 @@ export class StellarService {
         slippageTolerancePercent: number,
         strategy: string,
         strategyConfig: Record<string, unknown>,
+        name?: string,
+        description?: string,
     ): Promise<string> {
         const id = randomUUID()
         const now = new Date().toISOString()
         this.db.prepare(`
-            INSERT INTO portfolios (id, user_address, allocations, threshold, slippage_tolerance_percent, balances, total_value, created_at, last_rebalance, version)
-            VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, 1)
-        `).run(id, userAddress, JSON.stringify(allocations), threshold, slippageTolerancePercent, '{}', now, now)
+            INSERT INTO portfolios (id, user_address, allocations, threshold, slippage_tolerance_percent, balances, total_value, created_at, last_rebalance, version, name, description)
+            VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, 1, ?, ?)
+        `).run(id, userAddress, JSON.stringify(allocations), threshold, slippageTolerancePercent, '{}', now, now, name ?? null, description ?? null)
         return id
     }
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -53,6 +53,8 @@ export interface HistoricalPrice {
 export interface Portfolio {
     id: string
     userAddress: string
+    name?: string
+    description?: string
     allocations: Record<string, number>
     threshold: number
     slippageTolerancePercent?: number


### PR DESCRIPTION
This PR adds full-text search capability for portfolios using PostgreSQL's GIN index and tsvector, with a fallback for SQLite.

closes #894

**Changes include:**
- Added `name` and `description` to `portfolios` schema across Postgres and SQLite
- Implemented GIN index migration for `search_vector`
- Added `GET /api/v1/portfolios` endpoint supporting `?search=...`
- Ensured graceful fallback to `LIKE` queries for SQLite deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolios can now include a name and description when created or updated.
  * Added portfolio search with pagination, letting users filter portfolios by text and browse results.

* **Bug Fixes**
  * Portfolio listings now return name and description consistently across supported storage paths.
  * Search results and portfolio ordering are now handled more reliably when no search term is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->