### PR TITLE
feat: implement OpenTelemetry tracing, rate limiting, BullMQ jobs, an…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -270,6 +270,14 @@ CONSENT_AUDIT_RETENTION_DAYS=365
 READINESS_CACHE_TTL_MS=2000
 
 # --- Observability ---
+# Enable OpenTelemetry tracing | boolean | # Optional (default: false)
+OTEL_ENABLED=false
+# OTLP collector endpoint for traces | URL | # Optional (default: http://localhost:4318/v1/traces)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+# OpenTelemetry service name | string | # Optional (default: stellar-portfolio-backend)
+OTEL_SERVICE_NAME=stellar-portfolio-backend
+# Enable Swagger API documentation UI | boolean | # Optional (default: true in dev, false in prod)
+ENABLE_API_DOCS=true
 # Enable backend Sentry integration | boolean | # Optional (default: false)
 SENTRY_ENABLED=false
 # Sentry DSN for error reporting | URL | # Optional (default: empty)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "info": {
     "title": "Stellar Portfolio Rebalancer API",
     "description": "Intelligent portfolio rebalancing service for the Stellar ecosystem using Reflector oracles. Create portfolios, fetch prices, execute rebalances, and manage risk.",
@@ -391,6 +391,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "ValidationError": {
+                    "$ref": "#/components/examples/ValidationError"
+                  }
                 }
               }
             }
@@ -770,6 +775,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "ValidationError": {
+                    "$ref": "#/components/examples/ValidationError"
+                  }
                 }
               }
             }
@@ -922,6 +932,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "ValidationError": {
+                    "$ref": "#/components/examples/ValidationError"
+                  }
                 }
               }
             }
@@ -2200,6 +2215,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "ValidationError": {
+                    "$ref": "#/components/examples/ValidationError"
+                  }
                 }
               }
             }
@@ -2251,6 +2271,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "QueryValidationError": {
+                    "$ref": "#/components/examples/QueryValidationError"
+                  }
                 }
               }
             }
@@ -2302,6 +2327,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "QueryValidationError": {
+                    "$ref": "#/components/examples/QueryValidationError"
+                  }
                 }
               }
             }
@@ -2420,12 +2450,127 @@
         "description": "Admin API key or bearer token"
       }
     },
+    "examples": {
+      "ValidationError": {
+        "summary": "Validation error",
+        "value": {
+          "success": false,
+          "data": null,
+          "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Invalid request payload",
+            "details": [
+              {
+                "field": "allocations",
+                "message": "Allocations must sum to 100%"
+              }
+            ]
+          },
+          "timestamp": "2025-01-01T00:00:00.000Z"
+        }
+      },
+      "QueryValidationError": {
+        "summary": "Query parameter validation error",
+        "value": {
+          "success": false,
+          "data": null,
+          "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Invalid query parameters",
+            "details": [
+              {
+                "field": "limit",
+                "message": "Number must be less than or equal to 500"
+              }
+            ]
+          },
+          "timestamp": "2025-01-01T00:00:00.000Z"
+        }
+      }
+    },
     "schemas": {
       "ApiEnvelope": {
-        "type": "object"
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "data": {
+            "nullable": true
+          },
+          "error": {
+            "nullable": true,
+            "$ref": "#/components/schemas/ApiErrorBody"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "meta": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "ApiErrorBody": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "example": "VALIDATION_ERROR"
+          },
+          "message": {
+            "type": "string",
+            "example": "Invalid request payload"
+          },
+          "details": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object"
+              }
+            ]
+          }
+        }
       },
       "ApiError": {
-        "type": "object"
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "data": {
+            "nullable": true,
+            "example": null
+          },
+          "error": {
+            "$ref": "#/components/schemas/ApiErrorBody"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
       },
       "Portfolio": {
         "type": "object"
@@ -2493,6 +2638,15 @@
           },
           "events": {
             "$ref": "#/components/schemas/NotificationEventsInput"
+          },
+          "digestMode": {
+            "type": "string",
+            "enum": [
+              "immediate",
+              "daily",
+              "weekly"
+            ],
+            "description": "Delivery mode for notifications: immediate (per-event), daily digest, or weekly digest."
           }
         }
       }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,14 @@
             "name": "stellar-portfolio-backend",
             "version": "0.1.0",
             "dependencies": {
+                "@opentelemetry/api": "^1.9.1",
+                "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+                "@opentelemetry/instrumentation": "^0.219.0",
+                "@opentelemetry/instrumentation-express": "^0.67.0",
+                "@opentelemetry/instrumentation-http": "^0.219.0",
+                "@opentelemetry/resources": "^2.8.0",
+                "@opentelemetry/sdk-node": "^0.219.0",
+                "@opentelemetry/semantic-conventions": "^1.41.1",
                 "@sentry/node": "^9.14.0",
                 "@sentry/profiling-node": "^9.14.0",
                 "@stellar/stellar-sdk": "^12.0.1",
@@ -35,6 +43,7 @@
                 "@types/better-sqlite3": "^7.6.13",
                 "@types/cors": "^2.8.19",
                 "@types/express": "^4.17.23",
+                "@types/js-yaml": "^4.0.9",
                 "@types/jsonwebtoken": "^9.0.10",
                 "@types/node": "^20.19.39",
                 "@types/node-cron": "^3.0.11",
@@ -45,6 +54,7 @@
                 "@types/swagger-ui-express": "^4.1.8",
                 "@types/ws": "^8.18.1",
                 "@vitest/coverage-v8": "^4.0.18",
+                "js-yaml": "^5.2.0",
                 "openapi-typescript": "^7.8.0",
                 "supertest": "^6.3.3",
                 "tsx": "^4.1.4",
@@ -816,6 +826,28 @@
                 "npm": ">=6.0.0"
             }
         },
+        "node_modules/@newrelic/security-agent/node_modules/js-yaml": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
         "node_modules/@newrelic/security-agent/node_modules/uuid": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -852,15 +884,46 @@
             }
         },
         "node_modules/@opentelemetry/api-logs": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz",
+            "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api": "^1.3.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/configuration": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.219.0.tgz",
+            "integrity": "sha512-wXZUYv4ngu43nA4WEhuXNacm46LW+17LRM8nKyIhBzroRA24PBYjMnakwzR/w777nFUB5xlgsYTTeuXxumZM1Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "yaml": "^2.0.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.9.0"
+            }
+        },
+        "node_modules/@opentelemetry/configuration/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/context-async-hooks": {
@@ -897,6 +960,451 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.219.0.tgz",
+            "integrity": "sha512-7SvzDCIclHWAcCwZ1MTOLcwn4BVNPGI3QxS/DJraPNe1TTL+4TvUBq5zeQV8tsnYvtDN7wKW2qocVmaCP2l7sQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.14.3",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-transformer": "0.219.0",
+                "@opentelemetry/sdk-logs": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
+            "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-transformer": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
+            "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-logs": "0.219.0",
+                "@opentelemetry/sdk-metrics": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
+            "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.219.0.tgz",
+            "integrity": "sha512-mhl2HL6GmZI8b8PwPfqMws/5ovJfbRTxwc9Y5agVVHiQ+e5SL1btsFr/kJDgt7YCexDtsUn5HAreHQO9szFS0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-transformer": "0.219.0",
+                "@opentelemetry/sdk-logs": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
+            "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-transformer": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
+            "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-logs": "0.219.0",
+                "@opentelemetry/sdk-metrics": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
+            "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.219.0.tgz",
+            "integrity": "sha512-Ayw4Gf71PS9jhBVaYywa4WsajnqfDehMkTdVH3TSAVHqPcsAv/AhH/wTNRYNt99szeYr6Gbd/D6RjZD77wAxHg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-transformer": "0.219.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-logs": "0.219.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
+            "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-transformer": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
+            "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-logs": "0.219.0",
+                "@opentelemetry/sdk-metrics": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
+            "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.219.0.tgz",
+            "integrity": "sha512-6LaaSrPxK5L55bXevWajvOMxGOpNm0n12tG53TeZaUeNzXwLPg6d2KCC1zAlGsojan+xRG71mA4Qqs9K2VVrKQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.14.3",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.219.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-transformer": "0.219.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-metrics": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.219.0.tgz",
+            "integrity": "sha512-6CaDRbMVHZSDWzNXwrR8y/H4B/Z1eMNnkHiPQlTx3Ojz2OHY4X/aff/UC4P/3pHUQSuTfi3oh2UsPPZppw+Vrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-transformer": "0.219.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-metrics": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
+            "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-transformer": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
+            "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-logs": "0.219.0",
+                "@opentelemetry/sdk-metrics": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
+            "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
@@ -1032,21 +1540,418 @@
                 "@opentelemetry/api": ">=1.9.0 <1.10.0"
             }
         },
-        "node_modules/@opentelemetry/instrumentation": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+        "node_modules/@opentelemetry/exporter-prometheus": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.219.0.tgz",
+            "integrity": "sha512-TxOnJ85eWJY5JyOJsNMXiRTYlkDcOv0u3KbXEzWCc+tUS9sjL/BC6BcdxZ0B9r2OFVqsrZFXUzSD2sZUy42Ucw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@types/shimmer": "^1.2.0",
-                "import-in-the-middle": "^1.8.1",
-                "require-in-the-middle": "^7.1.1",
-                "semver": "^7.5.2",
-                "shimmer": "^1.2.1"
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-metrics": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.219.0.tgz",
+            "integrity": "sha512-BkDNv1UD6BscW19MxbAxVmSYSSFuyeqR6buV2/HTYqA7GrR0EbTFzqG6h86T3PtXmpdbsWjMGLDdjG2rikG27Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.14.3",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-transformer": "0.219.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
+            "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-transformer": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
+            "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-logs": "0.219.0",
+                "@opentelemetry/sdk-metrics": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
+            "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.219.0.tgz",
+            "integrity": "sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-transformer": "0.219.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
+            "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-transformer": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
+            "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-logs": "0.219.0",
+                "@opentelemetry/sdk-metrics": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
+            "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.219.0.tgz",
+            "integrity": "sha512-lF/LUBfhOFmxJa+SQsLN7ziV4MHa2pyKgOM6JNehSOfU+npjM4gwm9oIKEJrzrWcexMcqydiyoFy0XCb1Ql3wQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-transformer": "0.219.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
+            "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-transformer": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
+            "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-logs": "0.219.0",
+                "@opentelemetry/sdk-metrics": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
+            "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.8.0.tgz",
+            "integrity": "sha512-Mj84UkEa17BK2o903VTXW3wM8CrSZexGs4tRGVZVIMM9ni1T6TuGx5IrRfoWKAbshx42D5/kc7YV+axypLPYyA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.219.0.tgz",
+            "integrity": "sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "import-in-the-middle": "^3.0.0",
+                "require-in-the-middle": "^8.0.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
@@ -1061,6 +1966,38 @@
                 "@opentelemetry/core": "^1.8.0",
                 "@opentelemetry/instrumentation": "^0.57.1",
                 "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-amqplib/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-amqplib/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
@@ -1087,6 +2024,38 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-connect/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-connect/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-dataloader": {
             "version": "0.16.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.1.tgz",
@@ -1102,21 +2071,68 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
-        "node_modules/@opentelemetry/instrumentation-express": {
-            "version": "0.47.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.1.tgz",
-            "integrity": "sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==",
+        "node_modules/@opentelemetry/instrumentation-dataloader/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-dataloader/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-express": {
+            "version": "0.67.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.67.0.tgz",
+            "integrity": "sha512-1WTWX2YNZIV+jPmEqdf/Vd1gHMT92TKA/0pf/iIItWhV6+RhzhnUUW4kSWQn8L3qVcgWEzQ860/ZOwaIwayi8A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.219.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-express/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/instrumentation-fs": {
@@ -1127,6 +2143,38 @@
             "dependencies": {
                 "@opentelemetry/core": "^1.8.0",
                 "@opentelemetry/instrumentation": "^0.57.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-fs/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-fs/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
@@ -1150,6 +2198,38 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-generic-pool/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-generic-pool/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-graphql": {
             "version": "0.47.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.1.tgz",
@@ -1157,6 +2237,38 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/instrumentation": "^0.57.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-graphql/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-graphql/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
@@ -1182,17 +2294,30 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
-        "node_modules/@opentelemetry/instrumentation-http": {
+        "node_modules/@opentelemetry/instrumentation-hapi/node_modules/@opentelemetry/api-logs": {
             "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.2.tgz",
-            "integrity": "sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/instrumentation": "0.57.2",
-                "@opentelemetry/semantic-conventions": "1.28.0",
-                "forwarded-parse": "2.1.2",
-                "semver": "^7.5.2"
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-hapi/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
@@ -1201,13 +2326,37 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
-        "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+        "node_modules/@opentelemetry/instrumentation-http": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.219.0.tgz",
+            "integrity": "sha512-nNt1fqpyah/OKjNHdEOu8xLwISppRU2qJuF8aR+fCcftVwdFkPgtworBLA+TI1HU2iF508jcQBF2gerWczJAXg==",
             "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/instrumentation": "0.219.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0",
+                "forwarded-parse": "2.1.2"
+            },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/instrumentation-ioredis": {
@@ -1219,6 +2368,38 @@
                 "@opentelemetry/instrumentation": "^0.57.1",
                 "@opentelemetry/redis-common": "^0.36.2",
                 "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-ioredis/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-ioredis/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
@@ -1243,6 +2424,38 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-kafkajs/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-kafkajs/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-knex": {
             "version": "0.44.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.1.tgz",
@@ -1251,6 +2464,38 @@
             "dependencies": {
                 "@opentelemetry/instrumentation": "^0.57.1",
                 "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-knex/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-knex/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
@@ -1276,6 +2521,38 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-koa/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-koa/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
             "version": "0.44.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.1.tgz",
@@ -1283,6 +2560,38 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/instrumentation": "^0.57.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-lru-memoizer/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-lru-memoizer/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
@@ -1299,6 +2608,38 @@
             "dependencies": {
                 "@opentelemetry/instrumentation": "^0.57.1",
                 "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mongodb/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mongodb/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
@@ -1324,6 +2665,38 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-mongoose/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mongoose/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-mysql": {
             "version": "0.45.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.1.tgz",
@@ -1333,6 +2706,38 @@
                 "@opentelemetry/instrumentation": "^0.57.1",
                 "@opentelemetry/semantic-conventions": "^1.27.0",
                 "@types/mysql": "2.15.26"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mysql/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mysql/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
@@ -1358,6 +2763,38 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-mysql2/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mysql2/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-pg": {
             "version": "0.51.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.1.tgz",
@@ -1370,6 +2807,38 @@
                 "@opentelemetry/sql-common": "^0.40.1",
                 "@types/pg": "8.6.1",
                 "@types/pg-pool": "2.0.6"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
@@ -1406,6 +2875,38 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-tedious": {
             "version": "0.18.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.1.tgz",
@@ -1415,6 +2916,38 @@
                 "@opentelemetry/instrumentation": "^0.57.1",
                 "@opentelemetry/semantic-conventions": "^1.27.0",
                 "@types/tedious": "^4.0.14"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-tedious/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-tedious/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": ">=14"
@@ -1437,6 +2970,95 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.7.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-undici/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-undici/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation/node_modules/cjs-module-lexer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+            "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+            "license": "MIT"
+        },
+        "node_modules/@opentelemetry/instrumentation/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation/node_modules/import-in-the-middle": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.2.0.tgz",
+            "integrity": "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-import-attributes": "^1.9.5",
+                "cjs-module-lexer": "^2.2.0",
+                "module-details-from-path": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/@opentelemetry/instrumentation/node_modules/require-in-the-middle": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+            "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.5",
+                "module-details-from-path": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=9.3.0 || >=8.10.0 <9.0.0"
             }
         },
         "node_modules/@opentelemetry/otlp-exporter-base": {
@@ -1468,6 +3090,110 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.219.0.tgz",
+            "integrity": "sha512-iIk/s8QQu39zpTrRRmsW/Eg3SE2+Hg8tLWepr2FLRgmwUpNd0IpCTLJEHJ77hpt4hgIS8MAh44UYI4xQPZwWlw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.14.3",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-transformer": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
+            "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-transformer": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
+            "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-logs": "0.219.0",
+                "@opentelemetry/sdk-metrics": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
+            "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/otlp-transformer": {
@@ -1567,6 +3293,66 @@
                 "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
+        "node_modules/@opentelemetry/propagator-b3": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.8.0.tgz",
+            "integrity": "sha512-SazlvuSKi5533rPHTW2TwBwdMakhjZST4SYs0YauuvfGDkT13KbG1gJS75hV0uWVeevhtVP9sAIlaZLTHdSbMg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-jaeger": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.8.0.tgz",
+            "integrity": "sha512-Xnz9zZvvQzUw+9DrOn0MomR7BxFCkA2pcfXBQuHC28ndJpSbjLs7knzYb05kw5SyCjSsEWombkZMgGcJSk8JVg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
         "node_modules/@opentelemetry/redis-common": {
             "version": "0.36.2",
             "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
@@ -1577,28 +3363,34 @@
             }
         },
         "node_modules/@opentelemetry/resources": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+            "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/@opentelemetry/sdk-logs": {
@@ -1662,13 +3454,13 @@
             }
         },
         "node_modules/@opentelemetry/sdk-metrics": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
-            "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.8.0.tgz",
+            "integrity": "sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "2.6.1",
-                "@opentelemetry/resources": "2.6.1"
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0"
             },
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
@@ -1678,9 +3470,9 @@
             }
         },
         "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-            "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1692,13 +3484,174 @@
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
-        "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-            "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+        "node_modules/@opentelemetry/sdk-node": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.219.0.tgz",
+            "integrity": "sha512-NWLpWLEb8gV3+JBHYoIrktbM385wyHpRJoh3J/4Q52d4PR+AlPMNGJT3DzBUrDSUEVbKAXoHR+EDAPxtiNcj8g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "2.6.1",
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/configuration": "0.219.0",
+                "@opentelemetry/context-async-hooks": "2.8.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/exporter-logs-otlp-grpc": "0.219.0",
+                "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
+                "@opentelemetry/exporter-logs-otlp-proto": "0.219.0",
+                "@opentelemetry/exporter-metrics-otlp-grpc": "0.219.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.219.0",
+                "@opentelemetry/exporter-metrics-otlp-proto": "0.219.0",
+                "@opentelemetry/exporter-prometheus": "0.219.0",
+                "@opentelemetry/exporter-trace-otlp-grpc": "0.219.0",
+                "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
+                "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",
+                "@opentelemetry/exporter-zipkin": "2.8.0",
+                "@opentelemetry/instrumentation": "0.219.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.219.0",
+                "@opentelemetry/propagator-b3": "2.8.0",
+                "@opentelemetry/propagator-jaeger": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-logs": "0.219.0",
+                "@opentelemetry/sdk-metrics": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0",
+                "@opentelemetry/sdk-trace-node": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
+            "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.219.0.tgz",
+            "integrity": "sha512-6CaDRbMVHZSDWzNXwrR8y/H4B/Z1eMNnkHiPQlTx3Ojz2OHY4X/aff/UC4P/3pHUQSuTfi3oh2UsPPZppw+Vrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-transformer": "0.219.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-metrics": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.219.0.tgz",
+            "integrity": "sha512-DUS7XyIiEnoeccQUvuKy0G2/YqeKhpN8FVIrGbrLNIVMj10yeIFLRzRv0tibCI2kXXvlTTABVexGAk78wHk2ug==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.219.0",
+                "@opentelemetry/otlp-exporter-base": "0.219.0",
+                "@opentelemetry/otlp-transformer": "0.219.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-metrics": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
+            "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/otlp-transformer": "0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
+            "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/sdk-logs": "0.219.0",
+                "@opentelemetry/sdk-metrics": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
+            "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.219.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
@@ -1725,6 +3678,22 @@
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
+        "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
         "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
             "version": "1.28.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
@@ -1734,10 +3703,71 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@opentelemetry/sdk-trace-node": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.8.0.tgz",
+            "integrity": "sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/context-async-hooks": "2.8.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/context-async-hooks": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
+            "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
         "node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-            "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+            "version": "1.41.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+            "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
@@ -1784,6 +3814,38 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.8"
+            }
+        },
+        "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@prisma/prisma-fmt-wasm": {
@@ -1901,6 +3963,29 @@
             "engines": {
                 "node": ">=18.17.0",
                 "npm": ">=9.5.0"
+            }
+        },
+        "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@redocly/openapi-core/node_modules/minimatch": {
@@ -2365,6 +4450,108 @@
                 "@opentelemetry/semantic-conventions": "^1.34.0"
             }
         },
+        "node_modules/@sentry/node/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-express": {
+            "version": "0.47.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.1.tgz",
+            "integrity": "sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-http": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.2.tgz",
+            "integrity": "sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/instrumentation": "0.57.2",
+                "@opentelemetry/semantic-conventions": "1.28.0",
+                "forwarded-parse": "2.1.2",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@sentry/node/node_modules/@opentelemetry/resources": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@sentry/node/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@sentry/opentelemetry": {
             "version": "9.47.1",
             "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.47.1.tgz",
@@ -2557,6 +4744,13 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
             "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/js-yaml": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+            "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
             "dev": true,
             "license": "MIT"
         },
@@ -4798,9 +6992,10 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
+            "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -4816,7 +7011,7 @@
                 "argparse": "^2.0.1"
             },
             "bin": {
-                "js-yaml": "bin/js-yaml.js"
+                "js-yaml": "bin/js-yaml.mjs"
             }
         },
         "node_modules/json-bigint": {
@@ -7463,6 +9658,21 @@
             "license": "ISC",
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yaml-ast-parser": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,16 +3,15 @@
     "version": "0.1.0",
     "type": "module",
     "scripts": {
-        "dev": "tsx watch --import ./src/observability/apm-register.ts src/index.ts",
+        "dev": "tsx watch --import ./src/observability/register-tracing.ts --import ./src/observability/apm-register.ts src/index.ts",
         "build": "tsc",
-        "start": "node --import ./dist/observability/apm-register.js dist/index.js",
+        "start": "node --import ./dist/observability/register-tracing.js --import ./dist/observability/apm-register.js dist/index.js",
         "db:migrate": "tsx src/db/migrate.ts",
         "db:migrate:dry-run": "tsx src/db/migrate.ts -- --dry-run",
         "db:migrate:rollback": "tsx src/db/migrate.ts -- --rollback",
         "db:migrate:status": "tsx src/db/migrate.ts -- --status",
         "db:setup": "tsx src/db/migrate.ts",
         "db:seed:e2e": "tsx src/db/seed.e2e.ts",
-
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
         "test:ci": "npm run test:coverage",
@@ -31,6 +30,14 @@
         "indexer:reindex": "tsx scripts/reindex-events.ts"
     },
     "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/instrumentation-express": "^0.67.0",
+        "@opentelemetry/instrumentation-http": "^0.219.0",
+        "@opentelemetry/resources": "^2.8.0",
+        "@opentelemetry/sdk-node": "^0.219.0",
+        "@opentelemetry/semantic-conventions": "^1.41.1",
         "@sentry/node": "^9.14.0",
         "@sentry/profiling-node": "^9.14.0",
         "@stellar/stellar-sdk": "^12.0.1",
@@ -58,6 +65,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.23",
+        "@types/js-yaml": "^4.0.9",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.19.39",
         "@types/node-cron": "^3.0.11",
@@ -68,10 +76,11 @@
         "@types/swagger-ui-express": "^4.1.8",
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^4.0.18",
+        "js-yaml": "^5.2.0",
+        "openapi-typescript": "^7.8.0",
         "supertest": "^6.3.3",
         "tsx": "^4.1.4",
         "typescript": "^5.9.3",
-        "vitest": "^4.0.18",
-        "openapi-typescript": "^7.8.0"
+        "vitest": "^4.0.18"
     }
 }

--- a/backend/src/api/ops.routes.ts
+++ b/backend/src/api/ops.routes.ts
@@ -14,6 +14,7 @@ import { getPortfolioCheckWorkerStatus } from '../queue/workers/portfolioCheckWo
 import { getRebalanceWorkerStatus } from '../queue/workers/rebalanceWorker.js'
 import { getAnalyticsSnapshotWorkerStatus } from '../queue/workers/analyticsSnapshotWorker.js'
 import { getPortfolioExportWorkerStatus } from '../queue/workers/portfolioExportWorker.js'
+import { getQueueByName } from '../queue/queues.js'
 import { REBALANCE_STRATEGIES } from '../services/rebalancingStrategyService.js'
 import { logger } from '../utils/logger.js'
 import { getErrorObject, getErrorMessage } from '../utils/helpers.js'
@@ -191,6 +192,58 @@ opsRouter.get('/indexer/cursor', (_req: Request, res: Response) => {
             ...cursorInfo
         })
     } catch (error) {
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
+// ================================
+// JOB STATUS ROUTE
+// ================================
+
+opsRouter.get('/jobs/:id', async (req: Request, res: Response) => {
+    try {
+        const jobId = req.params.id
+        if (!jobId) {
+            return fail(res, 400, 'VALIDATION_ERROR', 'Job ID is required')
+        }
+
+        const queueNames = [
+            'portfolio-check',
+            'rebalance',
+            'analytics-snapshot',
+            'analytics-compaction',
+            'idempotency-cleanup',
+            'portfolio-export',
+            'price-history-snapshot',
+            'price-history-prune',
+        ]
+
+        for (const name of queueNames) {
+            const queue = getQueueByName(name)
+            if (!queue) continue
+            const job = await queue.getJob(jobId)
+            if (job) {
+                const state = await job.getState()
+                return ok(res, {
+                    jobId: job.id,
+                    queue: name,
+                    name: job.name,
+                    state,
+                    data: job.data,
+                    progress: job.progress,
+                    attemptsMade: job.attemptsMade,
+                    createdAt: job.timestamp ? new Date(job.timestamp).toISOString() : null,
+                    processedAt: job.processedOn ? new Date(job.processedOn).toISOString() : null,
+                    finishedAt: job.finishedOn ? new Date(job.finishedOn).toISOString() : null,
+                    failedReason: job.failedReason || null,
+                    returnValue: state === 'completed' ? job.returnvalue : null,
+                })
+            }
+        }
+
+        return fail(res, 404, 'NOT_FOUND', 'Job not found')
+    } catch (error) {
+        logger.error('[ERROR] Job status check failed', { error: getErrorObject(error) })
         return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
     }
 })

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -98,6 +98,11 @@ export async function main(argv: string[] = process.argv): Promise<void> {
 
     app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(spec as Record<string, unknown>))
 
+    const enableApiDocs = process.env.ENABLE_API_DOCS || (config.nodeEnv !== 'production' ? 'true' : 'false')
+    if (enableApiDocs === 'true') {
+        app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(spec as Record<string, unknown>))
+    }
+
     const serveOpenApiJson = (_req: Request, res: Response) => {
         res.setHeader('Content-Type', 'application/json')
         res.json(spec)

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -7,8 +7,8 @@ import { logger } from "../utils/logger.js";
 import { rateLimitMonitor } from "../services/rateLimitMonitor.js";
 import { REDIS_URL, getCachedRedisAvailability } from "../queue/connection.js";
 
-const GLOBAL_WINDOW_MS = parseInt(process.env.RATE_LIMIT_GLOBAL_WINDOW_MS || "", 10) || 15 * 60 * 1000;
-const GLOBAL_MAX = parseInt(process.env.RATE_LIMIT_GLOBAL_MAX || "", 10) || 100;
+const GLOBAL_WINDOW_MS = parseInt(process.env.RATE_LIMIT_WINDOW_MS || process.env.RATE_LIMIT_GLOBAL_WINDOW_MS || "", 10) || 15 * 60 * 1000;
+const GLOBAL_MAX = parseInt(process.env.RATE_LIMIT_MAX || process.env.RATE_LIMIT_GLOBAL_MAX || "", 10) || 100;
 const WRITE_MAX = parseInt(process.env.RATE_LIMIT_WRITE_MAX || "", 10) || 20;
 const AUTH_MAX = parseInt(process.env.RATE_LIMIT_AUTH_MAX || "", 10) || 10;
 const CRITICAL_MAX = parseInt(process.env.RATE_LIMIT_CRITICAL_MAX || "", 10) || 5;

--- a/backend/src/middleware/requestContext.ts
+++ b/backend/src/middleware/requestContext.ts
@@ -2,6 +2,7 @@ import type { Request, Response, NextFunction } from 'express'
 import { randomUUID } from 'node:crypto'
 import { logger } from '../utils/logger.js'
 import { runWithRequestContext } from '../utils/requestContext.js'
+import { getTraceId, getSpanId } from '../observability/tracing.js'
 
 const getHeaderValue = (value: string | string[] | undefined): string | undefined =>
     Array.isArray(value) ? value[0] : value
@@ -9,21 +10,29 @@ const getHeaderValue = (value: string | string[] | undefined): string | undefine
 export const requestContextMiddleware = (req: Request, res: Response, next: NextFunction): void => {
     const inboundId = getHeaderValue(req.headers['x-request-id'])
     const inboundCorrelationId = getHeaderValue(req.headers['x-correlation-id'])
+    const inboundTraceId = getHeaderValue(req.headers['x-trace-id']) || getHeaderValue(req.headers['traceparent'])
     const requestId = inboundId && inboundId.trim().length > 0 ? inboundId.trim() : randomUUID()
     const correlationId = inboundCorrelationId && inboundCorrelationId.trim().length > 0
         ? inboundCorrelationId.trim()
         : requestId
+    const otelTraceId = getTraceId() || (inboundTraceId ? inboundTraceId.trim().split('-')[1] || inboundTraceId.trim() : undefined)
+    const otelSpanId = getSpanId()
 
     req.requestId = requestId
     res.setHeader('X-Request-Id', requestId)
     res.setHeader('X-Correlation-Id', correlationId)
+    if (otelTraceId) {
+        res.setHeader('X-Trace-Id', otelTraceId)
+    }
 
     const start = process.hrtime.bigint()
 
-    runWithRequestContext({ requestId, correlationId }, () => {
+    runWithRequestContext({ requestId, correlationId, traceId: otelTraceId, spanId: otelSpanId }, () => {
         logger.info('http_request_start', {
             requestId,
             correlation_id: correlationId,
+            trace_id: otelTraceId,
+            span_id: otelSpanId,
             method: req.method,
             path: req.originalUrl,
             ip: req.ip,
@@ -35,6 +44,8 @@ export const requestContextMiddleware = (req: Request, res: Response, next: Next
             logger.info('http_request_end', {
                 requestId,
                 correlation_id: correlationId,
+                trace_id: otelTraceId,
+                span_id: otelSpanId,
                 method: req.method,
                 path: req.originalUrl,
                 statusCode: res.statusCode,

--- a/backend/src/observability/register-tracing.ts
+++ b/backend/src/observability/register-tracing.ts
@@ -1,0 +1,5 @@
+import { initTracing } from "./tracing.js";
+
+initTracing();
+
+export {};

--- a/backend/src/observability/tracing.ts
+++ b/backend/src/observability/tracing.ts
@@ -1,0 +1,72 @@
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
+import { ExpressInstrumentation } from "@opentelemetry/instrumentation-express";
+import { Resource } from "@opentelemetry/resources";
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
+import { trace } from "@opentelemetry/api";
+
+function parseBoolean(value: string | undefined, fallback = false): boolean {
+  if (value == null || value.trim() === "") return fallback;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "true" || normalized === "1" || normalized === "yes";
+}
+
+const OTLP_ENDPOINT = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://localhost:4318/v1/traces";
+const OTEL_ENABLED = parseBoolean(process.env.OTEL_ENABLED, false);
+
+let sdk: NodeSDK | null = null;
+
+export function initTracing(): void {
+  if (!OTEL_ENABLED) return;
+
+  const exporter = new OTLPTraceExporter({
+    url: OTLP_ENDPOINT,
+  });
+
+  sdk = new NodeSDK({
+    resource: new Resource({
+      [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME || "stellar-portfolio-backend",
+      [ATTR_SERVICE_VERSION]: process.env.npm_package_version || "1.0.0",
+      "deployment.environment": process.env.NODE_ENV || "development",
+    }),
+    traceExporter: exporter,
+    instrumentations: [
+      new HttpInstrumentation({
+        ignoreIncomingPaths: ["/health", "/ready", "/readiness", "/metrics"],
+      }),
+      new ExpressInstrumentation(),
+    ],
+    spanProcessors: [],
+  });
+
+  sdk.start();
+  console.log("[OTEL] Tracing enabled, exporting to " + OTLP_ENDPOINT);
+}
+
+export async function shutdownTracing(): Promise<void> {
+  if (sdk) {
+    await sdk.shutdown();
+    sdk = null;
+  }
+}
+
+export function getTracer(name?: string) {
+  return trace.getTracer(name || "stellar-portfolio-backend", "1.0.0");
+}
+
+export function getActiveSpan() {
+  return trace.getActiveSpan();
+}
+
+export function getTraceId(): string | undefined {
+  const span = trace.getActiveSpan();
+  if (!span) return undefined;
+  return span.spanContext().traceId;
+}
+
+export function getSpanId(): string | undefined {
+  const span = trace.getActiveSpan();
+  if (!span) return undefined;
+  return span.spanContext().spanId;
+}

--- a/backend/src/openapi/spec.ts
+++ b/backend/src/openapi/spec.ts
@@ -4,7 +4,7 @@
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const spec: Record<string, any> = {
-    openapi: '3.0.3',
+    openapi: '3.1.0',
     info: {
         title: 'Stellar Portfolio Rebalancer API',
         description: 'Intelligent portfolio rebalancing service for the Stellar ecosystem using Reflector oracles. Create portfolios, fetch prices, execute rebalances, and manage risk.',

--- a/backend/src/queue/queues.ts
+++ b/backend/src/queue/queues.ts
@@ -86,10 +86,10 @@ function getDefaultJobOptions() {
   return {
     removeOnComplete: { count: 100 },
     removeOnFail: { count: 200 },
-    attempts: 5,
+    attempts: 3,
     backoff: {
       type: "exponential" as const,
-      delay: 5000, // 5s → 10s → 20s → 40s → 80s
+      delay: 5000,
     },
   };
 }

--- a/backend/src/queue/workers/rebalanceWorker.ts
+++ b/backend/src/queue/workers/rebalanceWorker.ts
@@ -12,9 +12,35 @@ import {
   type WorkerRuntimeStatus,
 } from "./workerRuntime.js";
 import { randomUUID } from "node:crypto";
+import { broadcastPortfolioEvent } from "../../services/websocket.service.js";
 
 let worker: Worker | null = null;
 const runtimeStatus = createWorkerRuntimeStatus("rebalance", 3);
+
+function broadcastJobCompletion(jobId: string, portfolioId: string, triggeredBy: string | undefined, data: Record<string, unknown>) {
+  broadcastPortfolioEvent({
+    portfolioId,
+    event: "rebalance_completed",
+    data: {
+      jobId,
+      triggeredBy: triggeredBy || "unknown",
+      ...data,
+    },
+  });
+}
+
+function broadcastJobFailure(jobId: string, portfolioId: string, triggeredBy: string | undefined, error: string, attemptsMade: number) {
+  broadcastPortfolioEvent({
+    portfolioId,
+    event: "rebalance_failed",
+    data: {
+      jobId,
+      triggeredBy: triggeredBy || "unknown",
+      error,
+      attemptsMade,
+    },
+  });
+}
 
 /**
  * Core processor: executes a single portfolio rebalance.
@@ -86,6 +112,11 @@ export async function processRebalanceJob(
         portfolioId,
         trades: rebalanceResult.trades,
       });
+      broadcastJobCompletion(job.id || "unknown", portfolioId, triggeredBy, {
+        trades: rebalanceResult.trades ?? 0,
+        gasUsed: rebalanceResult.gasUsed ?? "0 XLM",
+        timestamp: new Date().toISOString(),
+      });
       if (triggeredBy === "auto") {
         logAudit("auto_rebalance_completed", {
           portfolioId,
@@ -118,6 +149,7 @@ export async function processRebalanceJob(
         error: errorMessage,
         attemptsMade: job.attemptsMade,
       });
+      broadcastJobFailure(job.id || "unknown", portfolioId, triggeredBy, errorMessage, job.attemptsMade);
       if (triggeredBy === "auto") {
         logAudit("auto_rebalance_failed", {
           portfolioId,
@@ -168,9 +200,13 @@ export function startRebalanceWorker(): Worker | null {
     });
 
   worker.on("completed", (j: Job) => {
+    markWorkerJobCompleted(runtimeStatus);
     logger.info("[WORKER:rebalance] Job completed", {
       jobId: j.id,
       portfolioId: j.data.portfolioId,
+    });
+    broadcastJobCompletion(j.id || "unknown", j.data.portfolioId, j.data.triggeredBy, {
+      timestamp: new Date().toISOString(),
     });
   });
 

--- a/backend/src/queue/workers/workerRuntime.ts
+++ b/backend/src/queue/workers/workerRuntime.ts
@@ -114,7 +114,7 @@ export function snapshotWorkerRuntimeStatus(status: WorkerRuntimeStatus): Worker
 }
 
 export async function handleFinalFailure(job: Job, error: unknown): Promise<void> {
-    const maxAttempts = job.opts.attempts || 5;
+    const maxAttempts = job.opts.attempts || 3;
     if (job.attemptsMade < maxAttempts) {
         return;
     }

--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -1,5 +1,10 @@
 import Database from 'better-sqlite3'
 import { randomUUID } from 'node:crypto'
+import { trace } from '@opentelemetry/api'
+
+function getTracer() {
+  return trace.getTracer('stellar-service', '1.0.0')
+}
 
 export interface ExecuteRebalanceOptions {
     simulateOnly?: boolean
@@ -34,53 +39,85 @@ export class StellarService {
     }
 
     async getPortfolio(portfolioId: string): Promise<any> {
-        const row = this.db.prepare('SELECT * FROM portfolios WHERE id = ?').get(portfolioId) as any
-        if (!row) return null
-        return {
-            id: row.id,
-            userAddress: row.user_address,
-            allocations: JSON.parse(row.allocations || '{}'),
-            threshold: row.threshold,
-            slippageTolerancePercent: row.slippage_tolerance_percent,
-            balances: JSON.parse(row.balances || '{}'),
-            totalValue: row.total_value,
-            createdAt: row.created_at,
-            lastRebalance: row.last_rebalance,
-            version: row.version,
+        const span = getTracer().startSpan('stellar.getPortfolio')
+        span.setAttribute('portfolio.id', portfolioId)
+        try {
+            const row = this.db.prepare('SELECT * FROM portfolios WHERE id = ?').get(portfolioId) as any
+            if (!row) {
+                span.setAttribute('portfolio.found', false)
+                return null
+            }
+            span.setAttribute('portfolio.found', true)
+            return {
+                id: row.id,
+                userAddress: row.user_address,
+                allocations: JSON.parse(row.allocations || '{}'),
+                threshold: row.threshold,
+                slippageTolerancePercent: row.slippage_tolerance_percent,
+                balances: JSON.parse(row.balances || '{}'),
+                totalValue: row.total_value,
+                createdAt: row.created_at,
+                lastRebalance: row.last_rebalance,
+                version: row.version,
+            }
+        } finally {
+            span.end()
         }
     }
 
     async checkRebalanceNeeded(portfolioId: string): Promise<boolean> {
-        return true
+        const span = getTracer().startSpan('stellar.checkRebalanceNeeded')
+        span.setAttribute('portfolio.id', portfolioId)
+        try {
+            return true
+        } finally {
+            span.end()
+        }
     }
 
     async executeRebalance(portfolioId: string, options?: ExecuteRebalanceOptions): Promise<any> {
-        return {
-            trades: 0,
-            gasUsed: '0 XLM',
-            timestamp: new Date().toISOString(),
-            status: 'success',
-            newBalances: {},
+        const span = getTracer().startSpan('stellar.executeRebalance')
+        span.setAttribute('portfolio.id', portfolioId)
+        if (options) {
+            span.setAttribute('rebalance.simulate_only', options.simulateOnly || false)
+            span.setAttribute('rebalance.ignore_safety_checks', options.ignoreSafetyChecks || false)
+        }
+        try {
+            return {
+                trades: 0,
+                gasUsed: '0 XLM',
+                timestamp: new Date().toISOString(),
+                status: 'success',
+                newBalances: {},
+            }
+        } finally {
+            span.end()
         }
     }
 
     async dryRunRebalance(portfolioId: string, options?: ExecuteRebalanceOptions): Promise<RebalanceDryRunResult> {
-        return {
-            portfolioId,
-            canExecute: true,
-            overallStatus: 'ready',
-            trigger: 'Threshold exceeded',
-            estimatedTrades: [],
-            skippedTrades: [],
-            skippedAssets: [],
-            guardrails: {
-                riskManagement: { allowed: true, reason: 'OK' },
-                cooldown: { allowed: true, reason: 'OK' },
-                marketConditions: { allowed: true, reason: 'OK' },
-                rebalanceRequired: { allowed: true, reason: 'OK' },
-            },
-            feeEstimate: { totalFeeXlm: 0, totalFeeUsd: 0, xlmPriceUsd: 0.35 },
-            estimatedTotalSlippageBps: 0,
+        const span = getTracer().startSpan('stellar.dryRunRebalance')
+        span.setAttribute('portfolio.id', portfolioId)
+        try {
+            return {
+                portfolioId,
+                canExecute: true,
+                overallStatus: 'ready',
+                trigger: 'Threshold exceeded',
+                estimatedTrades: [],
+                skippedTrades: [],
+                skippedAssets: [],
+                guardrails: {
+                    riskManagement: { allowed: true, reason: 'OK' },
+                    cooldown: { allowed: true, reason: 'OK' },
+                    marketConditions: { allowed: true, reason: 'OK' },
+                    rebalanceRequired: { allowed: true, reason: 'OK' },
+                },
+                feeEstimate: { totalFeeXlm: 0, totalFeeUsd: 0, xlmPriceUsd: 0.35 },
+                estimatedTotalSlippageBps: 0,
+            }
+        } finally {
+            span.end()
         }
     }
 
@@ -94,16 +131,31 @@ export class StellarService {
         name?: string,
         description?: string,
     ): Promise<string> {
-        const id = randomUUID()
-        const now = new Date().toISOString()
-        this.db.prepare(`
-            INSERT INTO portfolios (id, user_address, allocations, threshold, slippage_tolerance_percent, balances, total_value, created_at, last_rebalance, version, name, description)
-            VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, 1, ?, ?)
-        `).run(id, userAddress, JSON.stringify(allocations), threshold, slippageTolerancePercent, '{}', now, now, name ?? null, description ?? null)
-        return id
+        const span = getTracer().startSpan('stellar.createPortfolio')
+        span.setAttribute('user.address', userAddress)
+        span.setAttribute('portfolio.threshold', threshold)
+        span.setAttribute('portfolio.strategy', strategy)
+        try {
+            const id = randomUUID()
+            const now = new Date().toISOString()
+            this.db.prepare(`
+                INSERT INTO portfolios (id, user_address, allocations, threshold, slippage_tolerance_percent, balances, total_value, created_at, last_rebalance, version, name, description)
+                VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, 1, ?, ?)
+            `).run(id, userAddress, JSON.stringify(allocations), threshold, slippageTolerancePercent, '{}', now, now, name ?? null, description ?? null)
+            span.setAttribute('portfolio.id', id)
+            return id
+        } finally {
+            span.end()
+        }
     }
 
     async estimateRebalanceGas(portfolioId: string): Promise<{ estimatedGasXlm: string; estimatedGasUsd: string }> {
-        return { estimatedGasXlm: '0', estimatedGasUsd: '0' }
+        const span = getTracer().startSpan('stellar.estimateRebalanceGas')
+        span.setAttribute('portfolio.id', portfolioId)
+        try {
+            return { estimatedGasXlm: '0', estimatedGasUsd: '0' }
+        } finally {
+            span.end()
+        }
     }
 }

--- a/backend/src/utils/apiResponse.ts
+++ b/backend/src/utils/apiResponse.ts
@@ -1,4 +1,5 @@
 import type { Response } from 'express'
+import { getRequestId, getCorrelationId, getTraceId } from './requestContext.js'
 
 export interface ApiErrorBody {
     code: string
@@ -45,6 +46,9 @@ export function fail(
     details?: unknown,
     options: ResponseOptions = {}
 ): Response<ApiResponseEnvelope<null>> {
+    const requestId = getRequestId()
+    const correlationId = getCorrelationId()
+    const traceId = getTraceId()
     const payload: ApiResponseEnvelope<null> = {
         success: false,
         data: null,
@@ -56,6 +60,10 @@ export function fail(
         timestamp: nowIso(),
         ...(options.meta ? { meta: options.meta } : {})
     }
+
+    if (requestId) res.setHeader('X-Request-Id', requestId)
+    if (correlationId) res.setHeader('X-Correlation-Id', correlationId)
+    if (traceId) res.setHeader('X-Trace-Id', traceId)
 
     return res.status(status).json(payload)
 }

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,6 +1,7 @@
 import pino from 'pino'
 import { redactArgs } from './secretRedactor.js'
-import { getRequestId, getCorrelationId } from './requestContext.js'
+import { getRequestId, getCorrelationId, getTraceId, getSpanId } from './requestContext.js'
+import { getTraceId as getOtelTraceId, getSpanId as getOtelSpanId } from '../observability/tracing.js'
 
 const isProduction = process.env.NODE_ENV === 'production'
 
@@ -17,9 +18,15 @@ const baseLogger = pino({
     mixin() {
         const requestId = getRequestId()
         const correlationId = getCorrelationId()
+        const ctxTraceId = getTraceId()
+        const ctxSpanId = getSpanId()
+        const otelTraceId = getOtelTraceId()
+        const otelSpanId = getOtelSpanId()
         const fields: Record<string, string> = {}
         if (requestId) fields.requestId = requestId
         if (correlationId) fields.correlation_id = correlationId
+        if (ctxTraceId || otelTraceId) fields.trace_id = ctxTraceId || otelTraceId
+        if (ctxSpanId || otelSpanId) fields.span_id = ctxSpanId || otelSpanId
         return fields
     },
     hooks: {

--- a/backend/src/utils/requestContext.ts
+++ b/backend/src/utils/requestContext.ts
@@ -3,6 +3,8 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 export interface RequestContext {
     requestId?: string
     correlationId?: string
+    traceId?: string
+    spanId?: string
 }
 
 const requestContextStorage = new AsyncLocalStorage<RequestContext>()
@@ -18,3 +20,9 @@ export const getRequestId = (): string | undefined =>
 
 export const getCorrelationId = (): string | undefined =>
     requestContextStorage.getStore()?.correlationId
+
+export const getTraceId = (): string | undefined =>
+    requestContextStorage.getStore()?.traceId
+
+export const getSpanId = (): string | undefined =>
+    requestContextStorage.getStore()?.spanId

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -283,6 +283,29 @@ services:
           cpus: '0.25'
           memory: 64M
 
+  # Jaeger — OpenTelemetry trace collector and UI.
+  # Start with: docker compose --profile observability up
+  # Access Jaeger UI at http://localhost:16686
+  # OTLP HTTP endpoint at http://localhost:4318 for backend tracing.
+  jaeger:
+    image: jaegertracing/all-in-one:1.62.0
+    container_name: portfolio-jaeger
+    restart: unless-stopped
+    profiles:
+      - observability
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - COLLECTOR_OTLP_HTTP_PORT=4318
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+
   # Self-hosted Umami analytics — privacy-respecting, cookie-free.
   # Start with: docker compose --profile analytics up
   # Access dashboard at http://localhost:3004 (default login: admin / umami)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,1587 @@
+openapi: 3.1.0
+info:
+  title: Stellar Portfolio Rebalancer API
+  description: Intelligent portfolio rebalancing service for the Stellar ecosystem using Reflector oracles. Create portfolios, fetch prices, execute rebalances, and manage risk.
+  version: 1.0.0
+  contact:
+    name: API Support
+    url: https://github.com/your-username/stellar-portfolio-rebalancer
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+servers:
+  - url: http://localhost:3000
+    description: Development
+  - url: /
+    description: Current host
+tags:
+  - name: Health
+    description: Health and root
+  - name: Portfolio
+    description: Portfolio CRUD and rebalancing
+  - name: Rebalance history
+    description: Rebalance event history
+  - name: Risk
+    description: Risk metrics and checks
+  - name: Prices & market
+    description: Price feeds and market data
+  - name: Auto-rebalancer
+    description: Automatic rebalancing service
+  - name: System
+    description: System status
+  - name: Notifications
+    description: Notification preferences
+  - name: Queue
+    description: BullMQ queue health
+  - name: Debug
+    description: Debug endpoints (when enabled)
+paths:
+  /:
+    get:
+      tags:
+        - Health
+      summary: Root
+      description: API info and feature flags.
+      responses:
+        '200':
+          description: API info
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Stellar Portfolio Rebalancer API
+                  status:
+                    type: string
+                    example: running
+                  version:
+                    type: string
+                    example: 1.0.0
+                  timestamp:
+                    type: string
+                    format: date-time
+                  features:
+                    type: object
+                  endpoints:
+                    type: object
+  /health:
+    get:
+      tags:
+        - Health
+      summary: Health check
+      description: Lightweight liveness probe for process-up checks.
+      responses:
+        '200':
+          description: Process is up
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  timestamp:
+                    type: string
+                    format: date-time
+                  uptimeSeconds:
+                    type: integer
+                    example: 42
+  /ready:
+    get:
+      tags:
+        - Health
+      summary: Readiness check
+      description: Deep readiness probe covering database, Redis/queues, workers, indexer, and auto-rebalancer startup.
+      responses:
+        '200':
+          description: System is ready to serve traffic
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ready
+                  timestamp:
+                    type: string
+                    format: date-time
+                  uptimeSeconds:
+                    type: integer
+                    example: 42
+                  checks:
+                    type: object
+        '503':
+          description: System is not ready to serve traffic
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: not_ready
+                  timestamp:
+                    type: string
+                    format: date-time
+                  uptimeSeconds:
+                    type: integer
+                    example: 42
+                  checks:
+                    type: object
+  /api/rebalance/history:
+    get:
+      tags:
+        - Rebalance history
+      summary: Get rebalance history
+      description: List rebalance events, optionally filtered by portfolio and source.
+      parameters:
+        - name: portfolioId
+          in: query
+          schema:
+            type: string
+          description: Filter by portfolio ID
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+          description: Max items
+        - name: source
+          in: query
+          schema:
+            type: string
+            enum:
+              - offchain
+              - simulated
+              - onchain
+        - name: startTimestamp
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: endTimestamp
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: syncOnChain
+          in: query
+          schema:
+            type: boolean
+          description: Sync on-chain indexer once before query
+      responses:
+        '200':
+          description: History list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+              example:
+                success: true
+                data:
+                  history: []
+                  portfolioId: null
+                  filters: {}
+                error: null
+                timestamp: '2025-01-01T00:00:00.000Z'
+                meta:
+                  count: 0
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    post:
+      tags:
+        - Rebalance history
+      summary: Record rebalance event
+      description: Record a new rebalance event (idempotent).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - portfolioId
+                - trigger
+                - trades
+                - gasUsed
+                - status
+              properties:
+                portfolioId:
+                  type: string
+                trigger:
+                  type: string
+                trades:
+                  type: integer
+                  minimum: 0
+                gasUsed:
+                  type: string
+                status:
+                  type: string
+                  enum:
+                    - completed
+                    - failed
+                    - pending
+                isAutomatic:
+                  type: boolean
+                eventSource:
+                  type: string
+                  enum:
+                    - offchain
+                    - simulated
+                    - onchain
+            example:
+              portfolioId: pf-123
+              trigger: manual
+              trades: 2
+              gasUsed: 0.05 XLM
+              status: completed
+              isAutomatic: false
+      responses:
+        '200':
+          description: Event recorded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/rebalance/history/sync-onchain:
+    post:
+      tags:
+        - Rebalance history
+      summary: Sync on-chain history
+      description: Trigger a one-time sync of on-chain rebalance events. Admin only.
+      security:
+        - adminAuth: []
+      responses:
+        '200':
+          description: Sync result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/rebalance/summary/{portfolioId}:
+    get:
+      tags:
+        - Rebalance history
+      summary: Get rebalance readiness summary
+      description: 'Single-call summary of all preconditions for manual rebalance: system readiness, drift, slippage, risk, and data freshness. Provides actionable guidance before execution.'
+      parameters:
+        - name: portfolioId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Portfolio ID to check
+      responses:
+        '200':
+          description: Readiness summary with all preconditions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      portfolioId:
+                        type: string
+                      timestamp:
+                        type: string
+                        format: date-time
+                      readiness:
+                        type: object
+                        properties:
+                          systemReady:
+                            type: boolean
+                          canExecute:
+                            type: boolean
+                          status:
+                            type: string
+                            enum:
+                              - ready
+                              - not_ready
+                          checks:
+                            type: object
+                      drift:
+                        type: object
+                        properties:
+                          needsRebalance:
+                            type: boolean
+                          maxDriftPercent:
+                            type: number
+                          threshold:
+                            type: number
+                          exceedsThreshold:
+                            type: boolean
+                      slippage:
+                        type: object
+                        properties:
+                          maxSlippagePercent:
+                            type: number
+                          estimatedSlippageBps:
+                            type: integer
+                      risk:
+                        type: object
+                        properties:
+                          allowed:
+                            type: boolean
+                          reasonCode:
+                            type: string
+                          overallRiskLevel:
+                            type: string
+                            enum:
+                              - low
+                              - medium
+                              - high
+                              - critical
+                          alerts:
+                            type: array
+                      dataFreshness:
+                        type: object
+                        properties:
+                          ageSeconds:
+                            type: integer
+                          isStale:
+                            type: boolean
+                          priceCount:
+                            type: integer
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+                  meta:
+                    type: object
+                    properties:
+                      canExecute:
+                        type: boolean
+                      needsRebalance:
+                        type: boolean
+                      riskLevel:
+                        type: string
+              example:
+                success: true
+                data:
+                  portfolioId: pf-123
+                  readiness:
+                    systemReady: true
+                    canExecute: true
+                    status: ready
+                  drift:
+                    needsRebalance: true
+                    maxDriftPercent: 6.2
+                    threshold: 5
+                    exceedsThreshold: true
+                  slippage:
+                    maxSlippagePercent: 1
+                    estimatedSlippageBps: 100
+                  risk:
+                    allowed: true
+                    reasonCode: OK
+                    overallRiskLevel: low
+                    alerts: []
+                  dataFreshness:
+                    ageSeconds: 45
+                    isStale: false
+                    priceCount: 4
+                meta:
+                  canExecute: true
+                  needsRebalance: true
+                  riskLevel: low
+        '404':
+          description: Portfolio not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/portfolio:
+    post:
+      tags:
+        - Portfolio
+      summary: Create portfolio
+      description: Create a new portfolio with target allocations and threshold. Allocations must sum to 100%.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - userAddress
+                - allocations
+                - threshold
+              properties:
+                userAddress:
+                  type: string
+                  description: Stellar account address
+                allocations:
+                  type: object
+                  additionalProperties:
+                    type: number
+                  description: 'Target weights per asset (e.g. { "XLM": 40, "BTC": 30, "USDC": 30 }), must sum to 100'
+                threshold:
+                  type: number
+                  minimum: 1
+                  maximum: 50
+                  description: Rebalance threshold %
+                slippageTolerance:
+                  type: number
+                  minimum: 0.1
+                  maximum: 5
+                  default: 1
+                  description: Slippage tolerance %
+            example:
+              userAddress: GABC...
+              allocations:
+                XLM: 40
+                BTC: 30
+                USDC: 30
+              threshold: 5
+              slippageTolerance: 1
+      responses:
+        '201':
+          description: Portfolio created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      portfolioId:
+                        type: string
+                      status:
+                        type: string
+                        example: created
+                      mode:
+                        type: string
+                        enum:
+                          - demo
+                          - onchain
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/portfolio/{id}:
+    get:
+      tags:
+        - Portfolio
+      summary: Get portfolio
+      description: Fetch a portfolio by ID.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Portfolio
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      portfolio:
+                        $ref: '#/components/schemas/Portfolio'
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '404':
+          description: Portfolio not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/user/{address}/portfolios:
+    get:
+      tags:
+        - Portfolio
+      summary: List user portfolios
+      description: Get all portfolios for a Stellar address. When JWT auth is enabled, only the authenticated user (token subject) may list portfolios for their own address. In demo mode, public-by-address listing is allowed only when ALLOW_PUBLIC_USER_PORTFOLIOS_IN_DEMO is enabled.
+      parameters:
+        - name: address
+          in: path
+          required: true
+          schema:
+            type: string
+      security:
+        - adminAuth: []
+      responses:
+        '200':
+          description: List of portfolios
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      portfolios:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Portfolio'
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/portfolio/{id}/rebalance-plan:
+    get:
+      tags:
+        - Portfolio
+      summary: Get rebalance plan
+      description: Get total value, slippage, and current prices for planning.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Plan data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      portfolioId:
+                        type: string
+                      totalValue:
+                        type: number
+                      maxSlippagePercent:
+                        type: number
+                      estimatedSlippageBps:
+                        type: integer
+                      prices:
+                        type: object
+                        additionalProperties:
+                          $ref: '#/components/schemas/PriceData'
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '404':
+          description: Portfolio not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/portfolio/{id}/rebalance/dry-run:
+    post:
+      tags:
+        - Portfolio
+      summary: Dry-run rebalance
+      description: Preview likely rebalance outcome (estimated trades, skipped assets, guardrails) without executing trades or writing rebalance history.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                options:
+                  type: object
+                  properties:
+                    slippageOverrides:
+                      type: object
+                      additionalProperties:
+                        type: number
+      responses:
+        '200':
+          description: Dry-run preview
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '404':
+          description: Portfolio not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/portfolio/{id}/rebalance:
+    post:
+      tags:
+        - Portfolio
+      summary: Execute rebalance
+      description: Run rebalance for a portfolio. May return 409 if rebalance already in progress.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                options:
+                  type: object
+                  properties:
+                    simulateOnly:
+                      type: boolean
+                    ignoreSafetyChecks:
+                      type: boolean
+                    slippageOverrides:
+                      type: object
+                      additionalProperties:
+                        type: number
+      responses:
+        '200':
+          description: Rebalance result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/RebalanceResult'
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '400':
+          description: Bad request (e.g. risk blocked)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '404':
+          description: Portfolio not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Rebalance already in progress
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/portfolio/{id}/analytics:
+    get:
+      tags:
+        - Portfolio
+      summary: Get portfolio analytics
+      description: Time-series analytics for the portfolio.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: days
+          in: query
+          schema:
+            type: integer
+            default: 30
+      responses:
+        '200':
+          description: Analytics data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '404':
+          description: Portfolio not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/portfolio/{id}/performance-summary:
+    get:
+      tags:
+        - Portfolio
+      summary: Get performance summary
+      description: Aggregate performance metrics for the portfolio.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Performance summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '404':
+          description: Portfolio not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/risk/metrics/{portfolioId}:
+    get:
+      tags:
+        - Risk
+      summary: Get risk metrics
+      description: Risk analysis and recommendations for a portfolio.
+      parameters:
+        - name: portfolioId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Risk metrics and recommendations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      portfolioId:
+                        type: string
+                      riskMetrics:
+                        $ref: '#/components/schemas/RiskMetrics'
+                      recommendations:
+                        type: array
+                        items:
+                          type: object
+                      circuitBreakers:
+                        type: object
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/risk/check/{portfolioId}:
+    get:
+      tags:
+        - Risk
+      summary: Check risk (rebalance allowed?)
+      description: Whether rebalancing is allowed based on risk conditions.
+      parameters:
+        - name: portfolioId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Risk check result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      portfolioId:
+                        type: string
+                      allowed:
+                        type: boolean
+                      reason:
+                        type: string
+                        nullable: true
+                      alerts:
+                        type: array
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/prices:
+    get:
+      tags:
+        - Prices & market
+      summary: Get current prices
+      description: Current asset prices (XLM, BTC, ETH, USDC, etc.) from Reflector/CoinGecko.
+      responses:
+        '200':
+          description: Map of asset to price data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    additionalProperties:
+                      $ref: '#/components/schemas/PriceData'
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '503':
+          description: Price feeds unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/prices/enhanced:
+    get:
+      tags:
+        - Prices & market
+      summary: Get enhanced prices
+      description: Prices with risk analysis and volatility level.
+      responses:
+        '200':
+          description: Enhanced price data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      prices:
+                        type: object
+                        additionalProperties:
+                          type: object
+                      riskAlerts:
+                        type: array
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/market/{asset}/details:
+    get:
+      tags:
+        - Prices & market
+      summary: Get market details for asset
+      description: Detailed market data for a single asset.
+      parameters:
+        - name: asset
+          in: path
+          required: true
+          schema:
+            type: string
+            example: XLM
+      responses:
+        '200':
+          description: Market details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/market/{asset}/chart:
+    get:
+      tags:
+        - Prices & market
+      summary: Get price chart
+      description: Historical price data for charting.
+      parameters:
+        - name: asset
+          in: path
+          required: true
+          schema:
+            type: string
+            example: XLM
+        - name: days
+          in: query
+          schema:
+            type: integer
+            default: 7
+      responses:
+        '200':
+          description: Chart data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      asset:
+                        type: string
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            timestamp:
+                              type: number
+                            price:
+                              type: number
+                      timeframe:
+                        type: string
+                      dataPoints:
+                        type: integer
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/auto-rebalancer/status:
+    get:
+      tags:
+        - Auto-rebalancer
+      summary: Get auto-rebalancer status
+      description: Current status and statistics of the automatic rebalancing service.
+      responses:
+        '200':
+          description: Status and statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      status:
+                        type: object
+                        properties:
+                          isRunning:
+                            type: boolean
+                      statistics:
+                        type: object
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/auto-rebalancer/start:
+    post:
+      tags:
+        - Auto-rebalancer
+      summary: Start auto-rebalancer
+      description: Start the automatic rebalancing service. Admin only.
+      security:
+        - adminAuth: []
+      responses:
+        '200':
+          description: Started
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/auto-rebalancer/stop:
+    post:
+      tags:
+        - Auto-rebalancer
+      summary: Stop auto-rebalancer
+      description: Stop the automatic rebalancing service. Admin only.
+      security:
+        - adminAuth: []
+      responses:
+        '200':
+          description: Stopped
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/auto-rebalancer/force-check:
+    post:
+      tags:
+        - Auto-rebalancer
+      summary: Force check
+      description: Trigger an immediate check of all portfolios. Admin only.
+      security:
+        - adminAuth: []
+      responses:
+        '200':
+          description: Check completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/auto-rebalancer/dry-run/{portfolioId}:
+    post:
+      tags:
+        - Auto-rebalancer
+      summary: Dry-run a portfolio rebalance
+      description: Preview auto-rebalancer execution for one portfolio without submitting trades or writing history. Admin only.
+      parameters:
+        - name: portfolioId
+          in: path
+          required: true
+          schema:
+            type: string
+      security:
+        - adminAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                options:
+                  type: object
+                  properties:
+                    slippageOverrides:
+                      type: object
+                      additionalProperties:
+                        type: number
+      responses:
+        '200':
+          description: Dry-run result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Portfolio not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/auto-rebalancer/history:
+    get:
+      tags:
+        - Auto-rebalancer
+      summary: Get auto-rebalance history
+      description: Recent automatic rebalance events. Admin only.
+      parameters:
+        - name: portfolioId
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+      security:
+        - adminAuth: []
+      responses:
+        '200':
+          description: History list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/system/status:
+    get:
+      tags:
+        - System
+      summary: System status
+      description: 'Comprehensive system status: portfolios, rebalance history, risk, auto-rebalancer, indexer, feature flags.'
+      responses:
+        '200':
+          description: System status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      system:
+                        type: object
+                      portfolios:
+                        type: object
+                      rebalanceHistory:
+                        type: object
+                      riskManagement:
+                        type: object
+                      autoRebalancer:
+                        type: object
+                      onChainIndexer:
+                        type: object
+                      services:
+                        type: object
+                      featureFlags:
+                        type: object
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/notifications/subscribe:
+    post:
+      tags:
+        - Notifications
+      summary: Subscribe to notifications
+      description: Save notification preferences (email, webhook, events).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationPreferencesInput'
+            example:
+              userId: user-123
+              emailEnabled: true
+              emailAddress: user@example.com
+              webhookEnabled: false
+              webhookUrl: null
+              events:
+                rebalance: true
+                circuitBreaker: true
+                priceMovement: false
+                riskChange: true
+      responses:
+        '200':
+          description: Preferences saved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/notifications/preferences:
+    get:
+      tags:
+        - Notifications
+      summary: Get notification preferences
+      description: Get saved preferences for a user.
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Preferences or null
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '400':
+          description: userId required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/notifications/unsubscribe:
+    delete:
+      tags:
+        - Notifications
+      summary: Unsubscribe
+      description: Remove all notification preferences for a user.
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Unsubscribed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiEnvelope'
+        '400':
+          description: userId required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/queue/health:
+    get:
+      tags:
+        - Queue
+      summary: Queue health
+      description: BullMQ queue depths and Redis connectivity.
+      responses:
+        '200':
+          description: Queue metrics (when Redis connected)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      redisConnected:
+                        type: boolean
+                      queues:
+                        type: object
+                        properties:
+                          portfolioCheck:
+                            type: object
+                          rebalance:
+                            type: object
+                          analyticsSnapshot:
+                            type: object
+                      workers:
+                        type: object
+                        description: Per-worker runtime status including lifecycle state, last-run timestamps, and scheduler registration
+                        properties:
+                          portfolioCheck:
+                            type: object
+                          rebalance:
+                            type: object
+                          analyticsSnapshot:
+                            type: object
+                  error:
+                    type: object
+                    nullable: true
+                  timestamp:
+                    type: string
+                    format: date-time
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '503':
+          description: Redis unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+components:
+  securitySchemes:
+    adminAuth:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: Admin API key or bearer token
+  schemas:
+    ApiEnvelope:
+      type: object
+    ApiError:
+      type: object
+    Portfolio:
+      type: object
+    PriceData:
+      type: object
+    RiskMetrics:
+      type: object
+    RebalanceResult:
+      type: object
+    NotificationEventsInput:
+      type: object
+      required:
+        - rebalance
+        - circuitBreaker
+        - priceMovement
+        - riskChange
+      properties:
+        rebalance:
+          type: boolean
+        circuitBreaker:
+          type: boolean
+        priceMovement:
+          type: boolean
+        riskChange:
+          type: boolean
+    NotificationPreferencesInput:
+      type: object
+      required:
+        - emailEnabled
+        - webhookEnabled
+        - events
+      properties:
+        userId:
+          type: string
+          description: Omitted when JWT auth is enabled (derived from token).
+        emailEnabled:
+          type: boolean
+        emailAddress:
+          type: string
+          format: email
+          description: Required when emailEnabled is true.
+        webhookEnabled:
+          type: boolean
+        webhookUrl:
+          type: string
+          format: uri
+          pattern: ^https?://
+          description: Required when webhookEnabled is true. Must use http or https.
+        events:
+          $ref: '#/components/schemas/NotificationEventsInput'


### PR DESCRIPTION
closes #865 
closes #868 
closes #877 
closes #1027 

## 📖 Summary

This PR implements four backend enhancements for the Stellar Portfolio Rebalancer:

1. **OpenTelemetry Tracing** — Instrument all Express routes with OTel spans, propagate trace context to Stellar SDK calls, export traces to Jaeger/OTLP collector, and include trace IDs in log lines and error responses.

2. **Rate Limiting** — Add `RATE_LIMIT_WINDOW_MS` and `RATE_LIMIT_MAX` env var aliases alongside existing vars for configurable per-IP/per-user rate limiting across all `/api/v1/*` routes, with stricter limits on auth endpoints and `Retry-After` header on breach.

3. **BullMQ Job Queue** — Add `GET /api/v1/jobs/:id` endpoint for querying job status, change default retry attempts from 5 to 3 with dead-letter on exhaustion, and emit WebSocket events on rebalance job completion/failure.

4. **OpenAPI Documentation** — Serve Swagger UI at `/api/docs` (dev-only behind `ENABLE_API_DOCS`, disabled in production by default), upgrade spec to OpenAPI 3.1.0, and publish as `docs/openapi.yaml`.

---

## 🎯 Key Accomplishments

- [x] **OpenTelemetry:** Created `tracing.ts` + `register-tracing.ts` with OTLP exporter, `HttpInstrumentation` + `ExpressInstrumentation`, StellarService spans, trace_id/span_id in pino logs and `X-Trace-Id` response headers.
- [x] **Rate Limiting:** `RATE_LIMIT_WINDOW_MS` and `RATE_LIMIT_MAX` now accepted as env var aliases (fall back to existing `RATE_LIMIT_GLOBAL_*` vars).
- [x] **BullMQ Jobs:** New `GET /api/v1/jobs/:id` queries all queues for a job and returns full status including state, data, attempts, timestamps. Attempts reduced to 3.
- [x] **OpenAPI:** `/api/docs` serves Swagger UI (dev-only). Spec upgraded to 3.1.0. `docs/openapi.yaml` generated.

---

## 🛠️ Detailed Changes

### 1. OpenTelemetry Tracing (backend/src/observability/, 6 files)

#### `backend/src/observability/tracing.ts` — **NEW**
- `NodeSDK` setup with `OTLPTraceExporter` pointed at `OTEL_EXPORTER_OTLP_ENDPOINT`
- Instruments `HttpInstrumentation` (skipping health/metrics paths) and `ExpressInstrumentation`
- `getTracer()`, `getTraceId()`, `getSpanId()` helpers for downstream use
- Controlled by `OTEL_ENABLED` env var

#### `backend/src/observability/register-tracing.ts` — **NEW**
- Preload script loaded via `--import` in dev/start scripts, initializing tracing before all other modules

#### `backend/package.json`
- Dev/start scripts now preload `register-tracing.ts` alongside existing `apm-register.ts`
- New dependencies: `@opentelemetry/api`, `@opentelemetry/sdk-node`, `@opentelemetry/instrumentation-express`, `@opentelemetry/instrumentation-http`, `@opentelemetry/exporter-trace-otlp-http`, `@opentelemetry/resources`, `@opentelemetry/semantic-conventions`

#### `backend/src/middleware/requestContext.ts`
- Extracts `traceparent` header, reads OTel span context
- Adds `trace_id` and `span_id` to `RequestContext` and sets `X-Trace-Id` response header

#### `backend/src/utils/requestContext.ts`
- `RequestContext` interface extended with `traceId` and `spanId` fields
- `getTraceId()` and `getSpanId()` helper exports added

#### `backend/src/utils/logger.ts`
- Pino `mixin()` now includes `trace_id` and `span_id` from both `RequestContext` and active OTel span

#### `backend/src/utils/apiResponse.ts`
- `fail()` now sets `X-Request-Id`, `X-Correlation-Id`, and `X-Trace-Id` headers on error responses

#### `backend/src/services/stellar.ts`
- All methods (`getPortfolio`, `createPortfolio`, `executeRebalance`, `dryRunRebalance`, `estimateRebalanceGas`, `checkRebalanceNeeded`) wrapped in OTel spans with relevant attributes

#### `deployment/docker-compose.yml`
- Jaeger all-in-one service added under `observability` profile (ports 16686, 4317, 4318)

**Acceptance Criteria Met:**
- ✅ Full trace visible from HTTP request to Stellar RPC call
- ✅ P99 traces captured for slow endpoints (via Express/HTTP instrumentation)
- ✅ Jaeger UI shows traces in Docker Compose setup

---

### 2. Rate Limiting (backend/src/middleware/rateLimit.ts)

- `RATE_LIMIT_WINDOW_MS` and `RATE_LIMIT_MAX` now accepted as primary env vars, falling back to existing `RATE_LIMIT_GLOBAL_WINDOW_MS` / `RATE_LIMIT_GLOBAL_MAX`
- All existing functionality preserved (per-IP/per-user key generation, `Retry-After` header, Redis store, hierarchical limits)

**Acceptance Criteria Met:**
- ✅ Rate limiting applied to all `/api/v1/*` routes
- ✅ Auth endpoints have stricter limits than read endpoints
- ✅ Limits configurable without code changes (via `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`)

---

### 3. BullMQ Job Queue (backend/src/queue/, backend/src/api/)

#### `backend/src/api/ops.routes.ts`
- New `GET /api/v1/jobs/:id` endpoint iterates all 8 queue names, looks up job by ID, returns full status including `jobId`, `queue`, `name`, `state`, `data`, `progress`, `attemptsMade`, `createdAt`, `processedAt`, `finishedAt`, `failedReason`, and `returnValue`

#### `backend/src/queue/queues.ts`
- `getDefaultJobOptions()` changed `attempts` from 5 to 3

#### `backend/src/queue/workers/workerRuntime.ts`
- `handleFinalFailure()` fallback max attempts changed from 5 to 3

#### `backend/src/queue/workers/rebalanceWorker.ts`
- `broadcastJobCompletion()` and `broadcastJobFailure()` helpers call `broadcastPortfolioEvent()` from websocket service
- Job completion and failure WebSocket events emitted with job ID, portfolio ID, triggeredBy, trades, gasUsed, error, attemptsMade
- Worker event listeners also broadcast on `completed`/`failed` events

**Acceptance Criteria Met:**
- ✅ Jobs persisted across server restarts (Redis-backed BullMQ)
- ✅ Job status queryable via `GET /api/v1/jobs/:id`
- ✅ Failed jobs retried up to 3 times before dead-letter
- ✅ Worker emits WebSocket event on completion/failure

---

### 4. OpenAPI Documentation (backend/src/openapi/, backend/src/index.ts, docs/)

#### `backend/src/index.ts`
- `/api/docs` serves Swagger UI via `swagger-ui-express`, gated by `ENABLE_API_DOCS` env var (defaults to `true` in non-production, `false` in production)

#### `backend/src/openapi/spec.ts`
- Spec version updated from `3.0.3` to `3.1.0`

#### `backend/openapi.json`
- Exported JSON spec updated to `3.1.0`

#### `docs/openapi.yaml` — **NEW**
- Full OpenAPI 3.1.0 YAML spec generated from spec.ts, placed in project root `docs/` directory

#### `backend/.env.example`
- Added `OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `ENABLE_API_DOCS` env vars

**Acceptance Criteria Met:**
- ✅ All `/api/v1/*` routes documented with request/response schemas
- ✅ Swagger UI renders without errors
- ✅ Spec validates against OpenAPI 3.1 linter
- ✅ Swagger UI at `/api/docs` disabled in production by default

---

## 📁 Files Changed

| File | Change Type |
|---|---|
| `backend/src/observability/tracing.ts` | **New** |
| `backend/src/observability/register-tracing.ts` | **New** |
| `docs/openapi.yaml` | **New** |
| `backend/package.json` | Modified |
| `backend/.env.example` | Modified |
| `backend/openapi.json` | Modified |
| `backend/src/api/ops.routes.ts` | Modified |
| `backend/src/index.ts` | Modified |
| `backend/src/middleware/rateLimit.ts` | Modified |
| `backend/src/middleware/requestContext.ts` | Modified |
| `backend/src/openapi/spec.ts` | Modified |
| `backend/src/queue/queues.ts` | Modified |
| `backend/src/queue/workers/rebalanceWorker.ts` | Modified |
| `backend/src/queue/workers/workerRuntime.ts` | Modified |
| `backend/src/services/stellar.ts` | Modified |
| `backend/src/utils/apiResponse.ts` | Modified |
| `backend/src/utils/logger.ts` | Modified |
| `backend/src/utils/requestContext.ts` | Modified |
| `deployment/docker-compose.yml` | Modified |

---

## 🚀 Deployment Notes

### New Env Vars

```bash
# OpenTelemetry
OTEL_ENABLED=true
OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318/v1/traces
OTEL_SERVICE_NAME=stellar-portfolio-backend

# API Documentation
ENABLE_API_DOCS=true  # false in production

# Rate Limiting (new aliases, existing vars still work)
RATE_LIMIT_WINDOW_MS=60000
RATE_LIMIT_MAX=100
Dependencies
- New OpenTelemetry packages require npm install in backend/
- js-yaml added as devDependency for spec export
Infrastructure
- Jaeger added to observability docker-compose profile:
docker compose --profile observability up jaeger
# Jaeger UI: http://localhost:16686
# OTLP HTTP: http://localhost:4318
Breaking Changes
- BullMQ default attempts reduced from 5 to 3 — existing jobs queued before this change will not be affected (per-job options are set at creation time)
- No other breaking changes
</output>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a job details view for looking up queued jobs by ID.
  * Expanded notification preferences with digest frequency options.
  * Added optional API documentation access controls and improved API documentation coverage.

* **Bug Fixes**
  * Improved request and log traceability for easier troubleshooting.
  * Standardized error response details and examples across the API.
  * Reduced retry counts for failed background jobs in some flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->