### PR TITLE
feat(api): add multi-portfolio dashboard summary endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -286,11 +286,56 @@ Response:
 }
 ```
 
+### Multi-Portfolio Dashboard Summary
+
+Summarises every portfolio for one address in a single request, so a dashboard
+listing N portfolios costs one call rather than N. Prices are resolved once from
+the oracle cache and shared across the whole response.
+
+```bash
+GET /api/v1/portfolios/summary?userAddress={address}
+```
+
+Response:
+```json
+{
+  "success": true,
+  "data": {
+    "portfolios": [
+      {
+        "id": "portfolio-abc123",
+        "name": "Core holdings",
+        "total_value_usd": 10000,
+        "drift_status": "warning",
+        "last_rebalanced": "2026-01-02T00:00:00.000Z"
+      }
+    ]
+  },
+  "error": null,
+  "timestamp": "2026-01-02T12:00:00.000Z"
+}
+```
+
+`data.portfolios` is an empty array when the address has no portfolios.
+
+`drift_status` compares the largest allocation drift against that portfolio's own
+`threshold`, so each portfolio is judged against the tolerance its owner chose:
+
+| Status | Condition |
+|---|---|
+| `critical` | Largest drift is past the threshold. This is the same comparison the auto-rebalancer uses to decide a portfolio has drifted. |
+| `warning` | Largest drift is at or above half the threshold, but not past it. |
+| `ok` | Anything below that, including a portfolio holding nothing. |
+
+`name` is `null` for a portfolio that was never named, and an asset with no
+available price contributes zero to `total_value_usd` rather than being assumed.
+
 ### Get Rebalance Plan
 
 - **POST /api/portfolio** — Create portfolio (`userAddress`, `allocations`, `threshold`, optional `slippageTolerance`). Allocations must sum to 100%; threshold 1–50%. Supports `Idempotency-Key`.
 - **GET /api/portfolio/{id}** — Get portfolio by ID.
 - **GET /api/user/{address}/portfolios** — List portfolios for a Stellar address. When JWT auth is enabled, the token subject must match `:address` (otherwise `403`). In demo mode, public-by-address listing is allowed only when `ALLOW_PUBLIC_USER_PORTFOLIOS_IN_DEMO` is enabled.
+- **GET /api/portfolios/summary** — Dashboard summary of every portfolio for one address in a single request (query: `userAddress`, required). Returns `id`, `name`, `total_value_usd`, `drift_status` (`ok`/`warning`/`critical`), and `last_rebalanced` per portfolio; empty array for an unknown address. Prices are read once from the oracle cache for the whole response. Same ownership rules as `GET /api/user/{address}/portfolios`.
 - **GET /api/portfolio/{id}/rebalance-plan** — Get full read-only rebalance plan (per-asset buy/sell amounts, estimated fees, estimated slippage, projected allocations, prices).
 - **POST /api/portfolio/{id}/rebalance/dry-run** — Dry-run rebalance; returns the same response schema as `rebalance-plan` without DB writes, contract calls, or trade execution.
 - **POST /api/portfolio/{id}/rebalance** — Execute rebalance (body optional: `{ options: { simulateOnly, ignoreSafetyChecks, slippageOverrides } }`). Supports `Idempotency-Key`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,11 @@ Release changelog entries are generated into these sections:
 
 ### Added
 
+- Multi-portfolio dashboard summary endpoint `GET /api/v1/portfolios/summary?userAddress=ADDR` ([#974](https://github.com/ritik4ever/stellar-portfolio-rebalancer/issues/974))
+  - Returns `id`, `name`, `total_value_usd`, `drift_status`, and `last_rebalanced` for every portfolio belonging to one address in a single request, replacing one call per portfolio
+  - Resolves prices once from the oracle cache and shares them across the whole response; an address with no portfolios skips the price lookup entirely and returns an empty array
+  - `drift_status` is `ok`, `warning`, or `critical`, measured against each portfolio's own rebalance threshold
+
 - Public roadmap with Now, Next, Later buckets ([#573](https://github.com/ritik4ever/stellar-portfolio-rebalancer/issues/573))
   - Created `docs/ROADMAP.md` with detailed project roadmap
   - Added roadmap summary table to `README.md` for quick reference
@@ -120,6 +125,10 @@ Release changelog entries are generated into these sections:
 - Sharded backend test execution in CI (4 parallel shards with merged coverage and threshold enforcement) plus `test:shard`/`test:merge-coverage` scripts and contributor docs for reproducing it locally.
 - Portable health smoke script (`scripts/health-smoke.sh`, `npm run smoke`) that probes `/health`, `/api/health`, `/ready`, and `/metrics` across local/staging/prod with a clear pass/fail summary, documented in OPERATIONS.md and API.md.
 - Tightened generated-artifact guard: `backend/openapi.json` freshness is now verified by regenerating from source and diffing (replacing a heuristic that referenced a non-existent spec path), wired into the Generated Artifact Guard workflow and documented in backend/docs/openapi.md.
+
+### Fixed
+
+- Portfolio reads dropped the stored `name` and `description`: `rowToPortfolio` never mapped the two columns, so both came back undefined from every read path. A versioned `PUT /portfolio/:id` then merged that undefined over the stored row and wrote the name back as `NULL`, silently erasing it.
 
 ## [1.3.0] - 2026-04-27
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -974,6 +974,112 @@
         }
       }
     },
+    "/api/portfolios/summary": {
+      "get": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Multi-portfolio dashboard summary",
+        "description": "Get a compact summary of every portfolio belonging to one address in a single request, instead of one call per portfolio. Prices are read once from the oracle cache and shared across every portfolio in the response. Returns an empty array when the address has no portfolios. When JWT auth is enabled, only the authenticated user (token subject) may summarise their own address.",
+        "parameters": [
+          {
+            "name": "userAddress",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Stellar address whose portfolios are summarised."
+          }
+        ],
+        "security": [
+          {
+            "adminAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio summaries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "portfolios": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/PortfolioSummary"
+                          }
+                        }
+                      }
+                    },
+                    "error": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "ValidationError": {
+                    "$ref": "#/components/examples/ValidationError"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/portfolio/{id}/rebalance-plan": {
       "get": {
         "tags": [
@@ -994,177 +1100,6 @@
         "responses": {
           "200": {
             "description": "Plan data",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "portfolioId": {
-                          "type": "string"
-                        },
-                        "totalValue": {
-                          "type": "number"
-                        },
-                        "maxSlippagePercent": {
-                          "type": "number"
-                        },
-                        "estimatedSlippageBps": {
-                          "type": "integer"
-                        },
-                        "estimatedFees": {
-                          "type": "object",
-                          "properties": {
-                            "xlm": {
-                              "type": "number"
-                            },
-                            "usd": {
-                              "type": "number"
-                            },
-                            "perTradeXlm": {
-                              "type": "number"
-                            },
-                            "tradeCount": {
-                              "type": "integer"
-                            }
-                          }
-                        },
-                        "assets": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "asset": {
-                                "type": "string"
-                              },
-                              "action": {
-                                "type": "string",
-                                "enum": [
-                                  "buy",
-                                  "sell",
-                                  "hold"
-                                ]
-                              },
-                              "currentBalance": {
-                                "type": "number"
-                              },
-                              "currentValue": {
-                                "type": "number"
-                              },
-                              "currentAllocationPercent": {
-                                "type": "number"
-                              },
-                              "targetAllocationPercent": {
-                                "type": "number"
-                              },
-                              "targetValue": {
-                                "type": "number"
-                              },
-                              "driftPercent": {
-                                "type": "number"
-                              },
-                              "buyAmount": {
-                                "type": "number"
-                              },
-                              "sellAmount": {
-                                "type": "number"
-                              },
-                              "tradeValue": {
-                                "type": "number"
-                              },
-                              "projectedBalance": {
-                                "type": "number"
-                              },
-                              "projectedValue": {
-                                "type": "number"
-                              },
-                              "projectedAllocationPercent": {
-                                "type": "number"
-                              },
-                              "price": {
-                                "type": "number"
-                              }
-                            }
-                          }
-                        },
-                        "projectedAllocations": {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "number"
-                          }
-                        },
-                        "prices": {
-                          "type": "object",
-                          "additionalProperties": {
-                            "$ref": "#/components/schemas/PriceData"
-                          }
-                        },
-                        "priceFeedMeta": {
-                          "type": "object"
-                        }
-                      }
-                    },
-                    "error": {
-                      "type": "object",
-                      "nullable": true
-                    },
-                    "timestamp": {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Portfolio not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/portfolio/{id}/rebalance/dry-run": {
-      "post": {
-        "tags": [
-          "Portfolio"
-        ],
-        "summary": "Dry-run rebalance",
-        "description": "Return the full rebalance plan without executing trades. This dry-run performs no database writes and makes no contract call; use POST /api/portfolio/{id}/rebalance for live execution.",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Dry-run plan data. The response data schema is identical to GET /api/portfolio/{id}/rebalance-plan.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1834,6 +1769,151 @@
           },
           "503": {
             "description": "Price feeds unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/prices/ohlcv": {
+      "get": {
+        "tags": [
+          "Prices & market"
+        ],
+        "summary": "Get OHLCV candles",
+        "description": "Returns OHLCV (open, high, low, close) candles computed from stored price snapshots. Missing intervals are filled with the previous close. Results are cached for 10 minutes.",
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "XLM"
+            },
+            "description": "Asset symbol, e.g. XLM, BTC, ETH, USDC"
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1h",
+                "4h",
+                "1d"
+              ]
+            },
+            "description": "Candle interval"
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Start of time range (ISO 8601)"
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "End of time range (ISO 8601)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OHLCV candle array",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "asset": {
+                          "type": "string"
+                        },
+                        "interval": {
+                          "type": "string"
+                        },
+                        "candles": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "timestamp": {
+                                "type": "number",
+                                "description": "Unix ms of interval start"
+                              },
+                              "open": {
+                                "type": "number"
+                              },
+                              "high": {
+                                "type": "number"
+                              },
+                              "low": {
+                                "type": "number"
+                              },
+                              "close": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "error": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Database unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -2829,6 +2909,49 @@
       },
       "Portfolio": {
         "type": "object"
+      },
+      "PortfolioSummary": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "total_value_usd",
+          "drift_status",
+          "last_rebalanced"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "portfolio-abc123"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "description": "Null when the portfolio was never named.",
+            "example": "Core holdings"
+          },
+          "total_value_usd": {
+            "type": "number",
+            "description": "Current USD value of all holdings. An asset with no available price contributes zero.",
+            "example": 10000
+          },
+          "drift_status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "warning",
+              "critical"
+            ],
+            "description": "Largest allocation drift measured against the portfolio's own rebalance threshold: critical past the threshold, warning from half the threshold up to it, otherwise ok.",
+            "example": "warning"
+          },
+          "last_rebalanced": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "example": "2026-01-02T00:00:00.000Z"
+          }
+        }
       },
       "PriceData": {
         "type": "object"

--- a/backend/src/api/portfolios.routes.ts
+++ b/backend/src/api/portfolios.routes.ts
@@ -20,7 +20,8 @@ import { logger } from '../utils/logger.js'
 import { getErrorObject, getErrorMessage } from '../utils/helpers.js'
 import { ok, fail } from '../utils/apiResponse.js'
 import { ConflictError } from '../types/index.js'
-import { createPortfolioSchema, updatePortfolioSchema, portfolioExportQuerySchema, rebalancePortfolioSchema, portfolioHistoryQuerySchema, portfolioRebalanceHistoryQuerySchema, createDraftSchema, updateDraftSchema } from './validation.js'
+import { createPortfolioSchema, updatePortfolioSchema, portfolioExportQuerySchema, rebalancePortfolioSchema, portfolioHistoryQuerySchema, portfolioRebalanceHistoryQuerySchema, createDraftSchema, updateDraftSchema, portfolioSummaryQuerySchema } from './validation.js'
+import { buildPortfolioSummaries } from '../services/portfolioSummary.js'
 import type { Portfolio } from '../types/index.js'
 import { portfolioImportRouter } from './portfolioImportRoutes.js'
 
@@ -61,6 +62,55 @@ portfoliosRouter.get('/portfolios', async (req: Request, res: Response) => {
 const stellarService = new StellarService()
 const reflectorService = new ReflectorService()
 const featureFlags = getFeatureFlags()
+
+/**
+ * Dashboard summary for every portfolio belonging to one address.
+ *
+ * A dashboard listing N portfolios previously needed N calls to
+ * `GET /portfolio/:id`, each of which resolves prices independently. This
+ * serves the same listing from one database read plus one price lookup,
+ * regardless of how many portfolios come back. Prices come from
+ * `getCurrentPrices()`, which is already backed by the Redis and in-process
+ * oracle caches, so the endpoint does no oracle round trip on a warm cache.
+ */
+portfoliosRouter.get('/portfolios/summary', validateQuery(portfolioSummaryQuerySchema), async (req: Request, res: Response) => {
+    try {
+        const userAddress = req.query.userAddress as string
+
+        // Ownership rules mirror GET /user/:address/portfolios: when auth is on,
+        // an address's portfolios are only visible to that address.
+        const authConfig = getAuthConfig()
+        const allowPublicInDemo =
+            authConfig.enabled &&
+            featureFlags.demoMode &&
+            featureFlags.allowPublicUserPortfoliosInDemo
+
+        if (authConfig.enabled && !allowPublicInDemo) {
+            let nextCalled = false
+            requireJwt(req, res, () => { nextCalled = true })
+            if (!nextCalled) return
+
+            if (req.user?.address !== userAddress) {
+                return fail(res, 403, 'FORBIDDEN', 'You can only view your own portfolios')
+            }
+        }
+
+        const portfolios = await portfolioStorage.getUserPortfolios(userAddress)
+
+        // An unknown address resolves to an empty list without touching the
+        // price feed at all.
+        if (portfolios.length === 0) {
+            return ok(res, { portfolios: [] })
+        }
+
+        const prices = await reflectorService.getCurrentPrices()
+
+        return ok(res, { portfolios: buildPortfolioSummaries(portfolios, prices) })
+    } catch (error) {
+        logger.error('[ERROR] Get portfolio summaries failed', { error: getErrorObject(error) })
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
 
 portfoliosRouter.post('/portfolio', validateRequest(createPortfolioSchema), async (req: Request, res: Response) => {
     try {

--- a/backend/src/api/validation.ts
+++ b/backend/src/api/validation.ts
@@ -57,6 +57,11 @@ export const updatePortfolioSchema = createPortfolioSchema.partial().extend({
     version: z.number().int().min(1, "Version must be a positive integer")
 });
 
+// Schema for GET /portfolios/summary
+export const portfolioSummaryQuerySchema = z.object({
+    userAddress: z.string().min(1, "userAddress is required"),
+});
+
 // Schema for POST /portfolio/:id/rebalance
 export const rebalancePortfolioSchema = z.object({
     options: z.object({

--- a/backend/src/openapi/spec.ts
+++ b/backend/src/openapi/spec.ts
@@ -432,6 +432,45 @@ const spec: Record<string, any> = {
                 },
             },
         },
+        '/api/portfolios/summary': {
+            get: {
+                tags: ['Portfolio'],
+                summary: 'Multi-portfolio dashboard summary',
+                description: 'Get a compact summary of every portfolio belonging to one address in a single request, instead of one call per portfolio. Prices are read once from the oracle cache and shared across every portfolio in the response. Returns an empty array when the address has no portfolios. When JWT auth is enabled, only the authenticated user (token subject) may summarise their own address.',
+                parameters: [{ name: 'userAddress', in: 'query', required: true, schema: { type: 'string' }, description: 'Stellar address whose portfolios are summarised.' }],
+                security: [{ adminAuth: [] }],
+                responses: {
+                    '200': {
+                        description: 'Portfolio summaries',
+                        content: {
+                            'application/json': {
+                                schema: {
+                                    type: 'object',
+                                    properties: {
+                                        success: { type: 'boolean' },
+                                        data: {
+                                            type: 'object',
+                                            properties: {
+                                                portfolios: {
+                                                    type: 'array',
+                                                    items: { $ref: '#/components/schemas/PortfolioSummary' },
+                                                },
+                                            },
+                                        },
+                                        error: { type: 'object', nullable: true },
+                                        timestamp: { type: 'string', format: 'date-time' },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    '401': { description: 'Unauthorized', content: { 'application/json': { schema: { $ref: '#/components/schemas/ApiError' } } } },
+                    '403': { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/ApiError' } } } },
+                    '422': { description: 'Validation error', content: { 'application/json': { schema: { $ref: '#/components/schemas/ApiError' }, examples: { ValidationError: { $ref: '#/components/examples/ValidationError' } } } } },
+                    '500': { description: 'Internal error', content: { 'application/json': { schema: { $ref: '#/components/schemas/ApiError' } } } },
+                },
+            },
+        },
         '/api/portfolio/{id}/rebalance-plan': {
             get: {
                 tags: ['Portfolio'],
@@ -1272,6 +1311,22 @@ const spec: Record<string, any> = {
                 },
             },
             Portfolio: { type: 'object' },
+            PortfolioSummary: {
+                type: 'object',
+                required: ['id', 'name', 'total_value_usd', 'drift_status', 'last_rebalanced'],
+                properties: {
+                    id: { type: 'string', example: 'portfolio-abc123' },
+                    name: { type: 'string', nullable: true, description: 'Null when the portfolio was never named.', example: 'Core holdings' },
+                    total_value_usd: { type: 'number', description: 'Current USD value of all holdings. An asset with no available price contributes zero.', example: 10000 },
+                    drift_status: {
+                        type: 'string',
+                        enum: ['ok', 'warning', 'critical'],
+                        description: 'Largest allocation drift measured against the portfolio\'s own rebalance threshold: critical past the threshold, warning from half the threshold up to it, otherwise ok.',
+                        example: 'warning',
+                    },
+                    last_rebalanced: { type: 'string', format: 'date-time', nullable: true, example: '2026-01-02T00:00:00.000Z' },
+                },
+            },
             PriceData: { type: 'object' },
             RiskMetrics: { type: 'object' },
             RebalanceResult: { type: 'object' },

--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -40,6 +40,8 @@ export interface RebalanceHistoryQueryOptions {
 interface PortfolioRow {
   id: string;
   user_address: string;
+  name?: string | null;
+  description?: string | null;
   allocations: string;
   threshold: number;
   slippage_tolerance_percent?: number;
@@ -467,6 +469,12 @@ function rowToPortfolio(row: PortfolioRow): Portfolio {
   return {
     id: row.id,
     userAddress: row.user_address,
+    // `name` and `description` are persisted on create and on versioned
+    // update, so they have to be read back here. Dropping them made every
+    // versioned update rewrite the stored name as NULL, because the merge
+    // that feeds the UPDATE started from a row that had already lost it.
+    ...(row.name == null ? {} : { name: row.name }),
+    ...(row.description == null ? {} : { description: row.description }),
     allocations: safeJsonParse(
       row.allocations,
       {},

--- a/backend/src/services/portfolioSummary.ts
+++ b/backend/src/services/portfolioSummary.ts
@@ -1,0 +1,111 @@
+/**
+ * Portfolio summary projection.
+ *
+ * Builds the compact per-portfolio view served by
+ * `GET /api/v1/portfolios/summary`: current USD value, a coarse drift status,
+ * and the last rebalance timestamp.
+ *
+ * These are pure functions over an already-fetched price map. The caller reads
+ * prices once and passes the same map for every portfolio, which is what keeps
+ * a dashboard render at one price lookup instead of one per portfolio.
+ *
+ * Valuation follows `rebalancePlan.ts`: assets are the union of the allocation
+ * targets and the held balances, a missing price contributes zero rather than
+ * being assumed, and all arithmetic goes through `Dec` so repeated addition
+ * does not accumulate float error.
+ */
+
+import { Dec } from '../utils/decimal.js'
+import type { Portfolio, PricesMap } from '../types/index.js'
+
+export type DriftStatus = 'ok' | 'warning' | 'critical'
+
+export interface PortfolioSummary {
+    id: string
+    name: string | null
+    total_value_usd: number
+    drift_status: DriftStatus
+    last_rebalanced: string | null
+}
+
+/**
+ * Fraction of a portfolio's own rebalance threshold at which drift stops being
+ * `ok` and becomes `warning`. Drift past the threshold itself is `critical`.
+ *
+ * The bands are relative to each portfolio's configured threshold rather than
+ * fixed percentages, so a 2%-threshold portfolio and a 10%-threshold portfolio
+ * both report against the tolerance their owner actually chose.
+ */
+export const DRIFT_WARNING_RATIO = 0.5
+
+/** Assets that carry a target weight, a balance, or both. */
+function assetSymbols(portfolio: Portfolio): string[] {
+    return Array.from(new Set([
+        ...Object.keys(portfolio.allocations || {}),
+        ...Object.keys(portfolio.balances || {})
+    ])).sort()
+}
+
+/** Current USD value of everything the portfolio holds. */
+export function computeTotalValueUsd(portfolio: Portfolio, prices: PricesMap): number {
+    return assetSymbols(portfolio).reduce((sum, asset) => {
+        const balance = portfolio.balances?.[asset] ?? 0
+        const price = prices[asset]?.price ?? 0
+        return Dec.add(sum, Dec.mul(balance, price))
+    }, 0)
+}
+
+/**
+ * Largest gap, in percentage points, between any asset's current weight and its
+ * target weight. Returns 0 for an empty or unpriced portfolio, where no weight
+ * is defined.
+ */
+export function computeMaxDriftPercent(
+    portfolio: Portfolio,
+    prices: PricesMap,
+    totalValueUsd: number
+): number {
+    if (totalValueUsd <= 0) return 0
+
+    return assetSymbols(portfolio).reduce((max, asset) => {
+        const balance = portfolio.balances?.[asset] ?? 0
+        const price = prices[asset]?.price ?? 0
+        const currentPercent = Dec.percentage(Dec.mul(balance, price), totalValueUsd)
+        const targetPercent = portfolio.allocations?.[asset] ?? 0
+        return Math.max(max, Dec.drift(currentPercent, targetPercent))
+    }, 0)
+}
+
+/**
+ * Classify drift against the portfolio's rebalance threshold.
+ *
+ * `critical` uses the same comparison the auto-rebalancer uses to decide a
+ * portfolio has drifted, so a portfolio reported critical here is one the
+ * rebalancer would act on.
+ */
+export function classifyDrift(maxDriftPercent: number, threshold: number): DriftStatus {
+    if (maxDriftPercent > threshold) return 'critical'
+    if (threshold > 0 && maxDriftPercent >= threshold * DRIFT_WARNING_RATIO) return 'warning'
+    return 'ok'
+}
+
+export function buildPortfolioSummary(portfolio: Portfolio, prices: PricesMap): PortfolioSummary {
+    const totalValueUsd = computeTotalValueUsd(portfolio, prices)
+    const maxDriftPercent = computeMaxDriftPercent(portfolio, prices, totalValueUsd)
+
+    return {
+        id: portfolio.id,
+        name: portfolio.name ?? null,
+        total_value_usd: totalValueUsd,
+        drift_status: classifyDrift(maxDriftPercent, portfolio.threshold),
+        last_rebalanced: portfolio.lastRebalance ?? null
+    }
+}
+
+/** Project a whole set of portfolios against one shared price map. */
+export function buildPortfolioSummaries(
+    portfolios: Portfolio[],
+    prices: PricesMap
+): PortfolioSummary[] {
+    return portfolios.map((portfolio) => buildPortfolioSummary(portfolio, prices))
+}

--- a/backend/src/test/portfolioSummary.routes.test.ts
+++ b/backend/src/test/portfolioSummary.routes.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
+import express from 'express'
+import type { Express } from 'express'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { mkdirSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+vi.mock('../utils/logger.js', () => ({
+    logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+    }
+}))
+
+// The price feed is stubbed so the endpoint's own cost is what gets measured,
+// and so `getCurrentPrices` call counts are a direct check that the route does
+// one price lookup for the whole page rather than one per portfolio.
+const { getCurrentPrices } = vi.hoisted(() => ({
+    getCurrentPrices: vi.fn(async () => ({
+        XLM: { price: 0.5, change: 0, timestamp: 0 },
+        USDC: { price: 1, change: 0, timestamp: 0 }
+    }))
+}))
+
+vi.mock('../services/reflector.js', () => ({
+    ReflectorService: class {
+        getCurrentPrices = getCurrentPrices
+        getCurrentPricesWithMeta = vi.fn(async () => ({
+            prices: await getCurrentPrices(),
+            feedMeta: {}
+        }))
+    }
+}))
+
+const OWNER_ADDRESS = 'GSUMMARYOWNER123456789ABCDEF'
+const OTHER_ADDRESS = 'GSUMMARYOTHER123456789ABCDEF'
+const UNKNOWN_ADDRESS = 'GSUMMARYNOBODY123456789ABCDE'
+const JWT_SECRET = 'test-jwt-secret-for-summary-tests-min-32!!'
+
+const SUMMARY_PATH = '/api/portfolios/summary'
+
+let app: Express
+let testDbPath: string
+let portfolioStorage: any
+
+async function createApp(): Promise<Express> {
+    const app = express()
+    app.use(express.json())
+    app.set('trust proxy', 1)
+
+    const { portfoliosRouter } = await import('../api/portfolios.routes.js') as any
+    app.use('/api', portfoliosRouter)
+
+    return app
+}
+
+/** Seed one portfolio and return its id. */
+function seedPortfolio(
+    userAddress: string,
+    allocations: Record<string, number>,
+    balances: Record<string, number>,
+    threshold = 5
+): string {
+    return portfolioStorage.createPortfolioWithBalances(userAddress, allocations, threshold, balances)
+}
+
+beforeAll(async () => {
+    process.env.NODE_ENV = 'test'
+    delete process.env.JWT_SECRET
+
+    const testDir = join(tmpdir(), `stellar-summary-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(testDir, { recursive: true })
+    testDbPath = join(testDir, 'test.db')
+    process.env.DB_PATH = testDbPath
+
+    const dbModule = await import('../services/databaseService.js') as any
+    portfolioStorage = dbModule.databaseService
+
+    app = await createApp()
+})
+
+afterAll(() => {
+    if (existsSync(testDbPath)) {
+        try { rmSync(testDbPath, { force: true }) } catch { /* temp file */ }
+    }
+    delete process.env.DB_PATH
+    delete process.env.JWT_SECRET
+})
+
+beforeEach(() => {
+    getCurrentPrices.mockClear()
+})
+
+describe('GET /portfolios/summary', () => {
+    it('returns an empty array for an address with no portfolios', async () => {
+        const res = await request(app).get(SUMMARY_PATH).query({ userAddress: UNKNOWN_ADDRESS })
+
+        expect(res.status).toBe(200)
+        expect(res.body.success).toBe(true)
+        expect(res.body.data.portfolios).toEqual([])
+    })
+
+    it('does not touch the price feed when the address has no portfolios', async () => {
+        await request(app).get(SUMMARY_PATH).query({ userAddress: UNKNOWN_ADDRESS })
+
+        expect(getCurrentPrices).not.toHaveBeenCalled()
+    })
+
+    it('rejects a request with no userAddress', async () => {
+        const res = await request(app).get(SUMMARY_PATH)
+
+        expect(res.status).toBe(422)
+        expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('returns the documented fields for each portfolio', async () => {
+        const address = `${OWNER_ADDRESS}-FIELDS`
+        const id = seedPortfolio(address, { XLM: 50, USDC: 50 }, { XLM: 100, USDC: 50 })
+        portfolioStorage.updatePortfolio(id, { name: 'Core holdings' }, 1)
+
+        const res = await request(app).get(SUMMARY_PATH).query({ userAddress: address })
+
+        expect(res.status).toBe(200)
+        expect(res.body.data.portfolios).toHaveLength(1)
+
+        const summary = res.body.data.portfolios[0]
+        expect(Object.keys(summary).sort()).toEqual([
+            'drift_status',
+            'id',
+            'last_rebalanced',
+            'name',
+            'total_value_usd'
+        ])
+        expect(summary.id).toBe(id)
+        expect(summary.name).toBe('Core holdings')
+        expect(summary.total_value_usd).toBe(100)
+        expect(summary.drift_status).toBe('ok')
+        expect(typeof summary.last_rebalanced).toBe('string')
+    })
+
+    it('reports a null name for a portfolio that was never named', async () => {
+        const address = `${OWNER_ADDRESS}-UNNAMED`
+        seedPortfolio(address, { XLM: 100 }, { XLM: 100 })
+
+        const res = await request(app).get(SUMMARY_PATH).query({ userAddress: address })
+
+        expect(res.body.data.portfolios[0].name).toBeNull()
+    })
+
+    it('classifies drift as ok, warning, and critical from real balances', async () => {
+        const address = `${OWNER_ADDRESS}-DRIFT`
+        // Priced at XLM $0.50 / USDC $1.00 against a 50/50 target and a 5% threshold.
+        seedPortfolio(address, { XLM: 50, USDC: 50 }, { XLM: 100, USDC: 50 })   // 50/50  -> 0pp
+        seedPortfolio(address, { XLM: 50, USDC: 50 }, { XLM: 106, USDC: 47 })   // 53/47  -> 3pp
+        seedPortfolio(address, { XLM: 50, USDC: 50 }, { XLM: 160, USDC: 20 })   // 80/20  -> 30pp
+
+        const res = await request(app).get(SUMMARY_PATH).query({ userAddress: address })
+
+        const statuses = res.body.data.portfolios.map((p: any) => p.drift_status)
+        expect(statuses.sort()).toEqual(['critical', 'ok', 'warning'])
+    })
+
+    it('values a portfolio holding an asset with no price at zero for that asset', async () => {
+        const address = `${OWNER_ADDRESS}-UNPRICED`
+        seedPortfolio(address, { XLM: 50, NOPRICE: 50 }, { XLM: 100, NOPRICE: 999 })
+
+        const res = await request(app).get(SUMMARY_PATH).query({ userAddress: address })
+
+        expect(res.body.data.portfolios[0].total_value_usd).toBe(50)
+    })
+
+    it('returns only the requested address\'s portfolios', async () => {
+        const mine = `${OWNER_ADDRESS}-SCOPED`
+        const theirs = `${OTHER_ADDRESS}-SCOPED`
+        seedPortfolio(mine, { XLM: 100 }, { XLM: 10 })
+        seedPortfolio(theirs, { XLM: 100 }, { XLM: 10 })
+
+        const res = await request(app).get(SUMMARY_PATH).query({ userAddress: mine })
+
+        expect(res.body.data.portfolios).toHaveLength(1)
+    })
+})
+
+describe('GET /portfolios/summary — one request instead of N', () => {
+    const address = `${OWNER_ADDRESS}-TEN`
+
+    beforeAll(() => {
+        for (let i = 0; i < 10; i++) {
+            seedPortfolio(address, { XLM: 50, USDC: 50 }, { XLM: 100 + i * 4, USDC: 50 - i })
+        }
+    })
+
+    it('resolves prices once for ten portfolios', async () => {
+        const res = await request(app).get(SUMMARY_PATH).query({ userAddress: address })
+
+        expect(res.body.data.portfolios).toHaveLength(10)
+        expect(getCurrentPrices).toHaveBeenCalledTimes(1)
+    })
+
+    it('answers within the 300ms budget for ten portfolios', async () => {
+        // Warm up first so the measurement reflects steady-state serving rather
+        // than one-off statement preparation on a cold sqlite handle.
+        await request(app).get(SUMMARY_PATH).query({ userAddress: address })
+
+        const startedAt = performance.now()
+        const res = await request(app).get(SUMMARY_PATH).query({ userAddress: address })
+        const elapsedMs = performance.now() - startedAt
+
+        expect(res.status).toBe(200)
+        expect(res.body.data.portfolios).toHaveLength(10)
+        expect(elapsedMs).toBeLessThan(300)
+    })
+})
+
+describe('GET /portfolios/summary — ownership', () => {
+    const address = `${OWNER_ADDRESS}-AUTH`
+
+    beforeAll(() => {
+        seedPortfolio(address, { XLM: 100 }, { XLM: 10 })
+        process.env.JWT_SECRET = JWT_SECRET
+    })
+
+    afterAll(() => {
+        delete process.env.JWT_SECRET
+    })
+
+    function authHeader(forAddress: string): Record<string, string> {
+        const token = jwt.sign({ sub: forAddress, type: 'access' }, JWT_SECRET, { expiresIn: '15m' })
+        return { Authorization: `Bearer ${token}` }
+    }
+
+    it('rejects an unauthenticated request when auth is enabled', async () => {
+        const res = await request(app).get(SUMMARY_PATH).query({ userAddress: address })
+
+        expect(res.status).toBe(401)
+    })
+
+    it('rejects a caller asking for someone else\'s portfolios', async () => {
+        const res = await request(app)
+            .get(SUMMARY_PATH)
+            .query({ userAddress: address })
+            .set(authHeader(OTHER_ADDRESS))
+
+        expect(res.status).toBe(403)
+        expect(res.body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('serves the owner their own portfolios', async () => {
+        const res = await request(app)
+            .get(SUMMARY_PATH)
+            .query({ userAddress: address })
+            .set(authHeader(address))
+
+        expect(res.status).toBe(200)
+        expect(res.body.data.portfolios).toHaveLength(1)
+    })
+})

--- a/backend/src/test/portfolioSummary.service.test.ts
+++ b/backend/src/test/portfolioSummary.service.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import {
+    buildPortfolioSummaries,
+    buildPortfolioSummary,
+    classifyDrift,
+    computeMaxDriftPercent,
+    computeTotalValueUsd,
+    DRIFT_WARNING_RATIO
+} from '../services/portfolioSummary.js'
+import type { Portfolio, PricesMap } from '../types/index.js'
+
+function priceMap(prices: Record<string, number>): PricesMap {
+    return Object.fromEntries(
+        Object.entries(prices).map(([asset, price]) => [asset, { price, change: 0, timestamp: 0 }])
+    )
+}
+
+function portfolio(overrides: Partial<Portfolio> = {}): Portfolio {
+    return {
+        id: 'p-1',
+        userAddress: 'GTESTADDRESS',
+        allocations: { XLM: 50, USDC: 50 },
+        threshold: 5,
+        balances: { XLM: 100, USDC: 50 },
+        totalValue: 0,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        lastRebalance: '2026-01-02T00:00:00.000Z',
+        version: 1,
+        ...overrides
+    }
+}
+
+// XLM at $0.50 and USDC at $1.00 makes a 100 XLM / 50 USDC portfolio exactly
+// 50/50 by value, which keeps the drift arithmetic below easy to follow.
+const PRICES = priceMap({ XLM: 0.5, USDC: 1 })
+
+describe('computeTotalValueUsd', () => {
+    it('values every held asset at its current price', () => {
+        expect(computeTotalValueUsd(portfolio(), PRICES)).toBe(100)
+    })
+
+    it('treats an unpriced asset as zero rather than assuming a price', () => {
+        const p = portfolio({ allocations: { XLM: 50, MISSING: 50 }, balances: { XLM: 100, MISSING: 999 } })
+        expect(computeTotalValueUsd(p, PRICES)).toBe(50)
+    })
+
+    it('returns zero for a portfolio holding nothing', () => {
+        expect(computeTotalValueUsd(portfolio({ balances: {} }), PRICES)).toBe(0)
+    })
+
+    it('counts a held asset that has no target allocation', () => {
+        const p = portfolio({ allocations: { XLM: 100 }, balances: { XLM: 100, USDC: 25 } })
+        expect(computeTotalValueUsd(p, PRICES)).toBe(75)
+    })
+})
+
+describe('computeMaxDriftPercent', () => {
+    it('is zero when current weights match targets', () => {
+        const total = computeTotalValueUsd(portfolio(), PRICES)
+        expect(computeMaxDriftPercent(portfolio(), PRICES, total)).toBe(0)
+    })
+
+    it('reports the largest gap in percentage points', () => {
+        // 60 USD of XLM and 40 USDC against a 50/50 target is 10pp on both legs.
+        const p = portfolio({ balances: { XLM: 120, USDC: 40 } })
+        const total = computeTotalValueUsd(p, PRICES)
+        expect(total).toBe(100)
+        expect(computeMaxDriftPercent(p, PRICES, total)).toBe(10)
+    })
+
+    it('counts an untargeted holding as full drift against a zero target', () => {
+        const p = portfolio({ allocations: { XLM: 100 }, balances: { XLM: 100, USDC: 50 } })
+        const total = computeTotalValueUsd(p, PRICES)
+        expect(computeMaxDriftPercent(p, PRICES, total)).toBe(50)
+    })
+
+    it('is zero when the portfolio has no value to weight against', () => {
+        expect(computeMaxDriftPercent(portfolio({ balances: {} }), PRICES, 0)).toBe(0)
+    })
+})
+
+describe('classifyDrift', () => {
+    it('is ok below the warning band', () => {
+        expect(classifyDrift(2, 5)).toBe('ok')
+    })
+
+    it('enters warning at half the threshold', () => {
+        expect(classifyDrift(5 * DRIFT_WARNING_RATIO, 5)).toBe('warning')
+    })
+
+    it('stays warning at exactly the threshold', () => {
+        // The auto-rebalancer treats drift as exceeded only past the threshold,
+        // so the boundary itself must not read as critical here either.
+        expect(classifyDrift(5, 5)).toBe('warning')
+    })
+
+    it('is critical past the threshold', () => {
+        expect(classifyDrift(5.01, 5)).toBe('critical')
+    })
+
+    it('scales the bands to each portfolio threshold', () => {
+        expect(classifyDrift(6, 20)).toBe('ok')
+        expect(classifyDrift(6, 10)).toBe('warning')
+        expect(classifyDrift(6, 2)).toBe('critical')
+    })
+
+    it('treats any drift as critical when the threshold is zero', () => {
+        expect(classifyDrift(0, 0)).toBe('ok')
+        expect(classifyDrift(0.1, 0)).toBe('critical')
+    })
+})
+
+describe('buildPortfolioSummary', () => {
+    it('projects the dashboard fields for a balanced portfolio', () => {
+        expect(buildPortfolioSummary(portfolio({ name: 'Core' }), PRICES)).toEqual({
+            id: 'p-1',
+            name: 'Core',
+            total_value_usd: 100,
+            drift_status: 'ok',
+            last_rebalanced: '2026-01-02T00:00:00.000Z'
+        })
+    })
+
+    it('reports a null name when the portfolio was never named', () => {
+        expect(buildPortfolioSummary(portfolio(), PRICES).name).toBeNull()
+    })
+
+    it('surfaces each drift band from real balances', () => {
+        const ok = portfolio({ balances: { XLM: 100, USDC: 50 } })
+        const warning = portfolio({ balances: { XLM: 106, USDC: 47 } })
+        const critical = portfolio({ balances: { XLM: 160, USDC: 20 } })
+
+        expect(buildPortfolioSummary(ok, PRICES).drift_status).toBe('ok')
+        expect(buildPortfolioSummary(warning, PRICES).drift_status).toBe('warning')
+        expect(buildPortfolioSummary(critical, PRICES).drift_status).toBe('critical')
+    })
+
+    it('reports an empty portfolio as ok with no value', () => {
+        const summary = buildPortfolioSummary(portfolio({ balances: {} }), PRICES)
+        expect(summary.total_value_usd).toBe(0)
+        expect(summary.drift_status).toBe('ok')
+    })
+})
+
+describe('buildPortfolioSummaries', () => {
+    it('projects every portfolio against one shared price map', () => {
+        const summaries = buildPortfolioSummaries(
+            [portfolio({ id: 'a' }), portfolio({ id: 'b', balances: { XLM: 160, USDC: 20 } })],
+            PRICES
+        )
+
+        expect(summaries.map((s) => s.id)).toEqual(['a', 'b'])
+        expect(summaries.map((s) => s.drift_status)).toEqual(['ok', 'critical'])
+    })
+
+    it('returns an empty array for no portfolios', () => {
+        expect(buildPortfolioSummaries([], PRICES)).toEqual([])
+    })
+})


### PR DESCRIPTION
# Description

Adds the multi-portfolio dashboard summary endpoint from #974, so a dashboard listing N portfolios costs one request instead of N.

Fixes #974

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

---

## The endpoint

```
GET /api/v1/portfolios/summary?userAddress=ADDR
```

```json
{
  "success": true,
  "data": {
    "portfolios": [
      {
        "id": "portfolio-abc123",
        "name": "Core holdings",
        "total_value_usd": 10000,
        "drift_status": "warning",
        "last_rebalanced": "2026-01-02T00:00:00.000Z"
      }
    ]
  },
  "error": null,
  "timestamp": "2026-01-02T12:00:00.000Z"
}
```

The array is returned as `data.portfolios` rather than a bare top-level array, matching the response envelope every other endpoint in this API uses and the shape of the existing `GET /user/{address}/portfolios`.

## How the acceptance criteria are met

| Criterion | How |
|---|---|
| Single request instead of N | One `getUserPortfolios` query (a single `SELECT`) plus one `getCurrentPrices()` call, regardless of portfolio count. A test asserts the price feed is called exactly once for 10 portfolios, which is the check that actually catches an N+1 regression later. |
| Response time < 300ms for 10 portfolios | Asserted in `portfolioSummary.routes.test.ts` against 10 seeded portfolios. |
| Returns empty array for unknown address | Returned as `data.portfolios: []`, and the handler short-circuits before the price lookup, so an unknown address does no oracle work at all. Covered by two tests. |
| Drift status ok / warning / critical | See below. |

## Prices from cache

`reflectorService.getCurrentPrices()` already sits behind the Redis (`oracle:prices`) and in-process caches, so on a warm cache this endpoint does no oracle round trip. The important part is that the price map is resolved **once per request** and shared across every portfolio, rather than per portfolio.

## How drift_status is decided

The issue specifies the three values but not the bands. These are measured against each portfolio's own `threshold` rather than fixed percentages, so a 2%-threshold portfolio and a 10%-threshold one are each judged against the tolerance their owner actually configured:

| Status | Condition |
|---|---|
| `critical` | Largest drift is past the threshold. This is the same comparison `computeDrift` in `jobs/autoRebalance.ts` uses to decide a portfolio has drifted, so anything reported `critical` is something the auto-rebalancer would act on. |
| `warning` | Largest drift is at or above half the threshold, but not past it. |
| `ok` | Below that, including a portfolio holding nothing. |

The half-threshold ratio is a named constant (`DRIFT_WARNING_RATIO`), not a magic number, so it is one edit if you want a different band.

## Implementation notes

Valuation and drift live in a new `backend/src/services/portfolioSummary.ts` as pure functions over an already-fetched price map, which is what makes the "one price lookup for the whole page" property structural rather than incidental. They follow the conventions already established in `services/rebalancePlan.ts`, the most precision-careful module in this area:

- assets are the union of allocation targets and held balances, so an asset held with no target counts as drift instead of being invisible
- a missing price contributes **zero** rather than being assumed to be $1
- arithmetic goes through `Dec`, so summing many holdings does not accumulate float error

Ownership rules mirror `GET /user/{address}/portfolios` exactly: with JWT auth enabled, an address's portfolios are only visible to that address (`401` unauthenticated, `403` for someone else's address), with the same `ALLOW_PUBLIC_USER_PORTFOLIOS_IN_DEMO` escape hatch. The issue did not mention auth, but leaving this endpoint open would have been a way to enumerate any address's holdings, so it is gated the same way the equivalent existing endpoint is.

## The included bug fix

The issue requires `name` in the response, and it could not have worked: `rowToPortfolio` never mapped the `name` and `description` columns, so both came back `undefined` from every portfolio read, even though `SELECT *` returns them and both `stellarService.createPortfolio` and the versioned `updatePortfolio` write them.

That was also losing data. `updatePortfolio` merges the caller's changes over the stored row; because the stored row had already dropped the name, the merge wrote it back as `NULL`. **Naming a portfolio and then updating anything else erased the name.** This also affected `GET /portfolio/{id}` and `GET /user/{address}/portfolios`, which have been silently omitting the field.

It is a separate commit (`fix(db): ...`) so it can be reviewed, or reverted, independently of the feature.

# 📖 API Changes & Breaking Changes Checklist

- [x] **OpenAPI Spec:** Updated `backend/src/openapi/spec.ts` and regenerated `backend/openapi.json` via `npm run openapi:export`. Added a `PortfolioSummary` component schema.
- [x] **API Documentation:** Updated `API.md` with a worked example, the drift band table, and an entry in the checked endpoint list.
- [x] **Changelog:** Added entries under `[Unreleased]` for both the feature and the fix.
- [x] **Migration Notes:** None needed. The endpoint is additive. The fix is additive too: responses that previously omitted `name`/`description` now include them when set, and no field changes type or disappears.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] **This PR links to an issue or provides a rationale for no issue**
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Validation

33 new tests, all passing: 20 unit tests over the projection (valuation, drift, every band boundary including the exact-threshold case) and 13 route tests (empty address, validation, field shape, drift bands end to end, unpriced asset, address scoping, one-price-call, the 300ms budget, and all three auth outcomes).

I ran the full backend suite on a clean `upstream/main` checkout and on this branch and compared the results, because several suites fail locally without Redis and a raw pass/fail count would not have been meaningful:

| | Failed files | Failed tests | Passed tests |
|---|---|---|---|
| `upstream/main` | 39 | 132 | 530 |
| this branch | 39 | 132 | 563 |

Identical failure sets, no newly failing file, and passed tests up by exactly the 33 I added. `npx tsc --noEmit` reports the same 8 pre-existing errors before and after, none in files this PR touches.

## Three pre-existing issues I ran into, not addressed here

Flagging these because they affect CI on this PR and are not caused by it:

1. **`backend/package-lock.json` is out of sync with `backend/package.json`,** so `npm ci` (what every backend CI job runs) fails with `Missing: node-telegram-bot-api@0.67.0 from lock file`. It came in with #1106, which added the dependency without updating the lock. I installed locally without saving to keep it out of this diff. This needs a lockfile refresh in its own PR, and until then backend CI cannot install.

2. **`npm run api:validate` fails on main** with 25 endpoints present in `spec.ts` but missing from `API.md` (`GET /`, `/health`, `/ready`, `/api/prices`, and others). The count is 25 both before and after this PR: the endpoint added here is documented and is not among them.

3. **`npm run spec:check` fails on main** over a trailing newline, because the committed `openapi.json` ends with one and the exporter does not emit it. Regenerating the file here happens to fix that, so `spec:check` passes on this branch.

Happy to open a separate PR for the lockfile if that is useful, since it currently blocks CI for everyone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a portfolio summary API that returns multiple portfolios with total value, drift status, name, and rebalance date.
  - Added an OHLCV price candles API with asset, interval, and time-range filters.
  - Documented both endpoints and their response formats.

- **Bug Fixes**
  - Preserved portfolio names and descriptions when reading and updating portfolio data.
  - Clarified handling of unpriced assets, empty portfolios, and authorization responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->