### PR TITLE
feat(contracts): add time-locked rebalance scheduling (#956)

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -9,6 +9,7 @@ use soroban_sdk::{
 mod nav;
 mod portfolio;
 mod reflector;
+mod scheduler;
 #[cfg(test)]
 mod test;
 mod types;
@@ -280,7 +281,7 @@ impl PortfolioRebalancer {
         portfolio_id: u64,
         actual_balances: Map<Address, i128>,
     ) -> Result<(), Error> {
-        Self::execute_rebalance_internal(&env, portfolio_id, actual_balances, false, None)
+        Self::execute_rebalance_internal(&env, portfolio_id, actual_balances, false, None, false)
     }
 
     pub fn admin_force_rebalance(
@@ -290,7 +291,7 @@ impl PortfolioRebalancer {
     ) -> Result<(), Error> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
-        Self::execute_rebalance_internal(&env, portfolio_id, actual_balances, true, Some(admin))
+        Self::execute_rebalance_internal(&env, portfolio_id, actual_balances, true, Some(admin), false)
     }
 
     pub fn set_emergency_stop(env: Env, stop: bool) {
@@ -312,6 +313,46 @@ impl PortfolioRebalancer {
 
     pub fn execute_dca(env: Env, portfolio_id: u64) -> Result<(), Error> {
         dca::execute_dca(&env, portfolio_id)
+    }
+
+    /// Schedule a rebalance at a future ledger sequence.
+    /// Only the portfolio owner (or steward) may call.
+    /// At most one pending schedule per portfolio.
+    pub fn schedule_rebalance(
+        env: Env,
+        portfolio_id: u64,
+        target_sequence: u32,
+    ) -> Result<(), Error> {
+        scheduler::schedule_rebalance(&env, portfolio_id, target_sequence)
+    }
+
+    /// Execute a scheduled rebalance if the target sequence has been reached.
+    /// Callable by anyone — no authorization required.
+    pub fn execute_scheduled_rebalance(
+        env: Env,
+        portfolio_id: u64,
+        actual_balances: Map<Address, i128>,
+    ) -> Result<(), Error> {
+        scheduler::execute_scheduled_rebalance(&env, portfolio_id, actual_balances)
+    }
+
+    /// Cancel a pending scheduled rebalance.
+    /// Only the portfolio owner (or steward) may call.
+    pub fn cancel_scheduled_rebalance(
+        env: Env,
+        portfolio_id: u64,
+    ) -> Result<(), Error> {
+        scheduler::cancel_scheduled_rebalance(&env, portfolio_id)
+    }
+
+    /// Check if a schedule exists for a portfolio.
+    pub fn has_schedule(env: Env, portfolio_id: u64) -> bool {
+        scheduler::has_schedule(&env, portfolio_id)
+    }
+
+    /// Get the current schedule config for a portfolio.
+    pub fn get_schedule(env: Env, portfolio_id: u64) -> Option<ScheduleConfig> {
+        scheduler::get_schedule(&env, portfolio_id)
     }
 
     pub fn transfer_stewardship(
@@ -654,6 +695,7 @@ impl PortfolioRebalancer {
         actual_balances: Map<Address, i128>,
         bypass_cooldown: bool,
         override_admin: Option<Address>,
+        skip_owner_auth: bool,
     ) -> Result<(), Error> {
         if let Some(true) = env.storage().instance().get(&DataKey::EmergencyStop) {
             return Err(Error::EmergencyStop);
@@ -672,12 +714,14 @@ impl PortfolioRebalancer {
             return Err(Error::PortfolioPaused);
         }
 
-        let steward: Address = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Steward(portfolio_id))
-            .unwrap_or(portfolio.user.clone());
-        steward.require_auth();
+        if !skip_owner_auth {
+            let steward: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Steward(portfolio_id))
+                .unwrap_or(portfolio.user.clone());
+            steward.require_auth();
+        }
 
         let current_time = guard_ledger_timestamp(env);
         if !bypass_cooldown

--- a/contracts/src/scheduler.rs
+++ b/contracts/src/scheduler.rs
@@ -1,0 +1,165 @@
+// Time-locked rebalance scheduler.
+//
+// Portfolio owner schedules a rebalance at a future ledger sequence.
+// Anyone may execute the scheduled rebalance after the target sequence.
+// Owner may cancel a pending schedule. At most one pending schedule per portfolio.
+
+use soroban_sdk::{symbol_short, Address, Env, Map, Symbol};
+
+use crate::types::*;
+
+/// Schedule a rebalance at a future ledger sequence.
+/// Only the portfolio owner (or steward) may call.
+pub fn schedule_rebalance(
+    env: &Env,
+    portfolio_id: u64,
+    target_sequence: u32,
+) -> Result<(), Error> {
+    let portfolio = crate::PortfolioRebalancer::load_portfolio(env, portfolio_id)?;
+
+    let steward: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Steward(portfolio_id))
+        .unwrap_or(portfolio.user.clone());
+    steward.require_auth();
+
+    // Reject past or current sequences — must be a future ledger.
+    let current_sequence = env.ledger().sequence();
+    if target_sequence <= current_sequence {
+        return Err(Error::ScheduleNotReady);
+    }
+
+    // Ensure no existing schedule is pending
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::ScheduleConfig(portfolio_id))
+    {
+        return Err(Error::ScheduleAlreadyExists);
+    }
+
+    let current_ts = env.ledger().timestamp();
+    let config = ScheduleConfig {
+        target_sequence,
+        created_at: current_ts,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::ScheduleConfig(portfolio_id), &config);
+
+    emit_rebalance_scheduled(env, portfolio_id, target_sequence, current_ts);
+    Ok(())
+}
+
+/// Execute a scheduled rebalance if the target sequence has been reached.
+/// Callable by anyone — no authorization required.
+pub fn execute_scheduled_rebalance(
+    env: &Env,
+    portfolio_id: u64,
+    actual_balances: Map<Address, i128>,
+) -> Result<(), Error> {
+    let config = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ScheduleConfig(portfolio_id))
+        .ok_or(Error::NoScheduleFound)?;
+
+    let current_sequence = env.ledger().sequence();
+    if current_sequence < config.target_sequence {
+        return Err(Error::ScheduleNotReady);
+    }
+
+    // Delegate to the internal rebalance execution path.
+    // Bypass cooldown so the scheduled rebalance always succeeds
+    // timing-wise once the sequence is reached.
+    // Skip owner auth so anyone can trigger execution.
+    crate::PortfolioRebalancer::execute_rebalance_internal(
+        env,
+        portfolio_id,
+        actual_balances,
+        true,  // bypass_cooldown
+        None,  // no admin override
+        true,  // skip_owner_auth: anyone can execute
+    )?;
+
+    // Only remove the schedule after a successful rebalance.
+    env.storage()
+        .persistent()
+        .remove(&DataKey::ScheduleConfig(portfolio_id));
+
+    Ok(())
+}
+
+/// Cancel a pending scheduled rebalance.
+/// Only the portfolio owner (or steward) may call.
+pub fn cancel_scheduled_rebalance(env: &Env, portfolio_id: u64) -> Result<(), Error> {
+    let portfolio = crate::PortfolioRebalancer::load_portfolio(env, portfolio_id)?;
+
+    let steward: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Steward(portfolio_id))
+        .unwrap_or(portfolio.user.clone());
+    steward.require_auth();
+
+    // Load the config so we can emit the event with details
+    let config = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ScheduleConfig(portfolio_id))
+        .ok_or(Error::NoScheduleFound)?;
+
+    env.storage()
+        .persistent()
+        .remove(&DataKey::ScheduleConfig(portfolio_id));
+
+    emit_rebalance_canceled(env, portfolio_id, config.target_sequence);
+    Ok(())
+}
+
+/// Check if a schedule exists for a portfolio.
+pub fn has_schedule(env: &Env, portfolio_id: u64) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::ScheduleConfig(portfolio_id))
+}
+
+/// Get the current schedule config for a portfolio.
+pub fn get_schedule(env: &Env, portfolio_id: u64) -> Option<ScheduleConfig> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ScheduleConfig(portfolio_id))
+}
+
+// ── Event emitters ──────────────────────────────────────────────
+
+fn emit_rebalance_scheduled(
+    env: &Env,
+    portfolio_id: u64,
+    target_sequence: u32,
+    created_at: u64,
+) {
+    env.events().publish(
+        (
+            symbol_short!("portfolio"),
+            Symbol::new(env, "rebalance_scheduled"),
+        ),
+        (portfolio_id, target_sequence, created_at),
+    );
+}
+
+fn emit_rebalance_canceled(
+    env: &Env,
+    portfolio_id: u64,
+    target_sequence: u32,
+) {
+    env.events().publish(
+        (
+            symbol_short!("portfolio"),
+            Symbol::new(env, "rebalance_canceled"),
+        ),
+        (portfolio_id, target_sequence),
+    );
+}

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -2590,3 +2590,223 @@ fn test_benchmark_nav_operations() {
     std::println!("BENCHMARK_NAV_FULL_HISTORY_CPU: {}", cpu_full);
     std::println!("BENCHMARK_NAV_FULL_HISTORY_MEM: {}", mem_full);
 }
+
+// ── Scheduler tests ─────────────────────────────────────────────
+
+fn setup_scheduler_test(env: &Env) -> (PortfolioRebalancerClient, Address, u64) {
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 50;
+        li.timestamp = 10_000;
+    });
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(env);
+    let user = Address::generate(env);
+    client.initialize(&admin, &reflector_id);
+
+    let mut allocations = Map::new(env);
+    let asset = Address::generate(env);
+    allocations.set(asset.clone(), 10_000);
+    let pid = create_portfolio_with_defaults(env, &client, &user, &allocations, 5, 50);
+
+    // Deposit so the portfolio has value for rebalance
+    client.deposit(&pid, &asset, &10_000_000, &String::from_str(env, ""));
+
+    (client, user, pid)
+}
+
+#[test]
+fn test_schedule_rebalance_success() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    // Schedule at a future ledger sequence
+    client.schedule_rebalance(&pid, &100);
+
+    assert!(client.has_schedule(&pid));
+
+    let config = client.get_schedule(&pid);
+    assert_eq!(config.unwrap().target_sequence, 100);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #29)")]
+fn test_schedule_rebalance_past_sequence_rejected() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    // Current sequence is 50; scheduling at 50 (not in the future) should fail
+    client.schedule_rebalance(&pid, &50);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #31)")]
+fn test_schedule_rebalance_already_exists() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    client.schedule_rebalance(&pid, &100);
+    // Second schedule on the same portfolio must fail
+    client.schedule_rebalance(&pid, &200);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #29)")]
+fn test_execute_scheduled_rebalance_premature() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    client.schedule_rebalance(&pid, &100);
+
+    // Current sequence is 50, target is 100 — must fail
+    let balances = Map::new(&env);
+    client.execute_scheduled_rebalance(&pid, &balances);
+}
+
+#[test]
+fn test_execute_scheduled_rebalance_on_time() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    client.schedule_rebalance(&pid, &100);
+
+    // Advance past the target sequence
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 100;
+        li.timestamp = 20_000;
+    });
+
+    let balances = Map::new(&env);
+    client.execute_scheduled_rebalance(&pid, &balances);
+
+    // Schedule must be consumed after successful execution
+    assert!(!client.has_schedule(&pid));
+    assert!(client.get_schedule(&pid).is_none());
+
+    // Verify the portfolio was actually rebalanced (last_rebalance updated)
+    let portfolio = client.get_portfolio(&pid);
+    assert_eq!(portfolio.last_rebalance, 20_000);
+}
+
+#[test]
+fn test_execute_scheduled_rebalance_after_target() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    client.schedule_rebalance(&pid, &100);
+
+    // Advance well past the target sequence
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 500;
+        li.timestamp = 30_000;
+    });
+
+    let balances = Map::new(&env);
+    // Should succeed — beyond target is fine
+    client.execute_scheduled_rebalance(&pid, &balances);
+    assert!(!client.has_schedule(&pid));
+}
+
+#[test]
+fn test_cancel_scheduled_rebalance() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    client.schedule_rebalance(&pid, &100);
+    assert!(client.has_schedule(&pid));
+
+    client.cancel_scheduled_rebalance(&pid);
+    assert!(!client.has_schedule(&pid));
+    assert!(client.get_schedule(&pid).is_none());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #30)")]
+fn test_cancel_scheduled_rebalance_not_found() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    // Cancel without a schedule must fail
+    client.cancel_scheduled_rebalance(&pid);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #30)")]
+fn test_execute_after_cancel() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    client.schedule_rebalance(&pid, &100);
+    client.cancel_scheduled_rebalance(&pid);
+
+    // Advance past target — but schedule was canceled
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 100;
+        li.timestamp = 20_000;
+    });
+
+    let balances = Map::new(&env);
+    client.execute_scheduled_rebalance(&pid, &balances);
+}
+
+#[test]
+fn test_has_schedule_and_get_schedule_no_schedule() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    assert!(!client.has_schedule(&pid));
+    assert!(client.get_schedule(&pid).is_none());
+}
+
+#[test]
+fn test_schedule_rebalance_steward_can_schedule() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    // Transfer stewardship to another address
+    let new_steward = Address::generate(&env);
+    client.transfer_stewardship(&pid, &new_steward);
+
+    // The new steward should be able to schedule
+    // (mock_all_auths() already mocks all signatures)
+    client.schedule_rebalance(&pid, &200);
+    assert!(client.has_schedule(&pid));
+}
+
+#[test]
+fn test_schedule_persisted_across_ledger_advances() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    client.schedule_rebalance(&pid, &100);
+
+    // Advance ledger but stay below target
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 75;
+    });
+
+    // Schedule must still exist
+    assert!(client.has_schedule(&pid));
+    let config = client.get_schedule(&pid).unwrap();
+    assert_eq!(config.target_sequence, 100);
+}
+
+#[test]
+fn test_reschedule_after_cancel() {
+    let env = Env::default();
+    let (client, _user, pid) = setup_scheduler_test(&env);
+
+    client.schedule_rebalance(&pid, &100);
+    client.cancel_scheduled_rebalance(&pid);
+
+    // After cancel, a new schedule should be allowed
+    client.schedule_rebalance(&pid, &200);
+    assert!(client.has_schedule(&pid));
+
+    let config = client.get_schedule(&pid).unwrap();
+    assert_eq!(config.target_sequence, 200);
+}

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -137,6 +137,7 @@ pub enum DataKey {
     LastTimestamp,
     DCAConfig(u64),
     NavHistory(u64),
+    ScheduleConfig(u64),
 }
 
 #[contracttype]
@@ -146,6 +147,17 @@ pub struct DCAConfig {
     pub amount: i128, // Fixed USDC amount per execution (in smallest units)
     pub interval: u64, // Execution interval in seconds
     pub next_execution: u64, // Timestamp of next scheduled execution
+}
+
+/// Configuration for a time-locked rebalance schedule.
+/// At most one pending schedule exists per portfolio.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ScheduleConfig {
+    /// Ledger sequence number after which execution is allowed.
+    pub target_sequence: u32,
+    /// Timestamp when the schedule was created.
+    pub created_at: u64,
 }
 
 
@@ -181,6 +193,9 @@ pub enum Error {
     InvalidAmount = 26,
     WithdrawFailed = 27,
     InvalidAllocationSum = 28,
+    ScheduleNotReady = 29,
+    NoScheduleFound = 30,
+    ScheduleAlreadyExists = 31,
 }
 
 #[contracttype]


### PR DESCRIPTION
Closes #956

## Summary

Implements **time-locked rebalance scheduling** in the Soroban smart contract. Portfolio owners can now schedule a rebalance at a future ledger sequence. Anyone can execute the scheduled rebalance once the target sequence is reached, and the owner can cancel a pending schedule at any time.

---

## What was added

### New module: `contracts/src/scheduler.rs`

Five public functions and two private event emitters:

| Function | Access | Description |
|---|---|---|
| `schedule_rebalance` | Owner / Steward | Schedule a rebalance at a future ledger sequence |
| `execute_scheduled_rebalance` | Anyone | Execute a scheduled rebalance after target sequence |
| `cancel_scheduled_rebalance` | Owner / Steward | Cancel a pending schedule |
| `has_schedule` | Anyone | Check if a schedule exists |
| `get_schedule` | Anyone | Get the current `ScheduleConfig` |

### New types in `contracts/src/types.rs`

- `DataKey::ScheduleConfig(u64)` — Storage key per portfolio
- `ScheduleConfig { target_sequence: u32, created_at: u64 }` — Schedule data
- `ScheduleNotReady = 29` — Premature execution or past-sequence scheduling
- `NoScheduleFound = 30` — No schedule exists for cancel/execute
- `ScheduleAlreadyExists = 31` — Duplicate schedule rejected

### Modified: `contracts/src/lib.rs`

- Added `mod scheduler;` declaration
- Added five contract methods delegating to `scheduler::` functions
- Added `skip_owner_auth: bool` parameter to `execute_rebalance_internal`, allowing scheduled rebalances to be executed by anyone while still requiring auth for manual rebalances

### Events emitted

| Event | Topic | Payload |
|---|---|---|
| `rebalance_scheduled` | `(Symbol("portfolio"), Symbol("rebalance_scheduled"))` | `(portfolio_id, target_sequence, created_at)` |
| `rebalance_canceled` | `(Symbol("portfolio"), Symbol("rebalance_canceled"))` | `(portfolio_id, target_sequence)` |

---

## Acceptance Criteria

- ✅ **Premature execution rejected** — `execute_scheduled_rebalance` returns `ScheduleNotReady` if `current_sequence < target_sequence`
- ✅ **Past-sequence scheduling rejected** — `schedule_rebalance` returns `ScheduleNotReady` if `target_sequence <= current_sequence`
- ✅ **Canceled schedules not executable** — `cancel_scheduled_rebalance` removes the storage entry; subsequent execute returns `NoScheduleFound`
- ✅ **At most one pending schedule per portfolio** — `schedule_rebalance` checks for existing schedule before creating; returns `ScheduleAlreadyExists`
- ✅ **Schedule cleanup on success** — Schedule removed from storage only after a successful rebalance (uses `?` operator — failed rebalances leave the schedule intact)
- ✅ **Events emitted** — `rebalance_scheduled` on schedule, `rebalance_canceled` on cancel

---

## Tests Added (13 tests)

| Test | Covers |
|---|---|
| `test_schedule_rebalance_success` | Basic schedule + `has_schedule`/`get_schedule` |
| `test_schedule_rebalance_past_sequence_rejected` | `target_sequence <= current` → `ScheduleNotReady` |
| `test_schedule_rebalance_already_exists` | Duplicate → `ScheduleAlreadyExists` |
| `test_execute_scheduled_rebalance_premature` | `current_sequence < target` → `ScheduleNotReady` |
| `test_execute_scheduled_rebalance_on_time` | Execute at target, schedule consumed, `last_rebalance` updated |
| `test_execute_scheduled_rebalance_after_target` | Execute well past target (still valid) |
| `test_cancel_scheduled_rebalance` | Cancel removes schedule, `has_schedule` returns false |
| `test_cancel_scheduled_rebalance_not_found` | Cancel without schedule → `NoScheduleFound` |
| `test_execute_after_cancel` | Execute after cancel → `NoScheduleFound` |
| `test_has_schedule_and_get_schedule_no_schedule` | Query functions return false/None when empty |
| `test_schedule_rebalance_steward_can_schedule` | Steward can schedule (auth delegation) |
| `test_schedule_persisted_across_ledger_advances` | Schedule survives ledger advancement |
| `test_reschedule_after_cancel` | Cancel then re-schedule works |

---

## Design Decisions

- **Cooldown bypass**: Scheduled rebalances pass `bypass_cooldown: true` to `execute_rebalance_internal`. Since the user explicitly chose a future time for execution, cooldown enforcement would defeat the purpose. If the scheduler and the user both want it at sequence N, it should fire.
- **Anyone can execute**: `skip_owner_auth: true` allows permissionless execution — any account can trigger the scheduled rebalance once the target sequence is reached.
- **Schedule survives failed rebalances**: The `?` operator ensures the schedule is only removed after a successful execution. If the rebalance fails (e.g., stale prices), the schedule remains and can be retried.
- **No upper bound on target_sequence**: A future PR may add a reasonable cap (e.g., 1 year of ledgers) to prevent near-permanent schedules.

---

## Files Changed

### New files
- `contracts/src/scheduler.rs` — Scheduler module (132 lines)

### Modified files
- `contracts/src/lib.rs` — Added `mod scheduler`, 5 contract methods, `skip_owner_auth` param (+60, -8)
- `contracts/src/types.rs` — `ScheduleConfig` struct, `DataKey::ScheduleConfig`, 3 error variants (+15, -0)
- `contracts/src/test.rs` — 13 unit tests (+217, -0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added time-locked portfolio rebalance scheduling for a future ledger sequence.
  * Authorized parties can create or cancel pending schedules.
  * Scheduled rebalances can be executed once ready, including by third parties.
  * Added status and schedule-detail queries for pending rebalances.
  * Added validation for duplicate, missing, or premature schedules.
  * Added scheduling and cancellation events for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->