### PR TITLE
feat: Add infrastructure as code (Terraform) for cloud deployment

### DIFF
--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -1,0 +1,43 @@
+locals {
+  name_prefix = "${var.project_name}-${terraform.workspace}"
+}
+
+module "vpc" {
+  source      = "./modules/vpc"
+  name_prefix = local.name_prefix
+  vpc_cidr    = var.vpc_cidr
+}
+
+module "rds" {
+  source         = "./modules/rds"
+  name_prefix    = local.name_prefix
+  vpc_id         = module.vpc.vpc_id
+  subnet_ids     = module.vpc.private_subnet_ids
+  instance_class = lookup(var.db_instance_class, terraform.workspace, "db.t4g.micro")
+}
+
+module "elasticache" {
+  source      = "./modules/elasticache"
+  name_prefix = local.name_prefix
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.private_subnet_ids
+  node_type   = lookup(var.redis_node_type, terraform.workspace, "cache.t4g.micro")
+}
+
+module "ecs" {
+  source             = "./modules/ecs"
+  name_prefix        = local.name_prefix
+  vpc_id             = module.vpc.vpc_id
+  public_subnet_ids  = module.vpc.public_subnet_ids
+  private_subnet_ids = module.vpc.private_subnet_ids
+  task_cpu           = lookup(var.ecs_task_cpu, terraform.workspace, 256)
+  task_memory        = lookup(var.ecs_task_memory, terraform.workspace, 512)
+  db_secret_arn      = module.rds.db_secret_arn
+  db_host            = module.rds.db_endpoint
+  redis_host         = module.elasticache.redis_endpoint
+}
+
+module "s3_cloudfront" {
+  source      = "./modules/s3_cloudfront"
+  name_prefix = local.name_prefix
+}

--- a/deployment/terraform/modules/ecs/main.tf
+++ b/deployment/terraform/modules/ecs/main.tf
@@ -1,0 +1,211 @@
+resource "aws_ecs_cluster" "main" {
+  name = "${var.name_prefix}-ecs-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${var.name_prefix}-alb-sg"
+  description = "Security group for ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ecs_tasks" {
+  name        = "${var.name_prefix}-ecs-tasks-sg"
+  description = "Allow inbound access from the ALB only"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_lb" "main" {
+  name               = "${var.name_prefix}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.public_subnet_ids
+}
+
+resource "aws_lb_target_group" "main" {
+  name        = "${var.name_prefix}-tg"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    healthy_threshold   = 3
+    interval            = 30
+    protocol            = "HTTP"
+    matcher             = "200"
+    timeout             = 3
+    path                = "/api/v1/health"
+    unhealthy_threshold = 2
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.main.arn
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "${var.name_prefix}-ecsTaskExecutionRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_policy" "ecs_secrets_policy" {
+  name        = "${var.name_prefix}-ecsSecretsPolicy"
+  description = "Allows ECS tasks to read secrets from AWS Secrets Manager"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "kms:Decrypt"
+        ]
+        Resource = [
+          var.db_secret_arn,
+          # Optionally add external API keys ARNs here
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_secrets_policy_attach" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.ecs_secrets_policy.arn
+}
+
+resource "aws_ecs_task_definition" "main" {
+  family                   = "${var.name_prefix}-app"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "backend"
+      image = "ghcr.io/ritik4ever/stellar-portfolio-rebalancer-backend:latest"
+      portMappings = [
+        {
+          containerPort = 3000
+          hostPort      = 3000
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        {
+          name  = "PORT"
+          value = "3000"
+        },
+        {
+          name  = "DB_HOST"
+          value = var.db_host
+        },
+        {
+          name  = "REDIS_HOST"
+          value = var.redis_host
+        }
+      ]
+      secrets = [
+        {
+          name      = "DB_PASSWORD"
+          valueFrom = "${var.db_secret_arn}:password::"
+        },
+        {
+          name      = "DB_USER"
+          valueFrom = "${var.db_secret_arn}:username::"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/${var.name_prefix}-backend"
+          "awslogs-region"        = "us-east-1"
+          "awslogs-stream-prefix" = "ecs"
+          "awslogs-create-group"  = "true"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "main" {
+  name            = "${var.name_prefix}-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.main.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    subnets          = var.private_subnet_ids
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.main.arn
+    container_name   = "backend"
+    container_port   = 3000
+  }
+
+  depends_on = [aws_lb_listener.http]
+}

--- a/deployment/terraform/modules/ecs/outputs.tf
+++ b/deployment/terraform/modules/ecs/outputs.tf
@@ -1,0 +1,3 @@
+output "alb_dns_name" {
+  value = aws_lb.main.dns_name
+}

--- a/deployment/terraform/modules/ecs/variables.tf
+++ b/deployment/terraform/modules/ecs/variables.tf
@@ -1,0 +1,35 @@
+variable "name_prefix" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "public_subnet_ids" {
+  type = list(string)
+}
+
+variable "private_subnet_ids" {
+  type = list(string)
+}
+
+variable "task_cpu" {
+  type = number
+}
+
+variable "task_memory" {
+  type = number
+}
+
+variable "db_secret_arn" {
+  type = string
+}
+
+variable "db_host" {
+  type = string
+}
+
+variable "redis_host" {
+  type = string
+}

--- a/deployment/terraform/modules/elasticache/main.tf
+++ b/deployment/terraform/modules/elasticache/main.tf
@@ -1,0 +1,40 @@
+resource "aws_security_group" "redis" {
+  name        = "${var.name_prefix}-redis-sg"
+  description = "Security group for Redis"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    cidr_blocks     = ["10.0.0.0/16"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${var.name_prefix}-redis-subnet-group"
+  subnet_ids = var.subnet_ids
+}
+
+resource "aws_elasticache_cluster" "main" {
+  cluster_id           = "${var.name_prefix}-redis"
+  engine               = "redis"
+  node_type            = var.node_type
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis7"
+  engine_version       = "7.0"
+  port                 = 6379
+  subnet_group_name    = aws_elasticache_subnet_group.main.name
+  security_group_ids   = [aws_security_group.redis.id]
+
+  tags = {
+    Name = "${var.name_prefix}-redis"
+  }
+}

--- a/deployment/terraform/modules/elasticache/outputs.tf
+++ b/deployment/terraform/modules/elasticache/outputs.tf
@@ -1,0 +1,3 @@
+output "redis_endpoint" {
+  value = "${aws_elasticache_cluster.main.cache_nodes[0].address}:${aws_elasticache_cluster.main.cache_nodes[0].port}"
+}

--- a/deployment/terraform/modules/elasticache/variables.tf
+++ b/deployment/terraform/modules/elasticache/variables.tf
@@ -1,0 +1,15 @@
+variable "name_prefix" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "node_type" {
+  type = string
+}

--- a/deployment/terraform/modules/rds/main.tf
+++ b/deployment/terraform/modules/rds/main.tf
@@ -1,0 +1,48 @@
+resource "aws_security_group" "rds" {
+  name        = "${var.name_prefix}-rds-sg"
+  description = "Security group for RDS"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    cidr_blocks     = ["10.0.0.0/16"] # Allow access from VPC
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.name_prefix}-rds-subnet-group"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name = "${var.name_prefix}-rds-subnet-group"
+  }
+}
+
+resource "aws_db_instance" "main" {
+  identifier                  = "${var.name_prefix}-db"
+  engine                      = "postgres"
+  engine_version              = "15.4"
+  instance_class              = var.instance_class
+  allocated_storage           = 20
+  storage_type                = "gp3"
+  db_subnet_group_name        = aws_db_subnet_group.main.name
+  vpc_security_group_ids      = [aws_security_group.rds.id]
+  db_name                     = "stellar_portfolio"
+  username                    = "dbadmin"
+  manage_master_user_password = true # Stores password in Secrets Manager automatically
+  skip_final_snapshot         = true
+  publicly_accessible         = false
+
+  tags = {
+    Name = "${var.name_prefix}-db"
+  }
+}

--- a/deployment/terraform/modules/rds/outputs.tf
+++ b/deployment/terraform/modules/rds/outputs.tf
@@ -1,0 +1,7 @@
+output "db_endpoint" {
+  value = aws_db_instance.main.endpoint
+}
+
+output "db_secret_arn" {
+  value = aws_db_instance.main.master_user_secret[0].secret_arn
+}

--- a/deployment/terraform/modules/rds/variables.tf
+++ b/deployment/terraform/modules/rds/variables.tf
@@ -1,0 +1,15 @@
+variable "name_prefix" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "instance_class" {
+  type = string
+}

--- a/deployment/terraform/modules/s3_cloudfront/main.tf
+++ b/deployment/terraform/modules/s3_cloudfront/main.tf
@@ -1,0 +1,87 @@
+resource "aws_s3_bucket" "frontend" {
+  bucket        = "${var.name_prefix}-frontend-assets"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket                  = aws_s3_bucket.frontend.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudfront_origin_access_control" "default" {
+  name                              = "${var.name_prefix}-oac"
+  description                       = "OAC for ${var.name_prefix} frontend"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "frontend" {
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.default.id
+    origin_id                = "S3-${aws_s3_bucket.frontend.id}"
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "S3-${aws_s3_bucket.frontend.id}"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-cloudfront"
+  }
+}
+
+resource "aws_s3_bucket_policy" "frontend_oac" {
+  bucket = aws_s3_bucket.frontend.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontServicePrincipal"
+        Effect    = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.frontend.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      }
+    ]
+  })
+}

--- a/deployment/terraform/modules/s3_cloudfront/outputs.tf
+++ b/deployment/terraform/modules/s3_cloudfront/outputs.tf
@@ -1,0 +1,7 @@
+output "cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.frontend.domain_name
+}
+
+output "s3_bucket_id" {
+  value = aws_s3_bucket.frontend.id
+}

--- a/deployment/terraform/modules/s3_cloudfront/variables.tf
+++ b/deployment/terraform/modules/s3_cloudfront/variables.tf
@@ -1,0 +1,3 @@
+variable "name_prefix" {
+  type = string
+}

--- a/deployment/terraform/modules/vpc/main.tf
+++ b/deployment/terraform/modules/vpc/main.tf
@@ -1,0 +1,98 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.name_prefix}-vpc"
+  }
+}
+
+resource "aws_subnet" "public" {
+  count                   = length(var.azs)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 4, count.index)
+  availability_zone       = var.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.name_prefix}-public-${count.index + 1}"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.azs)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 4, count.index + length(var.azs))
+  availability_zone = var.azs[count.index]
+
+  tags = {
+    Name = "${var.name_prefix}-private-${count.index + 1}"
+  }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.name_prefix}-igw"
+  }
+}
+
+resource "aws_eip" "nat" {
+  count  = length(var.azs)
+  domain = "vpc"
+
+  tags = {
+    Name = "${var.name_prefix}-nat-eip-${count.index + 1}"
+  }
+}
+
+resource "aws_nat_gateway" "nat" {
+  count         = length(var.azs)
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = {
+    Name = "${var.name_prefix}-nat-${count.index + 1}"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.azs)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  count  = length(var.azs)
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat[count.index].id
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-private-rt-${count.index + 1}"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(var.azs)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}

--- a/deployment/terraform/modules/vpc/outputs.tf
+++ b/deployment/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}

--- a/deployment/terraform/modules/vpc/variables.tf
+++ b/deployment/terraform/modules/vpc/variables.tf
@@ -1,0 +1,12 @@
+variable "name_prefix" {
+  type = string
+}
+
+variable "vpc_cidr" {
+  type = string
+}
+
+variable "azs" {
+  type    = list(string)
+  default = ["us-east-1a", "us-east-1b"]
+}

--- a/deployment/terraform/outputs.tf
+++ b/deployment/terraform/outputs.tf
@@ -1,0 +1,16 @@
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "backend_url" {
+  value = module.ecs.alb_dns_name
+}
+
+output "frontend_url" {
+  value = module.s3_cloudfront.cloudfront_domain_name
+}
+
+output "db_secret_arn" {
+  value       = module.rds.db_secret_arn
+  description = "ARN of the Secrets Manager secret containing RDS credentials"
+}

--- a/deployment/terraform/providers.tf
+++ b/deployment/terraform/providers.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # NOTE: To use an S3 backend for remote state, uncomment and configure below.
+  # backend "s3" {
+  #   bucket         = "stellar-portfolio-tf-state"
+  #   key            = "state/terraform.tfstate"
+  #   region         = "us-east-1"
+  #   dynamodb_table = "stellar-portfolio-tf-locks"
+  # }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "StellarPortfolioRebalancer"
+      Environment = terraform.workspace
+      ManagedBy   = "Terraform"
+    }
+  }
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,0 +1,53 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Name of the project"
+  type        = string
+  default     = "stellar-portfolio"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class"
+  type        = map(string)
+  default = {
+    staging    = "db.t4g.micro"
+    production = "db.t4g.small"
+  }
+}
+
+variable "redis_node_type" {
+  description = "ElastiCache node type"
+  type        = map(string)
+  default = {
+    staging    = "cache.t4g.micro"
+    production = "cache.t4g.small"
+  }
+}
+
+variable "ecs_task_cpu" {
+  description = "ECS Task CPU"
+  type        = map(number)
+  default = {
+    staging    = 256
+    production = 512
+  }
+}
+
+variable "ecs_task_memory" {
+  description = "ECS Task Memory"
+  type        = map(number)
+  default = {
+    staging    = 512
+    production = 1024
+  }
+}


### PR DESCRIPTION
This PR adds a modular Terraform setup to deploy the Stellar Portfolio Rebalancer on AWS.

closes #1032

**Changes include:**
- Added Terraform modules for VPC, RDS PostgreSQL, ElastiCache Redis, ECS Fargate, and S3/CloudFront
- Utilized Terraform workspaces for environment separation (staging/production)
- Configured native AWS Secrets Manager integration for RDS to keep secrets out of state
- Set up IAM roles for ECS tasks to read secrets securely at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end infrastructure for a full deployment stack, including networking, database, caching, backend service hosting, and frontend asset delivery.
  * Introduced public endpoints for the backend service and frontend site, plus shared deployment outputs for key connection details.
  * Added workspace-aware sizing and naming so staging and production can use different resource profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->