### PR TITLE
[FEATURE] Add timelock delay / Add close_portfolio/ Add global slippa…

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -6,6 +6,7 @@ use soroban_sdk::{
     contract, contractimpl, symbol_short, token, Address, BytesN, Env, Map, String, Symbol, Vec,
 };
 
+mod circuit_breaker;
 mod nav;
 mod portfolio;
 mod reflector;
@@ -116,6 +117,11 @@ impl PortfolioRebalancer {
             total_value: 0,
             is_active: true,
             pause_reason: PauseReason::None,
+            circuit_breaker_config: CircuitBreakerConfig {
+                spike_threshold_bps: DEFAULT_CIRCUIT_BREAKER_SPIKE_THRESHOLD_BPS,
+                window_seconds: DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS,
+            },
+            global_max_slippage_bps: DEFAULT_GLOBAL_MAX_SLIPPAGE_BPS,
         };
 
         let _estimated_footprint =
@@ -390,15 +396,52 @@ impl PortfolioRebalancer {
     }
 
 
-    pub fn set_fee_config(env: Env, config: FeeConfig) {
+    pub fn queue_fee_config(env: Env, config: FeeConfig) {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         if config.fee_bps > MAX_FEE_BPS {
             panic!("fee_bps must be between 0 and 50");
         }
-        env.storage().instance().set(&DataKey::FeeConfig, &config);
-        env.events()
-            .publish((Symbol::new(&env, "FeeConfigUpdated"),), config);
+        
+        let current_time = env.ledger().timestamp();
+        let execute_after = current_time.saturating_add(TIMELOCK_DELAY_SECONDS);
+        
+        let queued = QueuedFeeConfig {
+            config: config.clone(),
+            execute_after,
+        };
+        
+        env.storage().instance().set(&DataKey::QueuedFeeConfig, &queued);
+        
+        env.events().publish(
+            (Symbol::new(&env, "fee_config_queued"),),
+            (config, execute_after),
+        );
+    }
+
+    pub fn execute_fee_config(env: Env) -> Result<(), Error> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        
+        let queued: QueuedFeeConfig = env.storage()
+            .instance()
+            .get(&DataKey::QueuedFeeConfig)
+            .ok_or(Error::PreviewUnavailable)?;
+        
+        let current_time = env.ledger().timestamp();
+        if current_time < queued.execute_after {
+            return Err(Error::TimelockNotElapsed);
+        }
+        
+        env.storage().instance().set(&DataKey::FeeConfig, &queued.config);
+        env.storage().instance().remove(&DataKey::QueuedFeeConfig);
+        
+        env.events().publish(
+            (Symbol::new(&env, "FeeConfigUpdated"),),
+            queued.config,
+        );
+        
+        Ok(())
     }
 
     pub fn get_fee_config(env: Env) -> FeeConfig {
@@ -413,26 +456,61 @@ impl PortfolioRebalancer {
             })
     }
 
-    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+    pub fn queue_upgrade(env: Env, new_wasm_hash: BytesN<32>) {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
+        
+        let current_time = env.ledger().timestamp();
+        let execute_after = current_time.saturating_add(TIMELOCK_DELAY_SECONDS);
+        
+        let queued = QueuedUpgrade {
+            new_wasm_hash: new_wasm_hash.clone(),
+            execute_after,
+        };
+        
+        env.storage().instance().set(&DataKey::QueuedUpgrade, &queued);
+        
+        env.events().publish(
+            (Symbol::new(&env, "upgrade_queued"),),
+            (new_wasm_hash, execute_after),
+        );
+    }
+
+    pub fn execute_upgrade(env: Env) -> Result<(), Error> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        
+        let queued: QueuedUpgrade = env.storage()
+            .instance()
+            .get(&DataKey::QueuedUpgrade)
+            .ok_or(Error::PreviewUnavailable)?;
+        
+        let current_time = env.ledger().timestamp();
+        if current_time < queued.execute_after {
+            return Err(Error::TimelockNotElapsed);
+        }
+        
         let current_hash: Option<BytesN<32>> = env.storage().instance().get(&DataKey::WasmHash);
         env.storage()
             .instance()
             .set(&DataKey::UpgradeAuthority, &admin);
         env.deployer()
-            .update_current_contract_wasm(new_wasm_hash.clone());
+            .update_current_contract_wasm(queued.new_wasm_hash.clone());
         env.storage()
             .instance()
-            .set(&DataKey::WasmHash, &new_wasm_hash);
+            .set(&DataKey::WasmHash, &queued.new_wasm_hash);
+        env.storage().instance().remove(&DataKey::QueuedUpgrade);
+        
         env.events().publish(
             ("portfolio", "upgraded"),
             UpgradeEvent {
                 from_hash: current_hash.unwrap_or(BytesN::from_array(&env, &[0u8; 32])),
-                to_hash: new_wasm_hash,
+                to_hash: queued.new_wasm_hash,
                 timestamp: env.ledger().timestamp(),
             },
         );
+        
+        Ok(())
     }
 
     pub fn min_rebalance_threshold(_env: Env) -> u32 {
@@ -586,6 +664,68 @@ impl PortfolioRebalancer {
         }
     }
 
+    pub fn set_circuit_breaker_config(
+        env: Env,
+        portfolio_id: u64,
+        spike_threshold_bps: u32,
+        window_seconds: u64,
+    ) -> Result<(), Error> {
+        let mut portfolio = Self::load_portfolio(&env, portfolio_id)?;
+        
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let caller_is_admin = env.auth().is_authorized(&admin);
+        let caller_is_owner = env.auth().is_authorized(&portfolio.user);
+        
+        if !caller_is_admin && !caller_is_owner {
+            return Err(Error::PortfolioNotFound);
+        }
+        
+        portfolio.circuit_breaker_config = CircuitBreakerConfig {
+            spike_threshold_bps,
+            window_seconds,
+        };
+        
+        env.storage()
+            .persistent()
+            .set(&DataKey::Portfolio(portfolio_id), &portfolio);
+        
+        env.events().publish(
+            (Symbol::new(&env, "circuit_breaker_config_updated"),),
+            (portfolio_id, spike_threshold_bps, window_seconds),
+        );
+        
+        Ok(())
+    }
+
+    pub fn set_global_max_slippage(
+        env: Env,
+        portfolio_id: u64,
+        global_max_slippage_bps: u32,
+    ) -> Result<(), Error> {
+        let mut portfolio = Self::load_portfolio(&env, portfolio_id)?;
+        
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let caller_is_admin = env.auth().is_authorized(&admin);
+        let caller_is_owner = env.auth().is_authorized(&portfolio.user);
+        
+        if !caller_is_admin && !caller_is_owner {
+            return Err(Error::PortfolioNotFound);
+        }
+        
+        portfolio.global_max_slippage_bps = global_max_slippage_bps;
+        
+        env.storage()
+            .persistent()
+            .set(&DataKey::Portfolio(portfolio_id), &portfolio);
+        
+        env.events().publish(
+            (Symbol::new(&env, "global_max_slippage_updated"),),
+            (portfolio_id, global_max_slippage_bps),
+        );
+        
+        Ok(())
+    }
+
     pub fn get_portfolio_value_usd(
         env: Env,
         portfolio_id: u64,
@@ -701,6 +841,22 @@ impl PortfolioRebalancer {
 
         let preview = portfolio::build_rebalance_preview(env, &portfolio, &reflector_client)?;
 
+        let mut current_prices = Map::new(env);
+        for (asset, _) in portfolio.target_allocations.iter() {
+            if let Some(price_data) =
+                reflector_client.lastprice(&crate::reflector::Asset::Stellar(asset.clone()))
+            {
+                current_prices.set(asset, price_data.price);
+            }
+        }
+
+        crate::circuit_breaker::check_volatility(
+            env,
+            &portfolio.circuit_breaker_config,
+            &reflector_client,
+            &current_prices,
+        )?;
+
         for (asset, _) in portfolio.target_allocations.iter() {
             if let Some(reason) = preview.skip_reasons.get(asset) {
                 match reason {
@@ -742,6 +898,7 @@ impl PortfolioRebalancer {
             };
 
             if total_value > 0 {
+                let mut total_slippage_bps = 0i128;
                 for (asset, target_pct) in portfolio.target_allocations.iter() {
                     let price_data = reflector_client
                         .lastprice(&crate::reflector::Asset::Stellar(asset.clone()))
@@ -765,10 +922,20 @@ impl PortfolioRebalancer {
                         let diff = expected_balance - actual_balance;
                         let diff_abs = if diff >= 0 { diff } else { -diff };
                         let slippage_bps = (diff_abs * 10000) / expected_abs;
+                        
+                        // Per-asset slippage check (existing behavior)
                         if slippage_bps > snapshot.slippage_tolerance as i128 {
                             return Err(Error::SlippageExceeded);
                         }
+                        
+                        // Accumulate for global slippage check
+                        total_slippage_bps += slippage_bps;
                     }
+                }
+                
+                // Global slippage cap check across all legs
+                if total_slippage_bps > portfolio.global_max_slippage_bps as i128 {
+                    return Err(Error::SlippageExceeded);
                 }
             }
         }
@@ -825,6 +992,60 @@ impl PortfolioRebalancer {
 
     pub fn get_nav_history(env: Env, portfolio_id: u64, limit: u32) -> Result<Vec<NavSnapshot>, Error> {
         nav::get_nav_history(&env, portfolio_id, limit)
+    }
+
+    pub fn close_portfolio(env: Env, portfolio_id: u64) -> Result<(), Error> {
+        let portfolio = Self::load_portfolio(&env, portfolio_id)?;
+        
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let caller_is_admin = env.auth().is_authorized(&admin);
+        let caller_is_owner = env.auth().is_authorized(&portfolio.user);
+        
+        if !caller_is_admin && !caller_is_owner {
+            return Err(Error::PortfolioNotFound);
+        }
+        
+        // Sweep all asset balances to the owner
+        let mut swept_amounts = Map::new(&env);
+        for (asset, balance) in portfolio.current_balances.iter() {
+            if balance > 0 {
+                let token_client = token::Client::new(&env, &asset);
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &portfolio.user,
+                    &balance,
+                );
+                swept_amounts.set(asset, balance);
+            }
+        }
+        
+        // Remove portfolio storage
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Portfolio(portfolio_id));
+        
+        // Remove steward if exists
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Steward(portfolio_id));
+        
+        // Remove DCA config if exists
+        env.storage()
+            .persistent()
+            .remove(&DataKey::DCAConfig(portfolio_id));
+        
+        // Remove NAV history if exists
+        env.storage()
+            .persistent()
+            .remove(&DataKey::NavHistory(portfolio_id));
+        
+        // Emit portfolio_closed event
+        env.events().publish(
+            (Symbol::new(&env, "portfolio_closed"),),
+            (portfolio_id, portfolio.user, swept_amounts),
+        );
+        
+        Ok(())
     }
 }
 

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -709,6 +709,11 @@ fn build_trade_test_portfolio(
         total_value,
         is_active: true,
         pause_reason: PauseReason::None,
+        circuit_breaker_config: CircuitBreakerConfig {
+            spike_threshold_bps: DEFAULT_CIRCUIT_BREAKER_SPIKE_THRESHOLD_BPS,
+            window_seconds: DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS,
+        },
+        global_max_slippage_bps: DEFAULT_GLOBAL_MAX_SLIPPAGE_BPS,
     }
 }
 
@@ -749,6 +754,11 @@ fn test_calculate_rebalance_trades_excludes_below_minimum_stroops() {
         total_value: target_balance,
         is_active: true,
         pause_reason: PauseReason::None,
+        circuit_breaker_config: CircuitBreakerConfig {
+            spike_threshold_bps: DEFAULT_CIRCUIT_BREAKER_SPIKE_THRESHOLD_BPS,
+            window_seconds: DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS,
+        },
+        global_max_slippage_bps: DEFAULT_GLOBAL_MAX_SLIPPAGE_BPS,
     };
 
     let mut prices = Map::new(&env);
@@ -789,6 +799,11 @@ fn test_calculate_rebalance_trades_2_asset() {
         total_value: 200 * 10i128.pow(14),
         is_active: true,
         pause_reason: PauseReason::None,
+        circuit_breaker_config: CircuitBreakerConfig {
+            spike_threshold_bps: DEFAULT_CIRCUIT_BREAKER_SPIKE_THRESHOLD_BPS,
+            window_seconds: DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS,
+        },
+        global_max_slippage_bps: DEFAULT_GLOBAL_MAX_SLIPPAGE_BPS,
     };
 
     let mut prices = Map::new(&env);
@@ -858,6 +873,11 @@ fn test_calculate_rebalance_trades_5_asset() {
         total_value: 500 * 10i128.pow(14),
         is_active: true,
         pause_reason: PauseReason::None,
+        circuit_breaker_config: CircuitBreakerConfig {
+            spike_threshold_bps: DEFAULT_CIRCUIT_BREAKER_SPIKE_THRESHOLD_BPS,
+            window_seconds: DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS,
+        },
+        global_max_slippage_bps: DEFAULT_GLOBAL_MAX_SLIPPAGE_BPS,
     };
 
     let mut prices = Map::new(&env);
@@ -903,6 +923,11 @@ fn test_calculate_rebalance_trades_direction_buy_sell() {
         total_value: 200 * 10i128.pow(14),
         is_active: true,
         pause_reason: PauseReason::None,
+        circuit_breaker_config: CircuitBreakerConfig {
+            spike_threshold_bps: DEFAULT_CIRCUIT_BREAKER_SPIKE_THRESHOLD_BPS,
+            window_seconds: DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS,
+        },
+        global_max_slippage_bps: DEFAULT_GLOBAL_MAX_SLIPPAGE_BPS,
     };
 
     let mut prices = Map::new(&env);
@@ -953,6 +978,11 @@ fn test_calculate_rebalance_trades_price_precision() {
         total_value: 100 * 10i128.pow(14),
         is_active: true,
         pause_reason: PauseReason::None,
+        circuit_breaker_config: CircuitBreakerConfig {
+            spike_threshold_bps: DEFAULT_CIRCUIT_BREAKER_SPIKE_THRESHOLD_BPS,
+            window_seconds: DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS,
+        },
+        global_max_slippage_bps: DEFAULT_GLOBAL_MAX_SLIPPAGE_BPS,
     };
 
     let mut prices = Map::new(&env);
@@ -1030,6 +1060,11 @@ fn test_calculate_rebalance_trades_exact_boundary() {
         total_value: 100_000_000i128,
         is_active: true,
         pause_reason: PauseReason::None,
+        circuit_breaker_config: CircuitBreakerConfig {
+            spike_threshold_bps: DEFAULT_CIRCUIT_BREAKER_SPIKE_THRESHOLD_BPS,
+            window_seconds: DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS,
+        },
+        global_max_slippage_bps: DEFAULT_GLOBAL_MAX_SLIPPAGE_BPS,
     };
 
     let mut prices = Map::new(&env);
@@ -1950,6 +1985,11 @@ fn test_portfolio_invariants_helper_rejects_invalid_allocations() {
         total_value: 0,
         is_active: true,
         pause_reason: PauseReason::None,
+        circuit_breaker_config: CircuitBreakerConfig {
+            spike_threshold_bps: DEFAULT_CIRCUIT_BREAKER_SPIKE_THRESHOLD_BPS,
+            window_seconds: DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS,
+        },
+        global_max_slippage_bps: DEFAULT_GLOBAL_MAX_SLIPPAGE_BPS,
     };
     assert_eq!(
         crate::portfolio::check_portfolio_invariants(&portfolio),
@@ -2675,6 +2715,388 @@ fn test_circuit_breaker_persists_pause_reason() {
         .collect();
     
     assert!(!cb_events.is_empty(), "circuit_breaker_tripped event should be emitted");
+}
+
+#[test]
+fn test_per_portfolio_circuit_breaker_config() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    
+    client.initialize(&admin, &reflector_id);
+    
+    // Create two portfolios with the same asset
+    let mut allocations = Map::new(&env);
+    let asset = Address::generate(&env);
+    allocations.set(asset.clone(), 10000);
+    
+    let pid1 = create_portfolio_with_defaults(&env, &client, &user1, &allocations, 5, 50);
+    let pid2 = create_portfolio_with_defaults(&env, &client, &user2, &allocations, 5, 50);
+    
+    // Configure portfolio 1 with a low threshold (1%)
+    client.set_circuit_breaker_config(&pid1, &100, &3600);
+    
+    // Configure portfolio 2 with a high threshold (10%)
+    client.set_circuit_breaker_config(&pid2, &1000, &3600);
+    
+    // Verify configs were set
+    let portfolio1 = client.get_portfolio(&pid1);
+    let portfolio2 = client.get_portfolio(&pid2);
+    assert_eq!(portfolio1.circuit_breaker_config.spike_threshold_bps, 100);
+    assert_eq!(portfolio1.circuit_breaker_config.window_seconds, 3600);
+    assert_eq!(portfolio2.circuit_breaker_config.spike_threshold_bps, 1000);
+    assert_eq!(portfolio2.circuit_breaker_config.window_seconds, 3600);
+    
+    // Test that portfolio 1 trips at 5% deviation but portfolio 2 does not
+    let config1 = portfolio1.circuit_breaker_config;
+    let config2 = portfolio2.circuit_breaker_config;
+    
+    let mut current_prices = Map::new(&env);
+    // Price has spiked 5% (500 bps)
+    current_prices.set(asset.clone(), 105_00000000000000i128);
+    
+    let reflector_client = ReflectorClient::new(&env, &reflector_id);
+    
+    // Portfolio 1 with 1% threshold should trip
+    let result1 = crate::circuit_breaker::check_volatility(&env, &config1, &reflector_client, &current_prices);
+    assert_eq!(result1, Err(Error::EmergencyStop));
+    
+    // Portfolio 2 with 10% threshold should not trip
+    let result2 = crate::circuit_breaker::check_volatility(&env, &config2, &reflector_client, &current_prices);
+    assert_eq!(result2, Ok(()));
+    
+    // Reset pause reason for next test
+    client.set_emergency_stop(&false);
+    
+    // Test that portfolio 2 trips at 15% deviation
+    let mut high_prices = Map::new(&env);
+    // Price has spiked 15% (1500 bps)
+    high_prices.set(asset.clone(), 115_00000000000000i128);
+    
+    let result2_high = crate::circuit_breaker::check_volatility(&env, &config2, &reflector_client, &high_prices);
+    assert_eq!(result2_high, Err(Error::EmergencyStop));
+}
+
+#[test]
+fn test_default_circuit_breaker_config() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    
+    client.initialize(&admin, &reflector_id);
+    
+    // Create a portfolio without setting custom config
+    let mut allocations = Map::new(&env);
+    let asset = Address::generate(&env);
+    allocations.set(asset.clone(), 10000);
+    let pid = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
+    
+    // Verify default config is used
+    let portfolio = client.get_portfolio(&pid);
+    assert_eq!(portfolio.circuit_breaker_config.spike_threshold_bps, DEFAULT_CIRCUIT_BREAKER_SPIKE_THRESHOLD_BPS);
+    assert_eq!(portfolio.circuit_breaker_config.window_seconds, DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS);
+}
+
+#[test]
+fn test_global_max_slippage_cap_aggregate_breach() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    
+    client.initialize(&admin, &reflector_id);
+    
+    // Create a portfolio with 3 assets
+    let mut allocations = Map::new(&env);
+    let asset1 = Address::generate(&env);
+    let asset2 = Address::generate(&env);
+    let asset3 = Address::generate(&env);
+    allocations.set(asset1.clone(), 3334);
+    allocations.set(asset2.clone(), 3333);
+    allocations.set(asset3.clone(), 3333);
+    
+    // Set per-asset slippage tolerance to 2% (200 bps)
+    // Set global max slippage to 3% (300 bps)
+    let pid = client.create_portfolio(
+        &user,
+        &allocations,
+        &allocation_decimals(&env, &allocations, DEFAULT_ASSET_DECIMALS),
+        &5,
+        &200, // 2% per-asset tolerance
+        &CURRENT_SLIPPAGE_POLICY_VERSION,
+    );
+    
+    // Set global max slippage to 3% (300 bps)
+    client.set_global_max_slippage(&pid, &300);
+    
+    // Deposit initial balances
+    client.deposit(&pid, &asset1, &100_000_000, &String::from_str(&env, ""));
+    client.deposit(&pid, &asset2, &100_000_000, &String::from_str(&env, ""));
+    client.deposit(&pid, &asset3, &100_000_000, &String::from_str(&env, ""));
+    
+    // Simulate actual balances with small slippage on each leg (1.5% each)
+    // Each leg is under the 2% per-asset limit, but total (4.5%) exceeds the 3% global cap
+    let mut actual_balances = Map::new(&env);
+    // Expected: 100M each, actual: 98.5M each (1.5% slippage per leg)
+    actual_balances.set(asset1.clone(), 98_500_000);
+    actual_balances.set(asset2.clone(), 98_500_000);
+    actual_balances.set(asset3.clone(), 98_500_000);
+    
+    let result = client.try_execute_rebalance(&pid, &actual_balances);
+    // Should fail due to global slippage cap (4.5% total > 3% cap)
+    assert_eq!(result, Err(Ok(Error::SlippageExceeded)));
+    
+    // Now test with lower slippage that stays under global cap
+    let mut low_slippage_balances = Map::new(&env);
+    // Expected: 100M each, actual: 99M each (1% slippage per leg, 3% total)
+    low_slippage_balances.set(asset1.clone(), 99_000_000);
+    low_slippage_balances.set(asset2.clone(), 99_000_000);
+    low_slippage_balances.set(asset3.clone(), 99_000_000);
+    
+    let result_low = client.try_execute_rebalance(&pid, &low_slippage_balances);
+    // Should succeed (3% total <= 3% cap)
+    assert_eq!(result_low, Ok(()));
+}
+
+#[test]
+fn test_close_portfolio_happy_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    
+    client.initialize(&admin, &reflector_id);
+    
+    // Create a portfolio with 2 assets
+    let mut allocations = Map::new(&env);
+    let asset1 = Address::generate(&env);
+    let asset2 = Address::generate(&env);
+    allocations.set(asset1.clone(), 5000);
+    allocations.set(asset2.clone(), 5000);
+    
+    let pid = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
+    
+    // Deposit assets
+    client.deposit(&pid, &asset1, &100_000_000, &String::from_str(&env, ""));
+    client.deposit(&pid, &asset2, &50_000_000, &String::from_str(&env, ""));
+    
+    // Verify portfolio exists
+    let portfolio_before = client.get_portfolio(&pid);
+    assert_eq!(portfolio_before.current_balances.get(asset1.clone()).unwrap(), 100_000_000);
+    assert_eq!(portfolio_before.current_balances.get(asset2.clone()).unwrap(), 50_000_000);
+    
+    // Close portfolio
+    client.close_portfolio(&pid);
+    
+    // Verify portfolio no longer exists
+    let result = client.try_get_portfolio(&pid);
+    assert_eq!(result, Err(Ok(Error::PortfolioNotFound)));
+    
+    // Verify portfolio_closed event was emitted
+    let events = env.events().all();
+    let close_events: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Some(topics) = e.topics.first() {
+                topics == &Symbol::new(&env, "portfolio_closed")
+            } else {
+                false
+            }
+        })
+        .collect();
+    
+    assert!(!close_events.is_empty(), "portfolio_closed event should be emitted");
+}
+
+#[test]
+fn test_close_portfolio_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    
+    client.initialize(&admin, &reflector_id);
+    
+    // Create a portfolio
+    let mut allocations = Map::new(&env);
+    let asset = Address::generate(&env);
+    allocations.set(asset.clone(), 10000);
+    
+    let pid = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
+    
+    // Try to close portfolio as unauthorized user
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "close_portfolio",
+            args: (pid).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    
+    let result = client.try_close_portfolio(&pid);
+    assert_eq!(result, Err(Ok(Error::PortfolioNotFound)));
+    
+    // Verify portfolio still exists
+    let portfolio = client.get_portfolio(&pid);
+    assert_eq!(portfolio.user, user);
+}
+
+#[test]
+fn test_timelock_fee_config_early_execution_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    
+    client.initialize(&admin, &reflector_id);
+    
+    // Queue a fee config change
+    let new_config = FeeConfig {
+        platform_name: String::from_str(&env, "TestPlatform"),
+        fee_bps: 25,
+        fee_recipient: admin.clone(),
+        enabled: true,
+    };
+    client.queue_fee_config(&new_config);
+    
+    // Try to execute immediately (should fail due to timelock)
+    let result = client.try_execute_fee_config();
+    assert_eq!(result, Err(Ok(Error::TimelockNotElapsed)));
+    
+    // Verify original config is still in place
+    let current_config = client.get_fee_config();
+    assert_eq!(current_config.fee_bps, 0);
+    assert!(!current_config.enabled);
+}
+
+#[test]
+fn test_timelock_fee_config_post_delay_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    
+    client.initialize(&admin, &reflector_id);
+    
+    // Queue a fee config change
+    let new_config = FeeConfig {
+        platform_name: String::from_str(&env, "TestPlatform"),
+        fee_bps: 25,
+        fee_recipient: admin.clone(),
+        enabled: true,
+    };
+    client.queue_fee_config(&new_config);
+    
+    // Advance ledger time past the timelock delay
+    env.ledger().with_mut(|li| {
+        li.timestamp = TIMELOCK_DELAY_SECONDS + 1;
+    });
+    
+    // Execute after delay (should succeed)
+    let result = client.execute_fee_config();
+    assert_eq!(result, Ok(()));
+    
+    // Verify new config is applied
+    let current_config = client.get_fee_config();
+    assert_eq!(current_config.fee_bps, 25);
+    assert!(current_config.enabled);
+}
+
+#[test]
+fn test_timelock_upgrade_early_execution_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    
+    client.initialize(&admin, &reflector_id);
+    
+    // Queue an upgrade
+    let new_wasm_hash = BytesN::from_array(&env, &[1u8; 32]);
+    client.queue_upgrade(&new_wasm_hash);
+    
+    // Try to execute immediately (should fail due to timelock)
+    let result = client.try_execute_upgrade();
+    assert_eq!(result, Err(Ok(Error::TimelockNotElapsed)));
+}
+
+#[test]
+fn test_timelock_upgrade_post_delay_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    
+    client.initialize(&admin, &reflector_id);
+    
+    // Queue an upgrade
+    let new_wasm_hash = BytesN::from_array(&env, &[1u8; 32]);
+    client.queue_upgrade(&new_wasm_hash);
+    
+    // Advance ledger time past the timelock delay
+    env.ledger().with_mut(|li| {
+        li.timestamp = TIMELOCK_DELAY_SECONDS + 1;
+    });
+    
+    // Execute after delay (should succeed)
+    let result = client.execute_upgrade();
+    assert_eq!(result, Ok(()));
+    
+    // Verify upgrade_queued and upgraded events were emitted
+    let events = env.events().all();
+    let queue_events: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Some(topics) = e.topics.first() {
+                topics == &Symbol::new(&env, "upgrade_queued")
+            } else {
+                false
+            }
+        })
+        .collect();
+    
+    let upgrade_events: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Some(topics) = e.topics.first() {
+                topics == &Symbol::short!("portfolio")
+            } else {
+                false
+            }
+        })
+        .collect();
+    
+    assert!(!queue_events.is_empty(), "upgrade_queued event should be emitted");
+    assert!(!upgrade_events.is_empty(), "upgraded event should be emitted");
 }
 
 #[test]

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -32,6 +32,10 @@ pub const MAX_REBALANCE_THRESHOLD: u32 = 50;
 pub const MIN_SLIPPAGE_TOLERANCE_BPS: u32 = 10;
 pub const MAX_SLIPPAGE_TOLERANCE_BPS: u32 = 500;
 pub const MAX_FEE_BPS: u32 = 50;
+pub const DEFAULT_CIRCUIT_BREAKER_SPIKE_THRESHOLD_BPS: u32 = 100; // 1%
+pub const DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS: u64 = 3600; // 1 hour
+pub const DEFAULT_GLOBAL_MAX_SLIPPAGE_BPS: u32 = 300; // 3%
+pub const TIMELOCK_DELAY_SECONDS: u64 = 172800; // 48 hours
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -60,6 +64,8 @@ pub struct Portfolio {
     pub total_value: i128,
     pub is_active: bool,
     pub pause_reason: PauseReason,
+    pub circuit_breaker_config: CircuitBreakerConfig,
+    pub global_max_slippage_bps: u32,
 }
 
 #[contracttype]
@@ -114,6 +120,27 @@ pub struct FeeConfig {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CircuitBreakerConfig {
+    pub spike_threshold_bps: u32,
+    pub window_seconds: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QueuedUpgrade {
+    pub new_wasm_hash: BytesN<32>,
+    pub execute_after: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QueuedFeeConfig {
+    pub config: FeeConfig,
+    pub execute_after: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpgradeEvent {
     pub from_hash: BytesN<32>,
     pub to_hash: BytesN<32>,
@@ -137,6 +164,8 @@ pub enum DataKey {
     LastTimestamp,
     DCAConfig(u64),
     NavHistory(u64),
+    QueuedUpgrade,
+    QueuedFeeConfig,
 }
 
 #[contracttype]
@@ -181,6 +210,7 @@ pub enum Error {
     InvalidAmount = 26,
     WithdrawFailed = 27,
     InvalidAllocationSum = 28,
+    TimelockNotElapsed = 29,
 }
 
 #[contracttype]


### PR DESCRIPTION
…ge/ Add configurable

Closed: #1147 
Closed #1148 
Closed #1155 
Closed #1156 

## Commit Type

- [ x] feat
- [ ] fix
- [ ] perf
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style
- [ ] revert

## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands, screenshots, or checks used to verify the change. -->

## Release Notes

- [ ] User-facing change
- [ ] Breaking change
- [ ] No release note needed

<!-- For breaking changes, include `!` in the commit type or add a `BREAKING CHANGE:` footer so the release changelog flags it. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-portfolio circuit-breaker settings and a portfolio-wide global slippage cap during rebalance.
  * Added `close_portfolio` to sweep remaining positive balances to the owner and remove portfolio state.
* **Bug Fixes**
  * Rebalance now fails when aggregated slippage across all legs exceeds the configured global cap.
* **Security**
  * Fee updates and contract upgrades now follow a queued, delayed timelock flow with early-execution rejection.
* **Tests**
  * Expanded unit tests for circuit-breaker defaults/customization, global slippage aggregation, portfolio closing (including unauthorized attempts), and timelocked fee/upgrade flows and events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->