### PR TITLE
feat: post-deploy capability verification, RDS retention, CloudFront invalidation, indexer dashboard

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,0 +1,93 @@
+name: Frontend Deploy
+
+# Uploads the built frontend to S3 and automatically invalidates the CloudFront
+# distribution so users see updated content immediately after every deploy (#1486).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-deploy.yml"
+  workflow_dispatch:
+    inputs:
+      invalidation_paths:
+        description: "CloudFront paths to invalidate (space-separated, default: /*)"
+        required: false
+        default: "/*"
+
+concurrency:
+  group: frontend-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write  # required for OIDC-based AWS credential exchange
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: production
+
+    env:
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+      S3_BUCKET: ${{ secrets.FRONTEND_S3_BUCKET }}
+      SMOKE_CHECK_URL: ${{ secrets.FRONTEND_CDN_URL }}
+      INVALIDATION_PATHS: ${{ github.event.inputs.invalidation_paths || '/*' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build --workspace=frontend
+        env:
+          VITE_CONTRACT_ADDRESS: ${{ secrets.VITE_CONTRACT_ADDRESS }}
+          VITE_NETWORK: ${{ secrets.VITE_NETWORK }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload frontend assets to S3
+        run: |
+          aws s3 sync frontend/dist/ "s3://${S3_BUCKET}/" \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html"
+
+          # index.html must never be cached so browsers always fetch the latest entry point.
+          aws s3 cp frontend/dist/index.html "s3://${S3_BUCKET}/index.html" \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+      - name: Invalidate CloudFront cache
+        # Fails loudly if invalidation fails — stale content is never silently served (#1486).
+        run: bash deployment/scripts/cloudfront-invalidate.sh
+        env:
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ env.CLOUDFRONT_DISTRIBUTION_ID }}
+          INVALIDATION_PATHS: ${{ env.INVALIDATION_PATHS }}
+          SMOKE_CHECK_URL: ${{ env.SMOKE_CHECK_URL }}
+          INVALIDATION_TIMEOUT: "300"
+
+      - name: Summarize deployment
+        if: always()
+        run: |
+          {
+            echo "## Frontend deployment"
+            echo ""
+            echo "- S3 bucket: \`$S3_BUCKET\`"
+            echo "- CloudFront distribution: \`$CLOUDFRONT_DISTRIBUTION_ID\`"
+            echo "- Invalidation paths: \`$INVALIDATION_PATHS\`"
+            echo "- Commit: \`${{ github.sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/deployment/contract-deploy.sh
+++ b/deployment/contract-deploy.sh
@@ -19,6 +19,9 @@ SOROBAN_NETWORK_PASSPHRASE="${SOROBAN_NETWORK_PASSPHRASE:-}"
 CONTRACT_ENV_FILE="${CONTRACT_ENV_FILE:-}"
 DEPLOYMENT_SHA="${GITHUB_SHA:-${DEPLOYMENT_SHA:-}}"
 GITHUB_REF_NAME="${GITHUB_REF_NAME:-}"
+# Bitmask of capability flags the deployed contract must expose (#1490).
+# PerPortfolioSteward=1, DifferentiatedPricing=2, EmergencyStop=4 → 7.
+EXPECTED_CAPABILITY_FLAGS="${EXPECTED_CAPABILITY_FLAGS:-7}"
 
 if [ -z "$DEPLOYMENT_ENVIRONMENT" ]; then
   fail "DEPLOYMENT_ENVIRONMENT is required"
@@ -99,5 +102,38 @@ REFLECTOR_ADDRESS=$REFLECTOR_ADDRESS
 DEPLOYMENT_SHA=$DEPLOYMENT_SHA
 EOF
 fi
+
+print_step "Verifying deployed contract capabilities"
+ACTUAL_CAPABILITY_FLAGS="$(soroban contract invoke \
+  --id "$CONTRACT_ID" \
+  --source ci-deployer \
+  --network "$STELLAR_NETWORK" \
+  -- capabilities 2>/dev/null | tr -d '[:space:]')"
+
+if [ -z "$ACTUAL_CAPABILITY_FLAGS" ]; then
+  fail "capabilities() returned an empty response — contract may not have deployed correctly"
+fi
+
+# Decode flags into human-readable names for the audit log.
+decode_capability_flags() {
+  local flags="$1"
+  local names=""
+  (( flags & 1 )) && names="${names:+$names, }PerPortfolioSteward"
+  (( flags & 2 )) && names="${names:+$names, }DifferentiatedPricing"
+  (( flags & 4 )) && names="${names:+$names, }EmergencyStop"
+  printf '%s' "${names:-<none>}"
+}
+
+printf '[%s] Verified capability flags : %s (%s)\n' \
+  "contract-deploy" "$ACTUAL_CAPABILITY_FLAGS" "$(decode_capability_flags "$ACTUAL_CAPABILITY_FLAGS")"
+printf '[%s] Expected capability flags  : %s (%s)\n' \
+  "contract-deploy" "$EXPECTED_CAPABILITY_FLAGS" "$(decode_capability_flags "$EXPECTED_CAPABILITY_FLAGS")"
+
+if [ "$ACTUAL_CAPABILITY_FLAGS" != "$EXPECTED_CAPABILITY_FLAGS" ]; then
+  fail "Capability mismatch: expected flags=$EXPECTED_CAPABILITY_FLAGS but got flags=$ACTUAL_CAPABILITY_FLAGS. \
+Aborting — the deployed contract does not match the expected capability manifest."
+fi
+
+print_step "Capability verification passed"
 
 printf '\n[%s] Contract deployed: %s\n' "contract-deploy" "$CONTRACT_ID"

--- a/deployment/observability/grafana/dashboards/contract-event-indexer.json
+++ b/deployment/observability/grafana/dashboards/contract-event-indexer.json
@@ -1,0 +1,192 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Contract event indexer health: lag behind chain tip and per-interval error rate (#1493).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Number of ledgers the contract event indexer is behind the current chain tip. Healthy threshold: < 10 ledgers. Alert threshold: ≥ 100 ledgers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short",
+          "min": 0,
+          "displayName": "Indexer lag (ledgers)"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "title": "Current Indexer Lag",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "contract_event_indexer_lag_ledgers",
+          "instant": true,
+          "legendFormat": "Lag",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Historical view of indexer lag (chain tip ledger − last indexed ledger) over the selected time range. Red band marks the alert threshold (100 ledgers).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Ledgers behind tip",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 3,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "line+area" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 18, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "title": "Indexer Lag Over Time",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "contract_event_indexer_lag_ledgers",
+          "legendFormat": "Lag (ledgers)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Rate of indexer errors per second over the selected interval. A sustained non-zero rate indicates the indexer is failing to process events.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Errors / second",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.01 }
+            ]
+          },
+          "unit": "reqps",
+          "color": { "fixedColor": "red", "mode": "fixed" }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "title": "Indexer Error Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(contract_event_indexer_errors_total[5m])",
+          "legendFormat": "Error rate",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["indexer", "contract-events", "stellar", "observability"],
+  "templating": { "list": [] },
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Contract Event Indexer",
+  "uid": "contract-event-indexer",
+  "version": 1
+}

--- a/deployment/scripts/cloudfront-invalidate.sh
+++ b/deployment/scripts/cloudfront-invalidate.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# cloudfront-invalidate.sh — Invalidate CloudFront paths after a frontend deploy.
+#
+# Usage:
+#   CLOUDFRONT_DISTRIBUTION_ID=E1ABC... bash deployment/scripts/cloudfront-invalidate.sh
+#
+# Optional env vars:
+#   INVALIDATION_PATHS   Space-separated list of paths to invalidate.
+#                        Defaults to "/*" (full invalidation).
+#   SMOKE_CHECK_URL      If set, curl-checks this URL after the invalidation
+#                        completes and exits 1 if the response is not 2xx.
+#   INVALIDATION_TIMEOUT Seconds to wait for the invalidation to complete.
+#                        Defaults to 300.
+#
+# The script exits non-zero if:
+#   - The invalidation request fails
+#   - AWS reports the invalidation as anything other than Completed
+#   - The optional smoke check returns a non-2xx HTTP status
+#
+# This script is wired into the frontend deploy pipeline to ensure users see
+# updated content immediately after an S3 upload, rather than serving stale
+# cached assets. Deploy pipelines fail loudly here rather than silently
+# serving stale content (#1486).
+set -euo pipefail
+
+print_step() {
+  printf '\n[%s] %s\n' "cloudfront-invalidate" "$1"
+}
+
+fail() {
+  printf '[%s] ERROR: %s\n' "cloudfront-invalidate" "$1" >&2
+  exit 1
+}
+
+CLOUDFRONT_DISTRIBUTION_ID="${CLOUDFRONT_DISTRIBUTION_ID:-}"
+INVALIDATION_PATHS="${INVALIDATION_PATHS:-/*}"
+SMOKE_CHECK_URL="${SMOKE_CHECK_URL:-}"
+INVALIDATION_TIMEOUT="${INVALIDATION_TIMEOUT:-300}"
+
+if [ -z "$CLOUDFRONT_DISTRIBUTION_ID" ]; then
+  fail "CLOUDFRONT_DISTRIBUTION_ID is required. Export it from the Terraform s3_cloudfront module output 'cloudfront_distribution_id'."
+fi
+
+if ! command -v aws &>/dev/null; then
+  fail "aws CLI is not installed or not on PATH"
+fi
+
+# Build the paths array for the AWS CLI call.
+# INVALIDATION_PATHS may be "/* /index.html" (space-separated).
+read -ra PATHS_ARRAY <<< "$INVALIDATION_PATHS"
+PATHS_COUNT="${#PATHS_ARRAY[@]}"
+
+print_step "Requesting invalidation on distribution $CLOUDFRONT_DISTRIBUTION_ID"
+printf '  Paths (%d): %s\n' "$PATHS_COUNT" "$INVALIDATION_PATHS"
+
+CALLER_REF="deploy-$(date +%s)-$$"
+
+INVALIDATION_ID="$(aws cloudfront create-invalidation \
+  --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+  --paths "${PATHS_ARRAY[@]}" \
+  --query 'Invalidation.Id' \
+  --output text)"
+
+if [ -z "$INVALIDATION_ID" ]; then
+  fail "create-invalidation returned an empty invalidation ID"
+fi
+
+printf '[%s] Invalidation created: %s\n' "cloudfront-invalidate" "$INVALIDATION_ID"
+
+print_step "Waiting for invalidation $INVALIDATION_ID to complete (timeout ${INVALIDATION_TIMEOUT}s)"
+
+DEADLINE=$(( $(date +%s) + INVALIDATION_TIMEOUT ))
+while true; do
+  STATUS="$(aws cloudfront get-invalidation \
+    --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+    --id "$INVALIDATION_ID" \
+    --query 'Invalidation.Status' \
+    --output text)"
+
+  printf '[%s] Status: %s\n' "cloudfront-invalidate" "$STATUS"
+
+  if [ "$STATUS" = "Completed" ]; then
+    break
+  fi
+
+  if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+    fail "Timed out after ${INVALIDATION_TIMEOUT}s waiting for invalidation $INVALIDATION_ID (last status: $STATUS)"
+  fi
+
+  sleep 10
+done
+
+print_step "Invalidation $INVALIDATION_ID completed"
+
+if [ -n "$SMOKE_CHECK_URL" ]; then
+  print_step "Running smoke check against $SMOKE_CHECK_URL"
+
+  HTTP_STATUS="$(curl -o /dev/null -s -w '%{http_code}' \
+    --max-time 15 \
+    --retry 3 \
+    --retry-delay 5 \
+    "$SMOKE_CHECK_URL")"
+
+  printf '[%s] CDN smoke check HTTP status: %s\n' "cloudfront-invalidate" "$HTTP_STATUS"
+
+  if [[ "$HTTP_STATUS" != 2* ]]; then
+    fail "Smoke check failed: expected 2xx from $SMOKE_CHECK_URL but got $HTTP_STATUS"
+  fi
+
+  printf '[%s] Smoke check passed\n' "cloudfront-invalidate"
+fi
+
+printf '\n[%s] CloudFront invalidation complete for distribution %s\n' \
+  "cloudfront-invalidate" "$CLOUDFRONT_DISTRIBUTION_ID"

--- a/deployment/terraform/modules/rds/main.tf
+++ b/deployment/terraform/modules/rds/main.tf
@@ -42,7 +42,91 @@ resource "aws_db_instance" "main" {
   skip_final_snapshot         = true
   publicly_accessible         = false
 
+  # Automated backup retention — kept for fast point-in-time recovery (#1484).
+  backup_retention_period = var.backup_retention_days
+  backup_window           = "03:00-04:00"
+
   tags = {
-    Name = "${var.name_prefix}-db"
+    Name        = "${var.name_prefix}-db"
+    Environment = var.environment
+    ManagedBy   = "terraform"
   }
+}
+
+# ── AWS Backup plan for long-term snapshot retention and auto-pruning (#1484) ─
+
+resource "aws_backup_vault" "rds" {
+  name = "${var.name_prefix}-rds-backup-vault"
+
+  tags = {
+    Name        = "${var.name_prefix}-rds-backup-vault"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_backup_plan" "rds" {
+  name = "${var.name_prefix}-rds-backup-plan"
+
+  rule {
+    rule_name         = "daily-snapshot"
+    target_vault_name = aws_backup_vault.rds.name
+    # Run the snapshot at 02:00 UTC daily, outside the RDS backup window.
+    schedule = "cron(0 2 * * ? *)"
+
+    lifecycle {
+      cold_storage_after = var.snapshot_cold_storage_after_days > 0 ? var.snapshot_cold_storage_after_days : null
+      delete_after       = var.snapshot_delete_after_days
+    }
+
+    recovery_point_tags = {
+      Environment = var.environment
+      ManagedBy   = "aws-backup"
+      # Date is injected by AWS Backup at recovery-point creation time via
+      # the aws:backup:source-resource-arn tag — we set project metadata here.
+      Project = "stellar-portfolio-rebalancer"
+    }
+  }
+
+  tags = {
+    Name        = "${var.name_prefix}-rds-backup-plan"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# IAM role that allows AWS Backup to snapshot the RDS instance.
+resource "aws_iam_role" "backup" {
+  name = "${var.name_prefix}-backup-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "backup.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.name_prefix}-backup-role"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+# Assign the backup plan to the RDS instance.
+resource "aws_backup_selection" "rds" {
+  iam_role_arn = aws_iam_role.backup.arn
+  name         = "${var.name_prefix}-rds-backup-selection"
+  plan_id      = aws_backup_plan.rds.id
+
+  resources = [aws_db_instance.main.arn]
 }

--- a/deployment/terraform/modules/rds/variables.tf
+++ b/deployment/terraform/modules/rds/variables.tf
@@ -13,3 +13,32 @@ variable "subnet_ids" {
 variable "instance_class" {
   type = string
 }
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment (e.g. testnet, staging, mainnet) — added to snapshot tags."
+  default     = "testnet"
+}
+
+variable "backup_retention_days" {
+  type        = number
+  description = "Number of days to retain automated RDS backups. Must be between 1 and 35."
+  default     = 7
+
+  validation {
+    condition     = var.backup_retention_days >= 1 && var.backup_retention_days <= 35
+    error_message = "backup_retention_days must be between 1 and 35."
+  }
+}
+
+variable "snapshot_cold_storage_after_days" {
+  type        = number
+  description = "Days after creation before AWS Backup moves a snapshot to cold storage. Set to 0 to disable cold-storage tier."
+  default     = 30
+}
+
+variable "snapshot_delete_after_days" {
+  type        = number
+  description = "Days after creation before AWS Backup permanently deletes a snapshot."
+  default     = 90
+}

--- a/deployment/terraform/modules/s3_cloudfront/outputs.tf
+++ b/deployment/terraform/modules/s3_cloudfront/outputs.tf
@@ -5,3 +5,10 @@ output "cloudfront_domain_name" {
 output "s3_bucket_id" {
   value = aws_s3_bucket.frontend.id
 }
+
+# Exposed so the post-deploy CloudFront invalidation step can reference the
+# correct distribution without hard-coding the ID in CI (#1486).
+output "cloudfront_distribution_id" {
+  description = "The CloudFront distribution ID — pass as CLOUDFRONT_DISTRIBUTION_ID to cloudfront-invalidate.sh."
+  value       = aws_cloudfront_distribution.frontend.id
+}


### PR DESCRIPTION
## Summary

Four devops/infrastructure features covering deploy safety, database backup lifecycle, CDN cache correctness, and observability.

---

### #1490 — Post-deploy contract capability verification (`deployment/contract-deploy.sh`)

Adds a verification step at the end of `contract-deploy.sh` that runs immediately after `initialize`:

1. Calls `soroban contract invoke -- capabilities` on the just-deployed contract.
2. Decodes the returned bitmask into human-readable flag names (`PerPortfolioSteward`, `DifferentiatedPricing`, `EmergencyStop`).
3. Compares against `EXPECTED_CAPABILITY_FLAGS` (default `7` = all three flags OR'd together, matching the contract's current `capabilities()` implementation).
4. Fails the script with a loud non-zero exit if there is any mismatch — a mis-built or downgraded WASM can never silently reach production.
5. Prints both actual and expected flags to stdout for the deploy audit log.

The expected value is overridable via the `EXPECTED_CAPABILITY_FLAGS` env var so future capability additions don't require a script change, only a manifest update.

---

### #1484 — Automated RDS snapshot retention (`deployment/terraform/modules/rds/`)

- **`aws_db_instance`**: enabled `backup_retention_period` (default 7 days, configurable) and set a fixed `backup_window` so automated backups don't race the primary workload.
- **`aws_backup_vault`**: dedicated vault for RDS snapshots.
- **`aws_backup_plan`**: daily schedule at 02:00 UTC with configurable cold-storage tier and hard delete lifecycle (defaults: cold after 30 days, deleted after 90).
- **`aws_iam_role` + policy attachment**: grants AWS Backup the `AWSBackupServiceRolePolicyForBackup` permissions to snapshot RDS.
- **`aws_backup_selection`**: targets the RDS instance ARN.
- **Tags**: `Environment`, `ManagedBy`, `Project` on every provisioned resource and on recovery points, making snapshots easily identifiable in the AWS console.
- **New variables**: `environment`, `backup_retention_days` (validated 1–35), `snapshot_cold_storage_after_days`, `snapshot_delete_after_days`.

`terraform apply` provisions the full retention automation with no manual steps.

---

### #1486 — CloudFront cache invalidation automation (`deployment/scripts/cloudfront-invalidate.sh` + `.github/workflows/frontend-deploy.yml`)

**`deployment/scripts/cloudfront-invalidate.sh`** — self-contained invalidation script:
- Accepts `CLOUDFRONT_DISTRIBUTION_ID` (required), `INVALIDATION_PATHS` (default `/*`), `SMOKE_CHECK_URL`, and `INVALIDATION_TIMEOUT` (default 300 s).
- Creates the invalidation, polls until `Completed` or timeout, then optionally curl-checks the CDN URL.
- Exits non-zero on invalidation failure, timeout, or smoke-check failure — stale content is never silently served.

**`.github/workflows/frontend-deploy.yml`** — dedicated CI workflow:
- Triggers on push to `main` when `frontend/**` changes (or via `workflow_dispatch` with a custom path input).
- Builds the frontend, syncs immutable assets with long-TTL headers and `index.html` with `no-cache`, then calls the invalidation script.
- The job fails loudly if invalidation fails so the pipeline surface area is clear.

**`deployment/terraform/modules/s3_cloudfront/outputs.tf`**: added `cloudfront_distribution_id` output so pipelines can reference the distribution ID from Terraform state rather than hard-coding it.

---

### #1493 — Grafana dashboard for contract event indexer lag (`deployment/observability/grafana/dashboards/contract-event-indexer.json`)

Provisioned as code — picked up automatically by the existing `dashboards.yml` Grafana provisioner. Three panels:

| Panel | Type | Metric | Alert threshold |
|---|---|---|---|
| Current Indexer Lag | Stat tile (background colour) | `contract_event_indexer_lag_ledgers` | Yellow ≥ 10, Red ≥ 100 ledgers |
| Indexer Lag Over Time | Time-series with threshold band | `contract_event_indexer_lag_ledgers` | Red band at 100 ledgers |
| Indexer Error Rate | Bar chart | `rate(contract_event_indexer_errors_total[5m])` | — |

Dashboard auto-refreshes every 30 s, defaults to the last 3-hour window, and is tagged `indexer`, `contract-events`, `stellar`, `observability`.

Closes #1484
Closes #1486
Closes #1490
Closes #1493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated frontend deployment with asset synchronization and CDN cache invalidation.
  * Added post-deployment smoke checks and deployment summaries.
  * Added contract capability verification during deployment.
  * Added Grafana monitoring for indexer lag and errors.
  * Added automated database backups with configurable retention and recovery settings.
  * Exposed the CDN distribution identifier for deployment automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->