### PR TITLE
feat(contracts): add two-step admin transfer (propose/accept)

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -67,6 +67,69 @@ impl PortfolioRebalancer {
         env.storage().instance().get(&DataKey::Admin).unwrap()
     }
 
+    /// Propose a new admin for the contract (two-step admin transfer, step 1).
+    ///
+    /// Only the current admin may call this. The proposed address is stored as
+    /// `PendingAdmin` and an `admin_transfer_proposed` event is emitted.  A
+    /// subsequent call from the current admin simply overwrites any prior
+    /// proposal with the new address.
+    pub fn propose_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        // Only the current admin is authorised to initiate a transfer.
+        let current_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        current_admin.require_auth();
+
+        // Store (or overwrite) the pending admin.
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingAdmin, &new_admin);
+
+        // Emit the proposal event so off-chain monitors can observe it.
+        env.events().publish(
+            (
+                symbol_short!("admin"),
+                Symbol::new(&env, "transfer_proposed"),
+            ),
+            (current_admin, new_admin),
+        );
+
+        Ok(())
+    }
+
+    /// Accept the pending admin transfer (two-step admin transfer, step 2).
+    ///
+    /// Only the address stored as `PendingAdmin` may call this.  On success
+    /// the stored `Admin` is replaced, `PendingAdmin` is cleared, and an
+    /// `admin_transferred` event is emitted.
+    pub fn accept_admin(env: Env) -> Result<(), Error> {
+        // There must be a pending proposal.
+        let pending_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(Error::NoPendingAdminTransfer)?;
+
+        // Only the pending admin is authorised to accept.
+        pending_admin.require_auth();
+
+        let previous_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+
+        // Finalise the transfer.
+        env.storage()
+            .instance()
+            .set(&DataKey::Admin, &pending_admin);
+
+        // Clear the pending slot so the value cannot be replayed.
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+
+        // Emit confirmation event.
+        env.events().publish(
+            (symbol_short!("admin"), Symbol::new(&env, "transferred")),
+            (previous_admin, pending_admin),
+        );
+
+        Ok(())
+    }
+
     pub fn create_portfolio(
         env: Env,
         user: Address,

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -2727,3 +2727,125 @@ fn test_benchmark_nav_operations() {
     std::println!("BENCHMARK_NAV_FULL_HISTORY_CPU: {}", cpu_full);
     std::println!("BENCHMARK_NAV_FULL_HISTORY_MEM: {}", mem_full);
 }
+
+// ── Two-step admin transfer tests (propose_admin / accept_admin) ────────────
+
+/// Happy path: admin proposes a new admin, new admin accepts, admin slot updated.
+#[test]
+fn test_propose_then_accept_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.initialize(&admin, &reflector_id);
+
+    // Step 1 – current admin proposes a new admin.
+    client.propose_admin(&new_admin);
+
+    // Admin slot must still be the original admin at this point.
+    assert_eq!(client.get_admin(), admin);
+
+    // Step 2 – proposed admin accepts.
+    client.accept_admin();
+
+    // Admin slot must now be the new admin.
+    assert_eq!(client.get_admin(), new_admin);
+
+    // Verify both events were emitted in the correct order.
+    let events = env.events().all();
+
+    let proposed_events: soroban_sdk::Vec<_> = events
+        .iter()
+        .filter(|e| {
+            // topic tuple is (symbol_short!("admin"), Symbol::new("transfer_proposed"))
+            e.topics.len() == 2
+                && e.topics.get(1).unwrap() == Symbol::new(&env, "transfer_proposed")
+        })
+        .collect();
+    assert_eq!(proposed_events.len(), 1, "admin_transfer_proposed event must be emitted once");
+
+    let transferred_events: soroban_sdk::Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.topics.len() == 2
+                && e.topics.get(1).unwrap() == Symbol::new(&env, "transferred")
+        })
+        .collect();
+    assert_eq!(transferred_events.len(), 1, "admin_transferred event must be emitted once");
+}
+
+/// Failure path: calling accept_admin without a prior propose must return
+/// NoPendingAdminTransfer (error code 29).
+#[test]
+fn test_accept_admin_without_propose_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    // No propose_admin has been called — accept_admin must fail.
+    let result = client.try_accept_admin();
+    assert_eq!(
+        result,
+        Err(Ok(Error::NoPendingAdminTransfer)),
+        "accept_admin without a prior propose must return NoPendingAdminTransfer"
+    );
+
+    // Admin slot must remain unchanged.
+    assert_eq!(client.get_admin(), admin);
+}
+
+/// Overwrite path: admin proposes address A, then overwrites with address B;
+/// only address B can accept, and the final admin is B.
+#[test]
+fn test_propose_then_overwrite_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+
+    let admin = Address::generate(&env);
+    let candidate_a = Address::generate(&env);
+    let candidate_b = Address::generate(&env);
+
+    client.initialize(&admin, &reflector_id);
+
+    // First proposal – candidate A.
+    client.propose_admin(&candidate_a);
+
+    // Overwrite – candidate B replaces candidate A.
+    client.propose_admin(&candidate_b);
+
+    // Two `transfer_proposed` events must have been emitted (one per propose call).
+    let events = env.events().all();
+    let proposed_events: soroban_sdk::Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.topics.len() == 2
+                && e.topics.get(1).unwrap() == Symbol::new(&env, "transfer_proposed")
+        })
+        .collect();
+    assert_eq!(proposed_events.len(), 2, "two transfer_proposed events must be emitted");
+
+    // Accepting must finalise to candidate B (the latest proposal).
+    client.accept_admin();
+
+    assert_eq!(
+        client.get_admin(),
+        candidate_b,
+        "final admin must be the last proposed address"
+    );
+}

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -137,6 +137,8 @@ pub enum DataKey {
     LastTimestamp,
     DCAConfig(u64),
     NavHistory(u64),
+    /// Holds the address of the next proposed admin until they call accept_admin.
+    PendingAdmin,
 }
 
 #[contracttype]
@@ -181,6 +183,8 @@ pub enum Error {
     InvalidAmount = 26,
     WithdrawFailed = 27,
     InvalidAllocationSum = 28,
+    /// Returned by accept_admin when there is no pending admin transfer in progress.
+    NoPendingAdminTransfer = 29,
 }
 
 #[contracttype]


### PR DESCRIPTION
Here's a PR description you can use:
  
  ────────────────────────────────────────────────────────────────────────────────────────
  
  feat(contracts): Two-step admin transfer (propose/accept)
  
  Summary
  
  Replaces the implicit single-step admin ownership model with a secure two-step
  propose/accept flow. The current admin proposes a successor; only that successor can
  finalise the transfer. This eliminates the risk of accidentally locking the contract by
  transferring admin rights to an invalid or uncontrolled address.
  
  Changes
  
  contracts/src/types.rs
  
  - Added DataKey::PendingAdmin — instance storage slot holding the
  proposed-but-not-yet-accepted admin address.
  - Added Error::NoPendingAdminTransfer = 29 — returned when accept_admin is called with
  no proposal in flight.
  
  contracts/src/lib.rs
  
  - propose_admin(new_admin) — callable only by the current admin. Stores new_admin as
  PendingAdmin (overwrites any prior proposal) and emits an (admin, transfer_proposed)
   event.
  - accept_admin() — callable only by the pending admin. Finalises the transfer, clears
  the PendingAdmin slot to prevent replay, and emits an (admin, transferred) event.
  
  contracts/src/test.rs
  
  - test_propose_then_accept_admin — full happy path; verifies admin slot, both events
  emitted.
  - test_accept_admin_without_propose_fails — asserts NoPendingAdminTransfer error and no
  change to admin slot.
  - test_propose_then_overwrite_admin — proposes A, overwrites with B, asserts two
  proposal events and final admin is B.
  
  Security properties
  
  ┌─────────────────────────────────┬───────────────────┐
  │ Property                        │ How it's enforced                             │
  ├──────────────────────────────────┼───────────────────────────────────────────────┤
  │ Only current admin can initiate  │ current_admin.require_auth() in propose_admin │
  ├──────────────────────────────────┼───────────────────────────────────────────────┤
  │ Only proposed address can accept │ pending_admin.require_auth() in accept_admin    │
  ├──────────────────────────────────┼─────────────────────────────────────────────────┤
  │                                         │ accept_admin                            │
  ├─────────────────────────────────────────┼─────────────────────────────────────────┤
  │ No replay after accept                  │ PendingAdmin slot removed on successful │
  │                                         │ accept_admin                            │
  ├─────────────────────────────────────────┼─────────────────────────────────────────┤
  │ Pending transfer can be safely          │ Re-calling propose_admin overwrites the │
  │ cancelled/overwritten                   │ stored value                            │
  └─────────────────────────────────────────┴─────────────────────────────────────────┘
  
  Testing
  
  Closes the three acceptance criteria scenarios: happy path, unauthorised accept
  rejection, and proposal overwrite.

closes #1146 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a two-step administrator transfer flow: the current administrator can propose a replacement, who must then accept the transfer.
  * New administrator changes and proposals emit events for off-chain monitoring.
  * New proposals replace any previously pending administrator proposal.

* **Bug Fixes**
  * Added clear error handling when an administrator transfer is accepted without an active proposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->