### PR TITLE
Add portfolio rebalance cost summary

### DIFF
--- a/backend/src/api/portfolios.routes.ts
+++ b/backend/src/api/portfolios.routes.ts
@@ -160,6 +160,19 @@ portfoliosRouter.get('/portfolio/:id', async (req: Request, res: Response) => {
     }
 })
 
+portfoliosRouter.get('/portfolio/:id/cost-summary', async (req: Request, res: Response) => {
+    try {
+        const portfolioId = req.params.id
+        if (!portfolioId) return fail(res, 400, 'VALIDATION_ERROR', 'Portfolio ID required')
+
+        const summary = await rebalanceHistoryService.getCostSummary(portfolioId)
+        return ok(res, summary)
+    } catch (error) {
+        logger.error('[ERROR] Get portfolio cost summary failed', { error: getErrorObject(error) })
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
 // ================================
 // PUBLIC SHARE ROUTES
 // ================================
@@ -570,6 +583,17 @@ portfoliosRouter.post('/portfolio/:id/rebalance', idempotencyMiddleware, validat
             const result = await stellarService.executeRebalance(portfolioId, mapRebalanceOptions(req.body));
 
             logger.info('Rebalance executed', { portfolioId, status: result.status, explanation: result.explanation });
+
+            await rebalanceHistoryService.recordRebalanceEvent({
+                portfolioId,
+                trigger: 'Manual Rebalancing',
+                trades: result.trades ?? 0,
+                gasUsed: result.gasUsed ?? '0 XLM',
+                feePaid: result.feePaid ?? result.feeEstimate?.totalFeeXlm ?? result.gasFeeXlm,
+                slippageBps: result.slippageBps ?? result.actualSlippageBps ?? result.estimatedTotalSlippageBps,
+                status: result.status === 'failed' ? 'failed' : 'completed',
+                isAutomatic: false,
+            });
 
             return ok(res, { result });
         } finally {

--- a/backend/src/api/validation.ts
+++ b/backend/src/api/validation.ts
@@ -73,7 +73,22 @@ export const recordRebalanceEventSchema = z.object({
     onChainLedger: z.number().int().optional(),
     onChainContractId: z.string().optional(),
     onChainPagingToken: z.string().optional(),
-    isSimulated: strictBoolean.optional()
+    isSimulated: strictBoolean.optional(),
+    feePaid: z.number().min(0).optional(),
+    slippageBps: z.number().min(0).optional(),
+    estimatedSlippageBps: z.number().min(0).optional(),
+    actualSlippageBps: z.number().min(0).optional(),
+    totalSlippageBps: z.number().min(0).optional(),
+    gasFeeXlm: z.number().min(0).optional(),
+    gasFeeUsd: z.number().min(0).optional(),
+    gasPerTradeXlm: z.number().min(0).optional(),
+    gasWarning: strictBoolean.optional(),
+    gasBreakdown: z.array(z.object({
+        tradeId: z.string(),
+        fromAsset: z.string().optional(),
+        toAsset: z.string().optional(),
+        feeXlm: z.number().min(0)
+    })).optional()
 }).strict();
 
 // Auto-Rebalancer control schemas (must be entirely empty payloads)

--- a/backend/src/db/migrations/011_rebalance_cost_metrics.down.sql
+++ b/backend/src/db/migrations/011_rebalance_cost_metrics.down.sql
@@ -1,0 +1,11 @@
+-- Migration: 011_rebalance_cost_metrics (down)
+-- Description: Remove realized fee and slippage metrics from rebalance events.
+
+DROP INDEX IF EXISTS idx_rebalance_events_portfolio_cost;
+
+ALTER TABLE rebalance_events
+DROP COLUMN IF EXISTS slippage_bps;
+
+ALTER TABLE rebalance_events
+DROP COLUMN IF EXISTS fee_paid;
+

--- a/backend/src/db/migrations/011_rebalance_cost_metrics.up.sql
+++ b/backend/src/db/migrations/011_rebalance_cost_metrics.up.sql
@@ -1,0 +1,13 @@
+-- Migration: 011_rebalance_cost_metrics (up)
+-- Description: Store realized fee and slippage metrics on rebalance events.
+-- Rollback: See 011_rebalance_cost_metrics.down.sql
+
+ALTER TABLE rebalance_events
+ADD COLUMN IF NOT EXISTS fee_paid NUMERIC NOT NULL DEFAULT 0;
+
+ALTER TABLE rebalance_events
+ADD COLUMN IF NOT EXISTS slippage_bps NUMERIC NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_rebalance_events_portfolio_cost
+    ON rebalance_events(portfolio_id, timestamp DESC);
+

--- a/backend/src/db/migrations/manifest.json
+++ b/backend/src/db/migrations/manifest.json
@@ -78,5 +78,13 @@
   {
     "file": "010_consent_audit_lifecycle.down.sql",
     "sha256": "351bae86974db75abfb7508e0cadf3b5695f3c223b93b68a1a6bf97dc3f85caf"
+  },
+  {
+    "file": "011_rebalance_cost_metrics.up.sql",
+    "sha256": "81de13521ba61016090ca7d20bdb97f758bdb1814a3f52507acb526df7b20776"
+  },
+  {
+    "file": "011_rebalance_cost_metrics.down.sql",
+    "sha256": "5760434f3e48c47c28e4be090296ec9b02b9f5822ead2fb8a337a3f4ba2be8b5"
   }
 ]

--- a/backend/src/db/rebalanceHistoryDb.ts
+++ b/backend/src/db/rebalanceHistoryDb.ts
@@ -7,6 +7,8 @@ export interface RebalanceEventRow {
     trigger: string
     trades: number
     gas_used: string
+    fee_paid: string
+    slippage_bps: string
     status: string
     is_automatic: boolean
     risk_alerts: unknown
@@ -23,6 +25,8 @@ function rowToEvent(r: RebalanceEventRow) {
         trigger: r.trigger,
         trades: r.trades,
         gasUsed: r.gas_used,
+        feePaid: Number(r.fee_paid ?? 0),
+        slippageBps: Number(r.slippage_bps ?? 0),
         status: r.status as 'completed' | 'failed' | 'pending',
         isAutomatic: r.is_automatic,
         riskAlerts: (r.risk_alerts as any[]) ?? [],
@@ -40,6 +44,8 @@ export async function dbInsertRebalanceEvent(event: {
     trigger: string
     trades: number
     gasUsed: string
+    feePaid?: number
+    slippageBps?: number
     status: string
     isAutomatic: boolean
     riskAlerts?: unknown[]
@@ -48,14 +54,16 @@ export async function dbInsertRebalanceEvent(event: {
     timestamp?: Date
 }): Promise<{ id: string }> {
     await query(
-        `INSERT INTO rebalance_events (id, portfolio_id, trigger, trades, gas_used, status, is_automatic, risk_alerts, error, details, timestamp)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, COALESCE($11, NOW()))`,
+        `INSERT INTO rebalance_events (id, portfolio_id, trigger, trades, gas_used, fee_paid, slippage_bps, status, is_automatic, risk_alerts, error, details, timestamp)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, COALESCE($13, NOW()))`,
         [
             event.id,
             event.portfolioId,
             event.trigger,
             event.trades,
             event.gasUsed,
+            event.feePaid ?? 0,
+            event.slippageBps ?? 0,
             event.status,
             event.isAutomatic,
             event.riskAlerts ? JSON.stringify(event.riskAlerts) : null,
@@ -81,6 +89,39 @@ export async function dbGetRebalanceHistoryCountByPortfolio(portfolioId: string)
         [portfolioId]
     )
     return parseInt(result.rows[0]?.count ?? '0', 10)
+}
+
+export interface RebalanceCostSummary {
+    total_fees_paid: number
+    avg_slippage_bps: number
+    cost_per_rebalance: number
+    total_rebalances: number
+}
+
+export async function dbGetRebalanceCostSummary(portfolioId: string): Promise<RebalanceCostSummary> {
+    const result = await query<{
+        total_fees_paid: string
+        avg_slippage_bps: string
+        total_rebalances: string
+    }>(
+        `SELECT
+            COALESCE(SUM(fee_paid), 0) as total_fees_paid,
+            COALESCE(AVG(slippage_bps), 0) as avg_slippage_bps,
+            COUNT(*) as total_rebalances
+         FROM rebalance_events
+         WHERE portfolio_id = $1`,
+        [portfolioId]
+    )
+    const row = result.rows[0]
+    const totalFees = Number(row?.total_fees_paid ?? 0)
+    const totalRebalances = parseInt(row?.total_rebalances ?? '0', 10)
+
+    return {
+        total_fees_paid: totalFees,
+        avg_slippage_bps: Number(row?.avg_slippage_bps ?? 0),
+        cost_per_rebalance: totalRebalances > 0 ? totalFees / totalRebalances : 0,
+        total_rebalances: totalRebalances
+    }
 }
 
 export async function dbGetRebalanceHistoryAll(limit: number, offset = 0) {

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -6,6 +6,8 @@ CREATE TABLE IF NOT EXISTS rebalance_events (
     trigger VARCHAR(512) NOT NULL,
     trades INTEGER NOT NULL DEFAULT 0,
     gas_used VARCHAR(64) NOT NULL DEFAULT '',
+    fee_paid NUMERIC NOT NULL DEFAULT 0,
+    slippage_bps NUMERIC NOT NULL DEFAULT 0,
     status VARCHAR(32) NOT NULL CHECK (status IN ('completed', 'failed', 'pending')),
     is_automatic BOOLEAN NOT NULL DEFAULT FALSE,
     event_source VARCHAR(32) NOT NULL DEFAULT 'offchain',

--- a/backend/src/queue/workers/rebalanceWorker.ts
+++ b/backend/src/queue/workers/rebalanceWorker.ts
@@ -101,6 +101,8 @@ export async function processRebalanceJob(
             : "Manual Rebalancing",
         trades: rebalanceResult.trades ?? 0,
         gasUsed: rebalanceResult.gasUsed ?? "0 XLM",
+        feePaid: rebalanceResult.feePaid ?? rebalanceResult.feeEstimate?.totalFeeXlm ?? rebalanceResult.gasFeeXlm,
+        slippageBps: rebalanceResult.slippageBps ?? rebalanceResult.actualSlippageBps ?? rebalanceResult.estimatedTotalSlippageBps,
         status: "completed",
         isAutomatic: triggeredBy === "auto",
       });

--- a/backend/src/services/rebalanceHistory.ts
+++ b/backend/src/services/rebalanceHistory.ts
@@ -8,8 +8,9 @@ import {
   dbGetAllAutoRebalances,
   dbGetHistoryStats,
   dbGetRebalanceHistoryCountByPortfolio,
+  dbGetRebalanceCostSummary,
 } from '../db/rebalanceHistoryDb.js'
-import type { RebalanceHistoryQueryOptions } from '../db/rebalanceHistoryDb.js'
+import type { RebalanceCostSummary, RebalanceHistoryQueryOptions } from '../db/rebalanceHistoryDb.js'
 import { getFeatureFlags } from '../config/featureFlags.js'
 import type { PricesMap } from '../types/index.js'
 import { logger } from '../utils/logger.js'
@@ -21,6 +22,8 @@ export interface RebalanceEvent {
     trigger: string
     trades: number
     gasUsed: string
+    feePaid?: number
+    slippageBps?: number
     status: 'completed' | 'failed' | 'pending'
     isAutomatic?: boolean
     riskAlerts?: any[]
@@ -56,6 +59,8 @@ export interface RebalanceEvent {
         gasPerTradeXlm?: number
         gasWarning?: boolean
         gasBreakdown?: Array<{ tradeId: string, fromAsset?: string, toAsset?: string, feeXlm: number }>
+        feePaid?: number
+        slippageBps?: number
     }
 }
 
@@ -97,6 +102,8 @@ export class RebalanceHistoryService {
         slippageExceededTolerance?: boolean
         /** Optional aggregate slippage in basis points for backwards compatibility. */
         totalSlippageBps?: number
+        feePaid?: number
+        slippageBps?: number
         gasFeeXlm?: number
         gasFeeUsd?: number
         gasPerTradeXlm?: number
@@ -125,6 +132,8 @@ export class RebalanceHistoryService {
             gasWarning: eventData.gasWarning,
             gasBreakdown: eventData.gasBreakdown
         }
+        const feePaid = this.deriveFeePaid(eventData, details)
+        const slippageBps = this.deriveSlippageBps(eventData)
 
         if (eventData.prices && eventData.portfolio) {
             try {
@@ -148,6 +157,8 @@ export class RebalanceHistoryService {
             trigger: eventData.trigger,
             trades: eventData.trades,
             gasUsed: eventData.gasUsed,
+            feePaid,
+            slippageBps,
             status: eventData.status,
             isAutomatic: eventData.isAutomatic ?? false,
             riskAlerts: eventData.riskAlerts ?? [],
@@ -173,6 +184,8 @@ export class RebalanceHistoryService {
             trigger: eventData.trigger,
             trades: eventData.trades,
             gasUsed: eventData.gasUsed,
+            feePaid,
+            slippageBps,
             status: eventData.status,
             isAutomatic: eventData.isAutomatic ?? false,
             riskAlerts: eventData.riskAlerts ?? [],
@@ -188,7 +201,11 @@ export class RebalanceHistoryService {
             onChainContractId: eventData.onChainContractId,
             onChainPagingToken: eventData.onChainPagingToken,
             isSimulated: eventData.isSimulated,
-            details,
+            details: {
+                ...details,
+                feePaid,
+                slippageBps
+            },
         }
 
         logger.info('[REBALANCE-HISTORY] Recorded rebalance event', {
@@ -324,5 +341,46 @@ export class RebalanceHistoryService {
 
     async getRebalanceHistoryCount(portfolioId: string): Promise<number> {
         return dbGetRebalanceHistoryCountByPortfolio(portfolioId)
+    }
+
+    async getCostSummary(portfolioId: string): Promise<RebalanceCostSummary> {
+        return dbGetRebalanceCostSummary(portfolioId)
+    }
+
+    private deriveFeePaid(
+        eventData: {
+            feePaid?: number
+            gasFeeXlm?: number
+            gasBreakdown?: Array<{ feeXlm: number }>
+        },
+        details: RebalanceEvent['details']
+    ): number {
+        if (typeof eventData.feePaid === 'number' && Number.isFinite(eventData.feePaid)) {
+            return Math.max(0, eventData.feePaid)
+        }
+        if (typeof eventData.gasFeeXlm === 'number' && Number.isFinite(eventData.gasFeeXlm)) {
+            return Math.max(0, eventData.gasFeeXlm)
+        }
+        const breakdownTotal = details?.gasBreakdown?.reduce((sum, item) => {
+            const fee = Number(item.feeXlm)
+            return sum + (Number.isFinite(fee) ? fee : 0)
+        }, 0)
+        return Math.max(0, breakdownTotal ?? 0)
+    }
+
+    private deriveSlippageBps(eventData: {
+        slippageBps?: number
+        actualSlippageBps?: number
+        totalSlippageBps?: number
+        estimatedSlippageBps?: number
+    }): number {
+        const candidates = [
+            eventData.slippageBps,
+            eventData.actualSlippageBps,
+            eventData.totalSlippageBps,
+            eventData.estimatedSlippageBps
+        ]
+        const value = candidates.find((candidate) => typeof candidate === 'number' && Number.isFinite(candidate))
+        return Math.max(0, value ?? 0)
     }
 }

--- a/backend/src/test/rebalanceHistory.service.test.ts
+++ b/backend/src/test/rebalanceHistory.service.test.ts
@@ -3,23 +3,34 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const recordMock = vi.fn()
 const getHistoryMock = vi.fn()
 const getRecentAutoMock = vi.fn()
+const getCostSummaryMock = vi.fn()
 
-vi.mock('../services/databaseService.js', () => ({
-    databaseService: {
-        recordRebalanceEvent: recordMock,
-        getRebalanceHistory: getHistoryMock,
-        getRecentAutoRebalances: getRecentAutoMock,
-        getAutoRebalancesSince: vi.fn(),
-        getAllAutoRebalances: vi.fn(),
-        initializeDemoData: vi.fn(),
-        clearHistory: vi.fn(),
-        getHistoryStats: vi.fn()
-    }
+vi.mock('../services/riskManagements.js', () => ({
+    RiskManagementService: class {
+        analyzePortfolioRisk() {
+            return { overallRiskLevel: 'low' }
+        }
+    },
+}))
+
+vi.mock('../db/rebalanceHistoryDb.js', () => ({
+    dbInsertRebalanceEvent: recordMock,
+    dbGetRebalanceHistoryByPortfolio: getHistoryMock,
+    dbGetRebalanceHistoryAll: vi.fn(),
+    dbGetRecentAutoRebalances: getRecentAutoMock,
+    dbGetAutoRebalancesSince: vi.fn(),
+    dbGetAllAutoRebalances: vi.fn(),
+    dbGetHistoryStats: vi.fn(),
+    dbGetRebalanceHistoryCountByPortfolio: vi.fn(),
+    dbGetRebalanceCostSummary: getCostSummaryMock,
 }))
 
 describe('RebalanceHistoryService', () => {
     beforeEach(() => {
-        vi.clearAllMocks()
+        recordMock.mockReset()
+        getHistoryMock.mockReset()
+        getRecentAutoMock.mockReset()
+        getCostSummaryMock.mockReset()
     })
 
     it('records enriched rebalance events with derived details', async () => {
@@ -40,6 +51,11 @@ describe('RebalanceHistoryService', () => {
             actor: 'scheduler',
             source: 'auto_rebalance',
             triggerMetadata: { driftPct: 8.2, thresholdPct: 5 },
+            gasBreakdown: [
+                { tradeId: 'trade-1', feeXlm: 0.01 },
+                { tradeId: 'trade-2', feeXlm: 0.02 },
+            ],
+            actualSlippageBps: 14,
             portfolio: { allocations: { XLM: 50, BTC: 50 } },
             prices: {
                 XLM: { price: 0.1, change: -2, timestamp: 1 },
@@ -52,11 +68,13 @@ describe('RebalanceHistoryService', () => {
         const saved = recordMock.mock.calls[0][0]
         expect(saved.details.reason).toMatch(/drift exceeded/i)
         expect(saved.details.riskLevel).toBe('medium')
+        expect(saved.feePaid).toBeCloseTo(0.03)
+        expect(saved.slippageBps).toBe(14)
         expect(saved.details.priceDirection).toMatch(/up|down/)
         expect(saved.actor).toBe('scheduler')
         expect(saved.source).toBe('auto_rebalance')
         expect(saved.triggerMetadata).toEqual({ driftPct: 8.2, thresholdPct: 5 })
-    })
+    }, 15000)
 
     it('infers actor/source from isAutomatic when not provided', async () => {
         recordMock.mockImplementation((event) => ({ id: 'evt-2', ...event }))
@@ -80,9 +98,15 @@ describe('RebalanceHistoryService', () => {
         expect(saved.source).toBe('dashboard')
     })
 
-    it('proxies history query calls', async () => {
+    it('proxies history and cost summary query calls', async () => {
         getHistoryMock.mockReturnValue([{ id: 'e1' }])
         getRecentAutoMock.mockReturnValue([{ id: 'e2' }])
+        getCostSummaryMock.mockResolvedValue({
+            total_fees_paid: 0.05,
+            avg_slippage_bps: 12.5,
+            cost_per_rebalance: 0.025,
+            total_rebalances: 2,
+        })
 
         const { RebalanceHistoryService } = await import('../services/rebalanceHistory.js')
         const service = new RebalanceHistoryService({
@@ -91,10 +115,18 @@ describe('RebalanceHistoryService', () => {
 
         const history = await service.getRebalanceHistory('p1', 20)
         const auto = await service.getRecentAutoRebalances('p1', 10)
+        const costSummary = await service.getCostSummary('p1')
 
         expect(history).toEqual([{ id: 'e1' }])
         expect(auto).toEqual([{ id: 'e2' }])
-        expect(getHistoryMock).toHaveBeenCalledWith('p1', 20, {})
+        expect(costSummary).toEqual({
+            total_fees_paid: 0.05,
+            avg_slippage_bps: 12.5,
+            cost_per_rebalance: 0.025,
+            total_rebalances: 2,
+        })
+        expect(getHistoryMock).toHaveBeenCalledWith('p1', 20, 0)
         expect(getRecentAutoMock).toHaveBeenCalledWith('p1', 10)
+        expect(getCostSummaryMock).toHaveBeenCalledWith('p1')
     })
 })

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react'
 import { motion } from 'framer-motion'
 import { PieChart, Pie, Cell, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
-import { TrendingUp, AlertCircle, RefreshCw, ArrowLeft, ExternalLink, Trash2, Plus, CheckCircle, Zap, Copy, Share2 } from 'lucide-react'
+import { TrendingUp, AlertCircle, RefreshCw, ArrowLeft, ExternalLink, Trash2, Plus, CheckCircle, Zap, Copy, Share2, Settings, WalletCards } from 'lucide-react'
 import ThemeToggle from './ThemeToggle'
 import LanguageSelector from './LanguageSelector'
 import { useTheme } from '../context/ThemeContext'
@@ -14,7 +14,7 @@ import NotificationPreferences from './NotificationPreferences'
 import { StellarWallet } from '../utils/stellar'
 import PriceTracker from './PriceTracker'
 import { API_CONFIG } from '../config/api'
-import { useUserPortfolios, usePortfolioDetails, useRebalanceEstimate, useRebalancePlan, portfolioKeys } from '../hooks/queries/usePortfolioQuery'
+import { useUserPortfolios, usePortfolioDetails, useRebalanceEstimate, useRebalancePlan, usePortfolioCostSummary, portfolioKeys } from '../hooks/queries/usePortfolioQuery'
 import { dashboardCopy } from '../content/uiCopy'
 import { buildPortfolioCloneDraft, savePortfolioCloneDraft, loadPortfolioCloneDraft, clearPortfolioCloneDraft } from '../utils/portfolioCloneDraft'
 import { usePrices, formatPriceFeedSummary, priceKeys } from '../hooks/queries/usePricesQuery'
@@ -69,6 +69,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
         refetch: refetchPrices,
     } = usePrices()
     const { data: rebalanceEstimate } = useRebalanceEstimate(latestPortfolioId)
+    const { data: costSummary, isLoading: costSummaryLoading } = usePortfolioCostSummary(latestPortfolioId)
 
     const [showRebalanceConfirm, setShowRebalanceConfirm] = useState(false)
     const { data: rebalancePlan, isLoading: rebalancePlanLoading, isError: rebalancePlanError } = useRebalancePlan(
@@ -839,6 +840,47 @@ const Dashboard: React.FC<DashboardProps> = ({ onNavigate, publicKey }) => {
                                     )}
                                 </motion.div>
                             )}
+
+                            <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">
+                                <div className="flex items-center justify-between mb-4">
+                                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Cost Summary</h3>
+                                    <WalletCards className="w-5 h-5 text-blue-500" aria-hidden />
+                                </div>
+                                {costSummaryLoading ? (
+                                    <div className="space-y-3" aria-busy="true">
+                                        <div className="h-5 w-28 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+                                        <div className="h-5 w-36 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+                                        <div className="h-5 w-32 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+                                    </div>
+                                ) : (
+                                    <div className="space-y-3 text-sm">
+                                        <div className="flex items-center justify-between">
+                                            <span className="text-gray-500 dark:text-gray-400">Total fees paid</span>
+                                            <span className="font-semibold text-gray-900 dark:text-white">
+                                                {(costSummary?.total_fees_paid ?? 0).toFixed(4)} XLM
+                                            </span>
+                                        </div>
+                                        <div className="flex items-center justify-between">
+                                            <span className="text-gray-500 dark:text-gray-400">Avg slippage</span>
+                                            <span className="font-semibold text-gray-900 dark:text-white">
+                                                {(costSummary?.avg_slippage_bps ?? 0).toFixed(2)} bps
+                                            </span>
+                                        </div>
+                                        <div className="flex items-center justify-between">
+                                            <span className="text-gray-500 dark:text-gray-400">Cost per rebalance</span>
+                                            <span className="font-semibold text-gray-900 dark:text-white">
+                                                {(costSummary?.cost_per_rebalance ?? 0).toFixed(4)} XLM
+                                            </span>
+                                        </div>
+                                        <div className="flex items-center justify-between">
+                                            <span className="text-gray-500 dark:text-gray-400">Total rebalances</span>
+                                            <span className="font-semibold text-gray-900 dark:text-white">
+                                                {costSummary?.total_rebalances ?? 0}
+                                            </span>
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
 
                             {/* Allocation Chart */}
                             <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm">

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -137,6 +137,7 @@ export const API_CONFIG = {
         PORTFOLIO_REBALANCE: (id: string) => `${API_RESOURCE_ROOT}/portfolio/${id}/rebalance`,
         PORTFOLIO_REBALANCE_ESTIMATE: (id: string) => `${API_RESOURCE_ROOT}/portfolio/${id}/rebalance-estimate`,
         PORTFOLIO_REBALANCE_PLAN: (id: string) => `${API_RESOURCE_ROOT}/portfolio/${id}/rebalance-plan`,
+        PORTFOLIO_COST_SUMMARY: (id: string) => `${API_RESOURCE_ROOT}/portfolio/${id}/cost-summary`,
         PORTFOLIO_REBALANCE_STATUS: (id: string) => `${API_RESOURCE_ROOT}/portfolio/${id}/rebalance-status`,
         PORTFOLIO_SHARE: (id: string) => `${API_RESOURCE_ROOT}/portfolio/${id}/share`,
         PORTFOLIO_SHARE_VIEW: (hash: string) => `${API_RESOURCE_ROOT}/portfolio/share/${hash}`,

--- a/frontend/src/hooks/queries/usePortfolioQuery.ts
+++ b/frontend/src/hooks/queries/usePortfolioQuery.ts
@@ -8,6 +8,7 @@ export const portfolioKeys = {
     list: (address: string) => [...portfolioKeys.lists(), address] as const,
     details: () => [...portfolioKeys.all, 'detail'] as const,
     detail: (id: string) => [...portfolioKeys.details(), id] as const,
+    costSummary: (id: string) => [...portfolioKeys.detail(id), 'cost-summary'] as const,
 }
 
 export type RebalanceConfirmationSummary = {
@@ -29,6 +30,13 @@ export type RebalancePlanSnapshot = {
     maxSlippagePercent: number
     estimatedSlippageBps: number
     priceFeedMeta?: PriceFeedClientMeta
+}
+
+export type PortfolioCostSummary = {
+    total_fees_paid: number
+    avg_slippage_bps: number
+    cost_per_rebalance: number
+    total_rebalances: number
 }
 
 export function buildRebalanceConfirmationSummary(input: {
@@ -186,6 +194,16 @@ export const useRebalancePlan = (id: string | null, enabled = true) => {
         queryFn: () => api.get<RebalancePlanSnapshot>(ENDPOINTS.PORTFOLIO_REBALANCE_PLAN(id!)),
         enabled: enabled && !!id && id !== 'demo',
         staleTime: 25000,
+        placeholderData: (previous) => previous,
+    })
+}
+
+export const usePortfolioCostSummary = (id: string | null) => {
+    return useQuery({
+        queryKey: portfolioKeys.costSummary(id || ''),
+        queryFn: () => api.get<PortfolioCostSummary>(ENDPOINTS.PORTFOLIO_COST_SUMMARY(id!)),
+        enabled: !!id && id !== 'demo',
+        staleTime: 30000,
         placeholderData: (previous) => previous,
     })
 }


### PR DESCRIPTION
Summary
- Adds first-class rebalance cost tracking by storing fee_paid and slippage_bps on rebalance_events.
- Adds a portfolio cost summary API that aggregates full-history fees, average slippage, cost per rebalance, and total rebalance count.
- Surfaces the cost summary in the dashboard with a dedicated Cost Summary card.
- Extends rebalance history validation and unit coverage for fee/slippage derivation and the summary service path.

Issue
- Closes #978

Changes
- Added migration 011_rebalance_cost_metrics with checksum manifest entries.
- Updated rebalance history DB inserts/reads to persist and return feePaid and slippageBps.
- Added GET /api/v1/portfolio/:id/cost-summary via the existing portfolio router.
- Records fee/slippage metrics from direct rebalance execution and rebalance worker execution paths when available, defaulting safely to 0 for older or unavailable values.
- Added frontend API endpoint config, React Query hook, and dashboard Cost Summary card.

Validation
- Passed: npm.cmd install in backend.
- Passed: npx.cmd vitest run src/test/rebalanceHistory.service.test.ts.
- Passed: git diff --check.
- Failed / repo issue: npm.cmd run build in backend fails before reaching this change because existing test files have syntax errors: src/test/assetRegistryValidation.test.ts, src/test/metrics.test.ts, and src/test/portfolioExport.integration.test.ts.
- Failed / repo issue: npm.cmd run db:migrate -- --dry-run fails on Node 24.16.0 because @opentelemetry/resources does not provide a named Resource export used by src/observability/tracing.ts.
- Not run: frontend build. Frontend install is blocked by the repo's existing Storybook peer dependency conflict unless using legacy peer resolution; the timed legacy install did not complete enough to expose local tsc.

Notes
- Existing rebalance rows receive default 0 values through the migration so historical summaries remain stable.
- No dependency or lockfile changes are included.