### PR TITLE
feat(contracts): add cargo-fuzz targets for rebalance and allocation flows

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
 soroban-sdk = "21.0.0"

--- a/contracts/fuzz/.gitignore
+++ b/contracts/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/contracts/fuzz/Cargo.toml
+++ b/contracts/fuzz/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "portfolio-rebalancer-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.portfolio-rebalancer]
+path = ".."
+features = ["testutils"]
+
+[dependencies.soroban-sdk]
+version = "21.0.0"
+features = ["testutils"]
+
+[[bin]]
+name = "fuzz_rebalance"
+path = "fuzz_targets/fuzz_rebalance.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_oracle_prices"
+path = "fuzz_targets/fuzz_oracle_prices.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_allocations"
+path = "fuzz_targets/fuzz_allocations.rs"
+test = false
+doc = false
+bench = false

--- a/contracts/fuzz/fuzz_targets/fuzz_allocations.rs
+++ b/contracts/fuzz/fuzz_targets/fuzz_allocations.rs
@@ -1,0 +1,52 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, Map};
+
+use portfolio_rebalancer::portfolio::validate_allocations;
+use portfolio_rebalancer::types::{
+    MAX_PORTFOLIO_ASSETS, MAX_REBALANCE_THRESHOLD, MAX_SLIPPAGE_TOLERANCE_BPS,
+    MIN_REBALANCE_THRESHOLD, MIN_SLIPPAGE_TOLERANCE_BPS,
+};
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() {
+        return;
+    }
+
+    let env = Env::default();
+
+    // Path 1: completely arbitrary allocation percentages — must never panic
+    {
+        let mut allocs: Map<Address, u32> = Map::new(&env);
+        for chunk in data.chunks(2).take(MAX_PORTFOLIO_ASSETS as usize + 2) {
+            if chunk.len() < 2 {
+                break;
+            }
+            allocs.set(Address::generate(&env), chunk[1] as u32);
+        }
+        let _ = validate_allocations(&allocs);
+    }
+
+    // Path 2: single asset — only valid when pct == 100
+    {
+        let pct = data[0] as u32;
+        let mut allocs: Map<Address, u32> = Map::new(&env);
+        allocs.set(Address::generate(&env), pct);
+        let result = validate_allocations(&allocs);
+        assert_eq!(
+            result,
+            pct == 100,
+            "single asset: expected {} for pct={pct}",
+            pct == 100
+        );
+    }
+
+    // Path 3: boundary constants must always be in the right order
+    {
+        assert!(MIN_REBALANCE_THRESHOLD <= MAX_REBALANCE_THRESHOLD);
+        assert!(MIN_SLIPPAGE_TOLERANCE_BPS <= MAX_SLIPPAGE_TOLERANCE_BPS);
+        assert!(MAX_PORTFOLIO_ASSETS >= 1);
+    }
+});

--- a/contracts/fuzz/fuzz_targets/fuzz_oracle_prices.rs
+++ b/contracts/fuzz/fuzz_targets/fuzz_oracle_prices.rs
@@ -1,0 +1,41 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use portfolio_rebalancer::portfolio::{balance_to_value, value_to_balance};
+use portfolio_rebalancer::types::{DEFAULT_ASSET_DECIMALS, MIN_TRADE_AMOUNT_STROOPS};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 16 {
+        return;
+    }
+
+    // Decode first 16 bytes as two i64s (price and balance)
+    let price_bytes: [u8; 8] = data[0..8].try_into().unwrap();
+    let balance_bytes: [u8; 8] = data[8..16].try_into().unwrap();
+    let price = i64::from_le_bytes(price_bytes) as i128;
+    let balance = i64::from_le_bytes(balance_bytes) as i128;
+
+    // These must never panic for any input
+    let value = balance_to_value(balance, price);
+    let _ = value_to_balance(value, price, DEFAULT_ASSET_DECIMALS);
+
+    // Explicitly test zero price — must return 0, not divide by zero
+    let _ = value_to_balance(value, 0, DEFAULT_ASSET_DECIMALS);
+
+    // Test extreme values that could overflow multiplication
+    let extremes: &[(i128, i128)] = &[
+        (0, 0),
+        (1, 1),
+        (i64::MAX as i128, i64::MAX as i128),
+        (-1, 1),
+        (1, -1),
+        (MIN_TRADE_AMOUNT_STROOPS, 10i128.pow(14)),
+        (10i128.pow(14) * 100_000, 10i128.pow(14)),
+    ];
+
+    for (b, p) in extremes {
+        let v = balance_to_value(*b, *p);
+        let _ = value_to_balance(v, *p, DEFAULT_ASSET_DECIMALS);
+        let _ = value_to_balance(v, 0, DEFAULT_ASSET_DECIMALS);
+    }
+});

--- a/contracts/fuzz/fuzz_targets/fuzz_rebalance.rs
+++ b/contracts/fuzz/fuzz_targets/fuzz_rebalance.rs
@@ -1,0 +1,100 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, Map};
+
+use portfolio_rebalancer::portfolio::{calculate_rebalance_trades, validate_allocations};
+use portfolio_rebalancer::types::{
+    PauseReason, Portfolio, MAX_PORTFOLIO_ASSETS, MIN_TRADE_AMOUNT_STROOPS,
+};
+
+fuzz_target!(|data: &[u8]| {
+    // Need at least one 3-byte chunk to do anything useful
+    if data.len() < 3 {
+        return;
+    }
+
+    let env = Env::default();
+    let mut allocs: Map<Address, u32> = Map::new(&env);
+    let mut balances: Map<Address, i128> = Map::new(&env);
+    let mut prices: Map<Address, i128> = Map::new(&env);
+
+    // Each 3 bytes = one asset: [allocation%, balance_seed, price_seed]
+    for chunk in data.chunks(3).take(MAX_PORTFOLIO_ASSETS as usize) {
+        if chunk.len() < 3 {
+            break;
+        }
+        let asset = Address::generate(&env);
+        let pct: u32 = (chunk[0] as u32 % 99) + 1;
+        let balance: i128 = chunk[1] as i128 * 1_000_000_000;
+        let price: i128 = if chunk[2] == 0 {
+            0
+        } else {
+            chunk[2] as i128 * 10i128.pow(11)
+        };
+        allocs.set(asset.clone(), pct);
+        balances.set(asset.clone(), balance);
+        prices.set(asset, price);
+    }
+
+    // Path 1: validate_allocations must never panic — only return true or false
+    let _ = validate_allocations(&allocs);
+
+    if allocs.is_empty() {
+        return;
+    }
+
+    // Path 2: normalise so allocations sum to exactly 100, then run rebalance math
+    let keys: soroban_sdk::Vec<Address> = allocs.keys();
+    let n = keys.len() as u32;
+    let base: u32 = 100 / n;
+    let remainder: u32 = 100 - base * n;
+    let mut normalised: Map<Address, u32> = Map::new(&env);
+    for (idx, key) in keys.iter().enumerate() {
+        let pct = if idx as u32 == n - 1 {
+            base + remainder  // last asset absorbs the leftover
+        } else {
+            base
+        };
+        normalised.set(key, pct);
+    }
+
+    let user = Address::generate(&env);
+    let portfolio = Portfolio {
+        user,
+        target_allocations: normalised,
+        current_balances: balances.clone(),
+        asset_decimals: Map::new(&env),
+        rebalance_threshold: 5,
+        slippage_tolerance: 100,
+        slippage_policy_version: 1,
+        last_rebalance: 0,
+        total_value: {
+            let mut tv = 0i128;
+            for (asset, bal) in balances.iter() {
+                if let Some(p) = prices.get(asset) {
+                    tv = tv.saturating_add(
+                        bal.saturating_mul(p)
+                            .checked_div(10i128.pow(14))
+                            .unwrap_or(0),
+                    );
+                }
+            }
+            tv
+        },
+        is_active: true,
+        pause_reason: PauseReason::None,
+    };
+
+    // Must never panic for any input
+    let trades = calculate_rebalance_trades(&env, &portfolio, &prices);
+
+    // Every trade that makes it through must be above the minimum size
+    for (_, amount) in trades.iter() {
+        assert!(
+            amount.abs() > MIN_TRADE_AMOUNT_STROOPS,
+            "trade below minimum slipped through: {amount}"
+        );
+    }
+});


### PR DESCRIPTION
Closes #1030 

## Summary
Adds cargo-fuzz support for the contract crate and introduces fuzz targets for:
- rebalance math and trade selection
- oracle price edge cases
- allocation validation

Also fixes the contract library entrypoint so the fuzz crate builds cleanly.

## What changed
- Restored the contract root in `contracts/src/lib.rs`
- Added missing contract types needed by the fuzz and contract code in `contracts/src/types.rs`
- Made the contract crate available as a normal library in `contracts/Cargo.toml`
- Added fuzz targets under `contracts/fuzz/`
- Cleaned up a small unused import in `contracts/src/portfolio.rs`

## Verification
- `cargo +nightly fuzz build fuzz_rebalance`
- `cargo +nightly fuzz build fuzz_oracle_prices`
- `cargo +nightly fuzz build fuzz_allocations`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fuzz testing support for portfolio rebalancing, allocation validation, and price conversion paths.

* **Bug Fixes**
  * Improved resilience around edge cases such as empty inputs, zero prices, and very small trade amounts.
  * Expanded library packaging to support broader Rust tooling and test workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->