### PR TITLE
[FEATURE] Implement contract-level stop-loss per asset (#960)

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -9,6 +9,7 @@ use soroban_sdk::{
 mod nav;
 mod portfolio;
 mod reflector;
+mod stop_loss;
 mod strategies;
 #[cfg(test)]
 mod test;
@@ -315,6 +316,31 @@ impl PortfolioRebalancer {
 
     pub fn execute_dca(env: Env, portfolio_id: u64) -> Result<(), Error> {
         dca::execute_dca(&env, portfolio_id)
+    }
+
+    pub fn set_stop_loss(
+        env: Env,
+        portfolio_id: u64,
+        asset: Address,
+        price: i128,
+    ) -> Result<(), Error> {
+        stop_loss::set_stop_loss(&env, portfolio_id, asset, price)
+    }
+
+    pub fn remove_stop_loss(
+        env: Env,
+        portfolio_id: u64,
+        asset: Address,
+    ) -> Result<(), Error> {
+        stop_loss::remove_stop_loss(&env, portfolio_id, asset)
+    }
+
+    pub fn get_stop_loss(
+        env: Env,
+        portfolio_id: u64,
+        asset: Address,
+    ) -> Option<i128> {
+        stop_loss::get_stop_loss(&env, portfolio_id, asset)
     }
 
     pub fn transfer_stewardship(
@@ -699,7 +725,21 @@ impl PortfolioRebalancer {
             .unwrap();
         let reflector_client = ReflectorClient::new(env, &reflector_address);
 
-        let preview = portfolio::build_rebalance_preview(env, &portfolio, &reflector_client)?;
+        let triggered = stop_loss::check_stop_losses(env, portfolio_id, &portfolio, &reflector_client);
+        let has_triggered = triggered.len() > 0;
+        let portfolio_for_preview = if has_triggered {
+            let adjusted = stop_loss::apply_stop_loss_adjustments(env, &triggered, &portfolio.target_allocations);
+            for (asset, price) in triggered.iter() {
+                stop_loss::emit_stop_loss_triggered(env, portfolio_id, asset.clone(), price);
+            }
+            let mut p = portfolio.clone();
+            p.target_allocations = adjusted;
+            p
+        } else {
+            portfolio.clone()
+        };
+
+        let preview = portfolio::build_rebalance_preview(env, &portfolio_for_preview, &reflector_client)?;
 
         for (asset, _) in portfolio.target_allocations.iter() {
             if let Some(reason) = preview.skip_reasons.get(asset) {

--- a/contracts/src/stop_loss.rs
+++ b/contracts/src/stop_loss.rs
@@ -1,0 +1,147 @@
+use soroban_sdk::{Address, Env, Map, Symbol, Vec};
+use crate::reflector::ReflectorClient;
+use crate::types::*;
+
+pub fn set_stop_loss(
+    env: &Env,
+    portfolio_id: u64,
+    asset: Address,
+    price: i128,
+) -> Result<(), Error> {
+    let portfolio = super::PortfolioRebalancer::load_portfolio(env, portfolio_id)?;
+    let steward = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Steward(portfolio_id))
+        .unwrap_or(portfolio.user.clone());
+    steward.require_auth();
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::StopLoss(portfolio_id, asset.clone()), &price);
+
+    env.events().publish(
+        (Symbol::new(env, "stop_loss"), Symbol::new(env, "set")),
+        (portfolio_id, asset, price),
+    );
+    Ok(())
+}
+
+pub fn remove_stop_loss(
+    env: &Env,
+    portfolio_id: u64,
+    asset: Address,
+) -> Result<(), Error> {
+    let portfolio = super::PortfolioRebalancer::load_portfolio(env, portfolio_id)?;
+    let steward = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Steward(portfolio_id))
+        .unwrap_or(portfolio.user.clone());
+    steward.require_auth();
+
+    env.storage()
+        .persistent()
+        .remove(&DataKey::StopLoss(portfolio_id, asset.clone()));
+
+    env.events().publish(
+        (Symbol::new(env, "stop_loss"), Symbol::new(env, "removed")),
+        (portfolio_id, asset),
+    );
+    Ok(())
+}
+
+pub fn get_stop_loss(
+    env: &Env,
+    portfolio_id: u64,
+    asset: Address,
+) -> Option<i128> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::StopLoss(portfolio_id, asset))
+}
+
+pub fn check_stop_losses(
+    env: &Env,
+    portfolio_id: u64,
+    portfolio: &Portfolio,
+    reflector_client: &ReflectorClient,
+) -> Vec<(Address, i128)> {
+    let mut triggered: Vec<(Address, i128)> = Vec::new(env);
+
+    for (asset, _) in portfolio.target_allocations.iter() {
+        if let Some(stop_loss_price) = get_stop_loss(env, portfolio_id, asset.clone()) {
+            if let Some(price_data) =
+                reflector_client.lastprice(&crate::reflector::Asset::Stellar(asset.clone()))
+            {
+                if price_data.price < stop_loss_price {
+                    triggered.push_back((asset.clone(), price_data.price));
+                }
+            }
+        }
+    }
+
+    triggered
+}
+
+pub fn apply_stop_loss_adjustments(
+    _env: &Env,
+    triggered: &Vec<(Address, i128)>,
+    target_allocations: &Map<Address, u32>,
+) -> Map<Address, u32> {
+    let mut adjusted = target_allocations.clone();
+    let mut freed_allocation: u32 = 0;
+
+    for (asset, _) in triggered.iter() {
+        let target = adjusted.get(asset.clone()).unwrap_or(0);
+        if target > 0 {
+            freed_allocation += target;
+            adjusted.set(asset.clone(), 0);
+        }
+    }
+
+    if freed_allocation > 0 {
+        let mut remaining_total: u32 = 0;
+        for (_, pct) in adjusted.iter() {
+            if pct > 0 {
+                remaining_total += pct;
+            }
+        }
+
+        if remaining_total > 0 {
+            let mut distributed: u32 = 0;
+            let mut last_asset: Option<Address> = None;
+
+            for (asset, pct) in adjusted.iter() {
+                if pct > 0 {
+                    let extra = (freed_allocation * pct) / remaining_total;
+                    adjusted.set(asset.clone(), pct + extra);
+                    distributed += extra;
+                    last_asset = Some(asset.clone());
+                }
+            }
+
+            let remainder = freed_allocation - distributed;
+            if remainder > 0 {
+                if let Some(last) = last_asset {
+                    let current = adjusted.get(last.clone()).unwrap_or(0);
+                    adjusted.set(last, current + remainder);
+                }
+            }
+        }
+    }
+
+    adjusted
+}
+
+pub fn emit_stop_loss_triggered(
+    env: &Env,
+    portfolio_id: u64,
+    asset: Address,
+    current_price: i128,
+) {
+    env.events().publish(
+        (Symbol::new(env, "stop_loss"), Symbol::new(env, "triggered")),
+        (portfolio_id, asset, current_price),
+    );
+}

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -137,6 +137,7 @@ pub enum DataKey {
     LastTimestamp,
     DCAConfig(u64),
     NavHistory(u64),
+    StopLoss(u64, Address),
 }
 
 #[contracttype]


### PR DESCRIPTION
## Summary

Implements **contract-level stop-loss per asset** for the portfolio rebalancer. Portfolio owners can set stop-loss prices on individual assets. During rebalance execution, if any asset price falls below its stop-loss threshold, the asset allocation is automatically zeroed out and redistributed proportionally to remaining assets.

Closes #960

## Changes

### New file: `contracts/src/stop_loss.rs`
- `set_stop_loss()` — Owner/steward sets a stop-loss price for an asset (emits `stop_loss`/`set` event)
- `remove_stop_loss()` — Owner/steward removes a stop-loss (emits `stop_loss`/`removed` event)
- `get_stop_loss()` — Public view function to query stop-loss price
- `check_stop_losses()` — Checks all portfolio assets against their stop-loss prices via reflector oracle
- `apply_stop_loss_adjustments()` — Zeroes out triggered asset allocations and redistributes proportionally
- `emit_stop_loss_triggered()` — Emits `stop_loss`/`triggered` event with `(portfolio_id, asset, current_price)`

### Modified: `contracts/src/types.rs`
- Added `DataKey::StopLoss(u64, Address)` variant for persistent per-asset per-portfolio storage

### Modified: `contracts/src/lib.rs`
- Added `mod stop_loss;` declaration
- Exposed public methods: `set_stop_loss`, `remove_stop_loss`, `get_stop_loss`
- Integrated stop-loss check into `execute_rebalance_internal`:
  - Checks all stop-losses before building rebalance preview
  - If triggered: creates adjusted target allocations (zeroed triggered assets, redistributed freed allocation)
  - Emits `StopLossTriggered` event for each triggered asset
  - Rebalance preview and trade execution use the adjusted allocations

## Behavior details

1. **Stop-loss check** occurs automatically in `execute_rebalance_internal` — no separate call required
2. **When triggered**: the asset's target allocation is set to 0%, and the freed allocation percentage is distributed proportionally to remaining assets based on their existing targets
3. **Redistribution** preserves the `ALLOCATION_DENOMINATOR` (10000 bps) invariant with correct remainder handling
4. **Original target allocations** in persistent storage are NOT modified — the stop-loss is a runtime guard
5. **Stop-loss persists** across rebalances — owner must call `remove_stop_loss` to clear it
6. **Events** are emitted for every stop-loss lifecycle action (set, removed, triggered)

## Testing

- Code compiles successfully with `cargo build`
- Test compilation blocked by pre-existing soroban-env-host/ed25519-dalek dependency incompatibility in this environment (not related to these changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable stop-loss support per portfolio and per asset.
  * Added endpoints to set, remove, and read stop-loss prices.
  * Stop-loss conditions are evaluated during rebalance preparation, and target allocations are adjusted to account for triggered assets.
  * Added stop-loss trigger events that include the current asset price.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->