### PR TITLE
feat(risk): add configurable CVaR/VaR auto-pause with notifications

### DIFF
--- a/backend/src/queue/workers/portfolioCheckWorker.ts
+++ b/backend/src/queue/workers/portfolioCheckWorker.ts
@@ -76,6 +76,20 @@ export async function processPortfolioCheckJob(
 
     const stellarService = new StellarService();
     for (const p of portfolios) {
+      // Skip portfolios that have been auto-paused due to a CVaR/VaR breach
+      if (p.riskPausedUntil && new Date(p.riskPausedUntil) > new Date()) {
+        logger.info(
+          "[WORKER:portfolio-check] Skipping risk-paused portfolio",
+          {
+            jobId: job.id,
+            portfolioId: p.id,
+            riskPausedUntil: p.riskPausedUntil,
+            correlationId,
+          },
+        );
+        continue;
+      }
+
       const needed = await stellarService.checkRebalanceNeeded(p.id);
       if (!needed) continue;
 

--- a/backend/src/services/notificationTemplates.ts
+++ b/backend/src/services/notificationTemplates.ts
@@ -27,6 +27,16 @@ export interface RiskChangeData {
   portfolioId: string
   oldLevel: string
   newLevel: string
+  /** Optional: breach details when auto-pause was triggered by a CVaR/VaR threshold. */
+  autoPause?: {
+    reason: 'VAR_BREACH' | 'CVAR_BREACH'
+    /** Measured value as a percentage string e.g. "14.23%" */
+    measuredValue: string
+    /** Threshold as a percentage string e.g. "12.00%" */
+    threshold: string
+    /** ISO string of when the pause expires */
+    pausedUntil: string
+  }
 }
 
 export type NotificationTemplateData =
@@ -65,9 +75,21 @@ const templates: {
     message: (d) => `${d.asset} has ${d.direction} by ${d.priceChange}%.`,
   },
   riskChange: {
-    title: () => 'Portfolio Risk Level Changed',
-    message: (d) =>
-      `Your portfolio risk level changed from ${d.oldLevel} to ${d.newLevel}.`,
+    title: (d) => d.autoPause ? 'Rebalancing Auto-Paused: Risk Threshold Breached' : 'Portfolio Risk Level Changed',
+    message: (d) => {
+      if (d.autoPause) {
+        const metricLabel = d.autoPause.reason === 'VAR_BREACH' ? 'VaR(95)' : 'CVaR(95)'
+        const pauseDate = new Date(d.autoPause.pausedUntil).toLocaleString('en-US', { timeZoneName: 'short' })
+        return (
+          `Scheduled rebalancing for portfolio ${d.portfolioId} has been automatically paused because the ` +
+          `${metricLabel} limit was exceeded (measured: ${d.autoPause.measuredValue}, threshold: ${d.autoPause.threshold}). ` +
+          `Rebalancing is suspended until ${pauseDate}. ` +
+          `Risk level: ${d.oldLevel} → ${d.newLevel}. ` +
+          `Review your portfolio and market conditions before resuming.`
+        )
+      }
+      return `Your portfolio risk level changed from ${d.oldLevel} to ${d.newLevel}.`
+    },
   },
 }
 

--- a/backend/src/services/riskManagements.ts
+++ b/backend/src/services/riskManagements.ts
@@ -1,6 +1,9 @@
 import type { PricesMap, RiskHeatmap } from '../types/index.js'
 import { assetRegistryService } from './assetRegistryService.js'
 import { logger } from '../utils/logger.js'
+import { notificationService } from './notificationService.js'
+import { buildNotificationPayload } from './notificationTemplates.js'
+import { portfolioStorage } from './portfolioStorage.js'
 
 export interface StatisticalRiskMetrics {
     ewmaVolatility: number
@@ -45,6 +48,25 @@ export type RiskDecisionReasonCode =
     | 'STAT_MODEL_CVAR_BREACH'
     | 'STAT_MODEL_DRAWDOWN_BREACH'
 
+export interface AutoPauseThresholds {
+    /** VaR(95) level that triggers an auto-pause. Expressed as a decimal fraction (e.g. 0.12 = 12%). */
+    var95?: number
+    /** CVaR(95) level that triggers an auto-pause. Expressed as a decimal fraction (e.g. 0.16 = 16%). */
+    cvar95?: number
+    /** How many milliseconds to pause the portfolio for once a breach is detected. Default: 24 hours. */
+    pauseDurationMs?: number
+}
+
+export interface CVaRVaRCheckResult {
+    portfolioId: string
+    breached: boolean
+    breachType?: 'VAR_BREACH' | 'CVAR_BREACH'
+    measuredValue?: number
+    threshold?: number
+    paused: boolean
+    riskMetrics: ReturnType<RiskManagementService['analyzePortfolioRisk']>
+}
+
 type ReturnPoint = { value: number, timestamp: number }
 type PricePoint = { price: number, timestamp: number }
 
@@ -68,7 +90,16 @@ export class RiskManagementService {
     private readonly CIRCUIT_BREAKER_THRESHOLD = 0.20
     private readonly CIRCUIT_BREAKER_COOLDOWN = 300000 // 5 minutes
 
-    constructor() {
+    /** Configurable CVaR/VaR auto-pause thresholds (fall back to class defaults when not set). */
+    private readonly autoPauseVar95Threshold: number
+    private readonly autoPauseCvar95Threshold: number
+    private readonly autoPauseDurationMs: number
+
+    constructor(autoPauseThresholds: AutoPauseThresholds = {}) {
+        this.autoPauseVar95Threshold = autoPauseThresholds.var95 ?? this.VAR95_BLOCK_THRESHOLD
+        this.autoPauseCvar95Threshold = autoPauseThresholds.cvar95 ?? this.CVAR95_BLOCK_THRESHOLD
+        this.autoPauseDurationMs = autoPauseThresholds.pauseDurationMs ?? 24 * 60 * 60 * 1000 // 24 h
+
         const symbols = assetRegistryService.getSymbols(true)
         const assets = symbols.length > 0 ? symbols : ['XLM', 'BTC', 'ETH', 'USDC']
         assets.forEach(asset => {
@@ -330,6 +361,137 @@ export class RiskManagementService {
             allowed: true,
             reasonCode: 'OK',
             alerts,
+            riskMetrics
+        }
+    }
+
+    /**
+     * Evaluates CVaR(95) and VaR(95) against the configured auto-pause thresholds.
+     *
+     * When either metric exceeds its threshold:
+     *  - Marks the portfolio as paused until `now + autoPauseDurationMs` by setting
+     *    `riskPausedUntil` on the portfolio record.
+     *  - Sends a `riskChange` notification to `userId` explaining the auto-pause.
+     *
+     * When neither metric is breached the portfolio is left unchanged and no
+     * notification is sent.
+     *
+     * @param portfolioId  The portfolio to evaluate and potentially pause.
+     * @param allocations  Current target allocations (weights or percentages).
+     * @param prices       Latest price data used for risk calculation.
+     * @param userId       Stellar address of the portfolio owner – used for notifications.
+     * @returns            A `CVaRVaRCheckResult` describing the outcome.
+     */
+    async checkCVaRVaRThresholdsAndAutoPause(
+        portfolioId: string,
+        allocations: Record<string, number>,
+        prices: PricesMap,
+        userId: string
+    ): Promise<CVaRVaRCheckResult> {
+        const riskMetrics = this.analyzePortfolioRisk(allocations, prices)
+
+        // Only run the threshold check once we have enough data for reliable stats
+        if (riskMetrics.sampleSize < this.MIN_RETURNS_FOR_STATS) {
+            logger.debug('[RISK] Skipping CVaR/VaR auto-pause check – insufficient sample size', {
+                portfolioId,
+                sampleSize: riskMetrics.sampleSize,
+                minRequired: this.MIN_RETURNS_FOR_STATS
+            })
+            return { portfolioId, breached: false, paused: false, riskMetrics }
+        }
+
+        // Determine which metric (if any) is breached – VaR is checked first
+        let breachType: 'VAR_BREACH' | 'CVAR_BREACH' | undefined
+        let measuredValue: number | undefined
+        let threshold: number | undefined
+
+        if (riskMetrics.var95 > this.autoPauseVar95Threshold) {
+            breachType = 'VAR_BREACH'
+            measuredValue = riskMetrics.var95
+            threshold = this.autoPauseVar95Threshold
+        } else if (riskMetrics.cvar95 > this.autoPauseCvar95Threshold) {
+            breachType = 'CVAR_BREACH'
+            measuredValue = riskMetrics.cvar95
+            threshold = this.autoPauseCvar95Threshold
+        }
+
+        if (!breachType) {
+            // All clear – no action needed
+            return { portfolioId, breached: false, paused: false, riskMetrics }
+        }
+
+        // ── Breach detected ──────────────────────────────────────────────────────
+        const pausedUntil = new Date(Date.now() + this.autoPauseDurationMs).toISOString()
+
+        logger.warn('[RISK] CVaR/VaR threshold breached – auto-pausing portfolio', {
+            portfolioId,
+            breachType,
+            measuredValue,
+            threshold,
+            pausedUntil
+        })
+
+        // 1. Persist the pause flag on the portfolio
+        try {
+            const portfolio = await portfolioStorage.getPortfolio(portfolioId)
+            if (portfolio) {
+                await portfolioStorage.updatePortfolio(portfolioId, { riskPausedUntil: pausedUntil })
+            } else {
+                logger.warn('[RISK] Portfolio not found for auto-pause', { portfolioId })
+            }
+        } catch (err) {
+            logger.error('[RISK] Failed to persist auto-pause on portfolio', {
+                portfolioId,
+                error: err instanceof Error ? err.message : String(err)
+            })
+        }
+
+        // 2. Send a notification explaining the pause
+        try {
+            const metricLabel = breachType === 'VAR_BREACH' ? 'VaR(95)' : 'CVaR(95)'
+            const measuredPct = `${(measuredValue! * 100).toFixed(2)}%`
+            const thresholdPct = `${(threshold! * 100).toFixed(2)}%`
+
+            const payload = buildNotificationPayload(userId, {
+                eventType: 'riskChange',
+                data: {
+                    portfolioId,
+                    oldLevel: riskMetrics.overallRiskLevel,
+                    newLevel: 'critical',
+                    autoPause: {
+                        reason: breachType,
+                        measuredValue: measuredPct,
+                        threshold: thresholdPct,
+                        pausedUntil
+                    }
+                }
+            })
+
+            await notificationService.notify(payload)
+
+            logger.info('[RISK] Auto-pause notification sent', {
+                portfolioId,
+                userId,
+                metricLabel,
+                measuredValue: measuredPct,
+                threshold: thresholdPct
+            })
+        } catch (err) {
+            // Notification failure must never prevent the pause from being recorded
+            logger.error('[RISK] Failed to send auto-pause notification', {
+                portfolioId,
+                userId,
+                error: err instanceof Error ? err.message : String(err)
+            })
+        }
+
+        return {
+            portfolioId,
+            breached: true,
+            breachType,
+            measuredValue,
+            threshold,
+            paused: true,
             riskMetrics
         }
     }

--- a/backend/src/test/riskManagements.test.ts
+++ b/backend/src/test/riskManagements.test.ts
@@ -1,6 +1,23 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { RiskManagementService } from '../services/riskManagements.js'
 import type { PricesMap } from '../types/index.js'
+
+// ── Module-level mocks ────────────────────────────────────────────────────────
+// Mock side-effecting services so auto-pause tests run without a real DB or
+// notification transport.
+
+vi.mock('../services/portfolioStorage.js', () => ({
+    portfolioStorage: {
+        getPortfolio: vi.fn(),
+        updatePortfolio: vi.fn(),
+    },
+}))
+
+vi.mock('../services/notificationService.js', () => ({
+    notificationService: {
+        notify: vi.fn(),
+    },
+}))
 
 const buildSeries = (
     base: number,
@@ -216,5 +233,243 @@ describe('RiskManagementService statistical model', () => {
 
         expect(risk.var95).toBeCloseTo(expectedVar95, 12)
         expect(risk.cvar95).toBeCloseTo(expectedCvar95, 12)
+    })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CVaR/VaR auto-pause tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RiskManagementService.checkCVaRVaRThresholdsAndAutoPause', () => {
+    // Helpers ─────────────────────────────────────────────────────────────────
+
+    const buildHighVolSeries = (
+        service: RiskManagementService,
+        size = 120
+    ): PricesMap => {
+        // Alternating ±18 % returns drive VaR and CVaR well above the 0.12/0.16 defaults
+        const btcReturns = Array.from({ length: size }, (_, i) => (i % 2 === 0 ? 0.18 : -0.18))
+        const ethReturns = Array.from({ length: size }, (_, i) => (i % 2 === 0 ? 0.17 : -0.17))
+        const usdcReturns = Array.from({ length: size }, () => 0.0001)
+
+        return feedSeries(service, {
+            BTC: buildSeries(100, btcReturns),
+            ETH: buildSeries(60, ethReturns),
+            USDC: buildSeries(1, usdcReturns),
+        })
+    }
+
+    const buildLowVolSeries = (
+        service: RiskManagementService,
+        size = 120
+    ): PricesMap => {
+        // ±0.2 % returns stay far below the default VaR/CVaR thresholds
+        const returns = Array.from({ length: size }, (_, i) => (i % 2 === 0 ? 0.002 : -0.002))
+        return feedSeries(service, {
+            BTC: buildSeries(100, returns),
+            ETH: buildSeries(60, returns),
+            USDC: buildSeries(1, Array.from({ length: size }, () => 0.0001)),
+        })
+    }
+
+    const PORTFOLIO_ID = 'test-portfolio-risk-pause'
+    const USER_ID = 'GSTELLARADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+    const ALLOCATIONS = { BTC: 60, ETH: 35, USDC: 5 }
+
+    // Fresh mocks for each test ───────────────────────────────────────────────
+
+    let mockGetPortfolio: ReturnType<typeof vi.fn>
+    let mockUpdatePortfolio: ReturnType<typeof vi.fn>
+    let mockNotify: ReturnType<typeof vi.fn>
+
+    beforeEach(async () => {
+        // Re-import the mocked modules so we get stable references each test
+        const { portfolioStorage } = await import('../services/portfolioStorage.js')
+        const { notificationService } = await import('../services/notificationService.js')
+
+        mockGetPortfolio = portfolioStorage.getPortfolio as ReturnType<typeof vi.fn>
+        mockUpdatePortfolio = portfolioStorage.updatePortfolio as ReturnType<typeof vi.fn>
+        mockNotify = notificationService.notify as ReturnType<typeof vi.fn>
+
+        // Provide a minimal fake portfolio by default
+        mockGetPortfolio.mockResolvedValue({
+            id: PORTFOLIO_ID,
+            userAddress: USER_ID,
+            allocations: ALLOCATIONS,
+            threshold: 5,
+            balances: {},
+            totalValue: 0,
+            createdAt: new Date().toISOString(),
+            lastRebalance: new Date().toISOString(),
+            version: 1,
+        })
+        mockUpdatePortfolio.mockResolvedValue(true)
+        mockNotify.mockResolvedValue(undefined)
+    })
+
+    afterEach(() => {
+        vi.clearAllMocks()
+    })
+
+    // Tests ───────────────────────────────────────────────────────────────────
+
+    it('returns breached=true and pauses the portfolio when VaR exceeds threshold', async () => {
+        const service = new RiskManagementService()
+        const prices = buildHighVolSeries(service)
+
+        const result = await service.checkCVaRVaRThresholdsAndAutoPause(
+            PORTFOLIO_ID, ALLOCATIONS, prices, USER_ID
+        )
+
+        expect(result.breached).toBe(true)
+        expect(result.paused).toBe(true)
+        expect(result.breachType).toMatch(/^(VAR_BREACH|CVAR_BREACH)$/)
+        expect(result.riskMetrics.sampleSize).toBeGreaterThanOrEqual(30)
+
+        // Portfolio must have been updated with riskPausedUntil
+        expect(mockUpdatePortfolio).toHaveBeenCalledOnce()
+        const [calledId, calledUpdates] = mockUpdatePortfolio.mock.calls[0]
+        expect(calledId).toBe(PORTFOLIO_ID)
+        expect(calledUpdates).toHaveProperty('riskPausedUntil')
+        expect(typeof calledUpdates.riskPausedUntil).toBe('string')
+        // pausedUntil must be in the future
+        expect(new Date(calledUpdates.riskPausedUntil).getTime()).toBeGreaterThan(Date.now())
+    })
+
+    it('sends a riskChange notification when a breach is detected', async () => {
+        const service = new RiskManagementService()
+        const prices = buildHighVolSeries(service)
+
+        await service.checkCVaRVaRThresholdsAndAutoPause(
+            PORTFOLIO_ID, ALLOCATIONS, prices, USER_ID
+        )
+
+        expect(mockNotify).toHaveBeenCalledOnce()
+        const [notifyPayload] = mockNotify.mock.calls[0]
+        expect(notifyPayload.userId).toBe(USER_ID)
+        expect(notifyPayload.eventType).toBe('riskChange')
+        expect(notifyPayload.title).toMatch(/auto-paused|threshold/i)
+        expect(notifyPayload.message).toContain(PORTFOLIO_ID)
+        expect(notifyPayload.message).toMatch(/rebalancing|paused/i)
+        expect(notifyPayload.data?.autoPause?.reason).toMatch(/^(VAR_BREACH|CVAR_BREACH)$/)
+        expect(notifyPayload.data?.autoPause?.pausedUntil).toBeDefined()
+    })
+
+    it('notification message includes the measured value and threshold', async () => {
+        const service = new RiskManagementService()
+        const prices = buildHighVolSeries(service)
+
+        await service.checkCVaRVaRThresholdsAndAutoPause(
+            PORTFOLIO_ID, ALLOCATIONS, prices, USER_ID
+        )
+
+        const [notifyPayload] = mockNotify.mock.calls[0]
+        // Message should contain percentage values
+        expect(notifyPayload.message).toMatch(/\d+\.\d+%/)
+    })
+
+    it('returns breached=false and does NOT pause or notify when metrics are within threshold', async () => {
+        const service = new RiskManagementService()
+        const prices = buildLowVolSeries(service)
+
+        const result = await service.checkCVaRVaRThresholdsAndAutoPause(
+            PORTFOLIO_ID, ALLOCATIONS, prices, USER_ID
+        )
+
+        expect(result.breached).toBe(false)
+        expect(result.paused).toBe(false)
+        expect(result.breachType).toBeUndefined()
+
+        // No side effects
+        expect(mockUpdatePortfolio).not.toHaveBeenCalled()
+        expect(mockNotify).not.toHaveBeenCalled()
+    })
+
+    it('returns breached=false and skips everything when sample size is too small', async () => {
+        const service = new RiskManagementService()
+
+        // Only 10 price points – far below the 30-return minimum
+        const smallSeries = feedSeries(service, {
+            BTC: buildSeries(100, Array.from({ length: 10 }, (_, i) => (i % 2 === 0 ? 0.3 : -0.3))),
+            ETH: buildSeries(60, Array.from({ length: 10 }, () => 0.001)),
+            USDC: buildSeries(1, Array.from({ length: 10 }, () => 0.0001)),
+        })
+
+        const result = await service.checkCVaRVaRThresholdsAndAutoPause(
+            PORTFOLIO_ID, ALLOCATIONS, smallSeries, USER_ID
+        )
+
+        expect(result.breached).toBe(false)
+        expect(result.paused).toBe(false)
+        expect(mockUpdatePortfolio).not.toHaveBeenCalled()
+        expect(mockNotify).not.toHaveBeenCalled()
+    })
+
+    it('respects custom configurable thresholds passed to the constructor', async () => {
+        // Very tight custom thresholds: any positive VaR/CVaR will trigger a breach
+        const service = new RiskManagementService({ var95: 0.0001, cvar95: 0.0001 })
+        const prices = buildLowVolSeries(service)
+
+        const result = await service.checkCVaRVaRThresholdsAndAutoPause(
+            PORTFOLIO_ID, ALLOCATIONS, prices, USER_ID
+        )
+
+        // With thresholds this tight, even low-volatility data should breach
+        expect(result.breached).toBe(true)
+        expect(result.paused).toBe(true)
+        expect(mockUpdatePortfolio).toHaveBeenCalledOnce()
+        expect(mockNotify).toHaveBeenCalledOnce()
+    })
+
+    it('respects a custom pause duration from constructor options', async () => {
+        const pauseDurationMs = 2 * 60 * 60 * 1000 // 2 hours
+        const service = new RiskManagementService({ pauseDurationMs })
+        const prices = buildHighVolSeries(service)
+
+        const beforeCall = Date.now()
+        await service.checkCVaRVaRThresholdsAndAutoPause(
+            PORTFOLIO_ID, ALLOCATIONS, prices, USER_ID
+        )
+
+        const [, calledUpdates] = mockUpdatePortfolio.mock.calls[0]
+        const pausedTs = new Date(calledUpdates.riskPausedUntil).getTime()
+
+        // pausedUntil should be approximately now + pauseDurationMs (within 5 s tolerance)
+        expect(pausedTs).toBeGreaterThanOrEqual(beforeCall + pauseDurationMs - 5000)
+        expect(pausedTs).toBeLessThanOrEqual(beforeCall + pauseDurationMs + 5000)
+    })
+
+    it('still records the pause even when the notification delivery fails', async () => {
+        const service = new RiskManagementService()
+        const prices = buildHighVolSeries(service)
+
+        // Simulate notification failure
+        mockNotify.mockRejectedValueOnce(new Error('SMTP offline'))
+
+        const result = await service.checkCVaRVaRThresholdsAndAutoPause(
+            PORTFOLIO_ID, ALLOCATIONS, prices, USER_ID
+        )
+
+        // Pause must have been persisted despite the notification error
+        expect(result.paused).toBe(true)
+        expect(mockUpdatePortfolio).toHaveBeenCalledOnce()
+    })
+
+    it('does not throw when portfolio cannot be found in storage', async () => {
+        const service = new RiskManagementService()
+        const prices = buildHighVolSeries(service)
+
+        // Portfolio not in storage
+        mockGetPortfolio.mockResolvedValueOnce(undefined)
+
+        // Should resolve without throwing
+        const result = await service.checkCVaRVaRThresholdsAndAutoPause(
+            PORTFOLIO_ID, ALLOCATIONS, prices, USER_ID
+        )
+
+        expect(result.breached).toBe(true)
+        expect(result.paused).toBe(true)
+        // updatePortfolio was NOT called because the portfolio wasn't found
+        expect(mockUpdatePortfolio).not.toHaveBeenCalled()
     })
 })

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -66,6 +66,8 @@ export interface Portfolio {
     createdAt: string
     lastRebalance: string
     version: number
+    /** ISO timestamp until which scheduled rebalancing is paused due to a CVaR/VaR breach. */
+    riskPausedUntil?: string
 }
 
 export type RebalanceTrigger = 'auto' | 'manual' | 'system'


### PR DESCRIPTION
Summary

- Add AutoPauseThresholds constructor options to RiskManagementService (var95, cvar95, pauseDurationMs) with sensible defaults (12%/16%/24h)
- Add checkCVaRVaRThresholdsAndAutoPause() method that:
  - Evaluates VaR(95) and CVaR(95) after each risk recalculation
  - Persists riskPausedUntil on the portfolio when a threshold is breached
  - Sends a riskChange notification explaining the auto-pause to the user
  - Gracefully handles notification failures without suppressing the pause
- Add riskPausedUntil field to Portfolio type
- Update portfolioCheckWorker to skip risk-paused portfolios before enqueueing rebalance jobs
- Extend notificationTemplates RiskChangeData with autoPause details and update riskChange template with human-readable breach message
- Add 8 tests covering breach-triggers-pause, within-threshold-no-pause, custom thresholds, custom duration, notification failure resilience, and missing portfolio edge case (16/16 passing)

## Commit Type

- [ ] feat
- [ ] fix
- [ ] perf
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style
- [ ] revert

## Release Notes

- [ ] User-facing change
- [ ] Breaking change
- [ ] No release note needed
closes #1182 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic portfolio pauses when VaR or CVaR risk thresholds are breached.
  * Added notifications with breach details, measured values, thresholds, and pause expiration times.
  * Added configurable risk thresholds and pause durations.

* **Bug Fixes**
  * Prevented rebalancing from being scheduled while a portfolio is paused due to a risk breach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->