### PR TITLE
feat: add testnet/mainnet switch confirmation modal

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,8 @@ import Compare from './pages/Compare'
 import Shortcuts from './components/Shortcuts'
 import Onboarding, { resetOnboarding } from './components/Onboarding'
 import OnboardingChecklist from './components/OnboardingChecklist'
+import { useNetworkDetection } from './hooks/useNetworkDetection'
+import { NetworkSwitchModal } from './components/NetworkSwitchModal'
 
 function App() {
     const queryClient = useQueryClient()
@@ -55,6 +57,20 @@ function App() {
     const [sessionRecoverySource, setSessionRecoverySource] = useState<string | null>(null)
     const [isRecoveringSession, setIsRecoveringSession] = useState(false)
     const { notices, loadError, loading: readinessLoading, bootReady } = useReadinessReport()
+    
+    // Network detection and confirmation
+    const {
+        walletNetwork,
+        pendingWalletNetwork,
+        confirmNetworkSwitch,
+        cancelNetworkSwitch
+    } = useNetworkDetection()
+    
+    const handleConfirmNetworkSwitch = async () => {
+        confirmNetworkSwitch()
+        await queryClient.invalidateQueries()
+    }
+    
     const [apiCompatibility, setApiCompatibility] = useState<ApiCompatibilityResult | null>(null)
     const [apiCompatibilityDismissed, setApiCompatibilityDismissed] = useState(false)
     const [apiCompatibilityLoading, setApiCompatibilityLoading] = useState(true)
@@ -358,6 +374,14 @@ function App() {
                     }
                 }}
             />
+            {pendingWalletNetwork && walletNetwork && (
+                <NetworkSwitchModal
+                    currentNetwork={walletNetwork}
+                    pendingNetwork={pendingWalletNetwork}
+                    onConfirm={handleConfirmNetworkSwitch}
+                    onCancel={cancelNetworkSwitch}
+                />
+            )}
             <Onboarding />
             <OnboardingChecklist publicKey={publicKey} onNavigate={handleNavigate} />
             {sessionRecovery ? (

--- a/frontend/src/components/NetworkSwitchModal.test.tsx
+++ b/frontend/src/components/NetworkSwitchModal.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { NetworkSwitchModal } from './NetworkSwitchModal'
+import '@testing-library/jest-dom'
+
+describe('NetworkSwitchModal', () => {
+  it('renders correctly for a testnet to mainnet switch', () => {
+    const onConfirm = vi.fn()
+    const onCancel = vi.fn()
+
+    render(
+      <NetworkSwitchModal
+        currentNetwork="testnet"
+        pendingNetwork="mainnet"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    )
+
+    expect(screen.getByText(/Network Switch Detected/i)).toBeInTheDocument()
+    expect(screen.getByText(/Warning: Real Funds Implication/i)).toBeInTheDocument()
+    
+    const confirmButton = screen.getByRole('button', { name: /Proceed to Mainnet/i })
+    expect(confirmButton).toBeInTheDocument()
+    
+    fireEvent.click(confirmButton)
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    
+    const cancelButton = screen.getByRole('button', { name: /Cancel Switch/i })
+    fireEvent.click(cancelButton)
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders correctly for a mainnet to testnet switch without funds warning', () => {
+    const onConfirm = vi.fn()
+    const onCancel = vi.fn()
+
+    render(
+      <NetworkSwitchModal
+        currentNetwork="mainnet"
+        pendingNetwork="testnet"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    )
+
+    expect(screen.queryByText(/Warning: Real Funds Implication/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Proceed to Testnet/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/NetworkSwitchModal.tsx
+++ b/frontend/src/components/NetworkSwitchModal.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { StellarNetwork } from '../utils/networkDetection'
+
+interface NetworkSwitchModalProps {
+  pendingNetwork: StellarNetwork
+  currentNetwork: StellarNetwork
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+const NETWORK_LABELS: Record<StellarNetwork, string> = {
+  testnet: 'Testnet',
+  mainnet: 'Mainnet (Public)',
+  standalone: 'Standalone / Sandbox',
+  futurenet: 'Futurenet',
+  unknown: 'Unknown',
+}
+
+export const NetworkSwitchModal: React.FC<NetworkSwitchModalProps> = ({
+  pendingNetwork,
+  currentNetwork,
+  onConfirm,
+  onCancel,
+}) => {
+  const isSwitchingToMainnet = pendingNetwork === 'mainnet'
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-slate-900" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+        <h2 id="modal-title" className="text-xl font-bold text-slate-900 dark:text-white">
+          Network Switch Detected
+        </h2>
+        
+        <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
+          Your wallet has switched from <strong>{NETWORK_LABELS[currentNetwork] || currentNetwork}</strong> to <strong>{NETWORK_LABELS[pendingNetwork] || pendingNetwork}</strong>.
+        </p>
+
+        {isSwitchingToMainnet && (
+          <div className="mt-4 rounded-lg bg-red-50 p-4 border border-red-200 dark:bg-red-950/30 dark:border-red-900">
+            <p className="text-sm font-semibold text-red-800 dark:text-red-300">
+              ⚠️ Warning: Real Funds Implication
+            </p>
+            <p className="mt-1 text-sm text-red-700 dark:text-red-400">
+              You are switching to the Mainnet. Any transactions approved on this network will use real funds and are irreversible.
+            </p>
+          </div>
+        )}
+
+        <div className="mt-4 text-sm text-slate-600 dark:text-slate-300">
+          Do you want to apply this network switch to the application?
+        </div>
+
+        <div className="mt-6 flex flex-col-reverse justify-end gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="w-full rounded-lg px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 sm:w-auto transition-colors"
+          >
+            Cancel Switch
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={`w-full rounded-lg px-4 py-2 text-sm font-semibold text-white sm:w-auto transition-colors ${
+              isSwitchingToMainnet
+                ? 'bg-red-600 hover:bg-red-700'
+                : 'bg-blue-600 hover:bg-blue-700'
+            }`}
+          >
+            Proceed to {NETWORK_LABELS[pendingNetwork] || pendingNetwork}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useNetworkDetection.test.tsx
+++ b/frontend/src/hooks/useNetworkDetection.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useNetworkDetection } from './useNetworkDetection'
+import { walletManager } from '../utils/walletManager'
+import * as networkDetectionUtils from '../utils/networkDetection'
+
+vi.mock('../utils/walletManager', () => ({
+  walletManager: {
+    getWalletType: vi.fn(),
+  },
+}))
+
+describe('useNetworkDetection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(networkDetectionUtils, 'getConfiguredNetwork').mockReturnValue('testnet')
+    vi.spyOn(networkDetectionUtils, 'detectWalletNetwork').mockResolvedValue('testnet')
+    vi.mocked(walletManager.getWalletType).mockReturnValue('freighter')
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('initializes and polls for network changes', async () => {
+    const { result } = renderHook(() => useNetworkDetection())
+    
+    // Initial state
+    expect(result.current.checking).toBe(true)
+
+    // Wait for initial check
+    await act(async () => {
+      vi.advanceTimersByTime(10)
+      await Promise.resolve()
+    })
+
+    expect(result.current.walletNetwork).toBe('testnet')
+    expect(result.current.pendingWalletNetwork).toBeNull()
+
+    // Simulate network change in wallet
+    vi.spyOn(networkDetectionUtils, 'detectWalletNetwork').mockResolvedValue('mainnet')
+
+    // Advance time to trigger polling interval
+    await act(async () => {
+      vi.advanceTimersByTime(3000)
+      await Promise.resolve()
+    })
+
+    // Should detect pending switch but not apply it yet
+    expect(result.current.walletNetwork).toBe('testnet')
+    expect(result.current.pendingWalletNetwork).toBe('mainnet')
+
+    // Confirm switch
+    act(() => {
+      result.current.confirmNetworkSwitch()
+    })
+
+    expect(result.current.walletNetwork).toBe('mainnet')
+    expect(result.current.pendingWalletNetwork).toBeNull()
+  })
+
+  it('allows cancelling a network switch', async () => {
+    const { result } = renderHook(() => useNetworkDetection())
+    
+    await act(async () => {
+      vi.advanceTimersByTime(10)
+      await Promise.resolve()
+    })
+
+    // Simulate network change
+    vi.spyOn(networkDetectionUtils, 'detectWalletNetwork').mockResolvedValue('mainnet')
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000)
+      await Promise.resolve()
+    })
+
+    expect(result.current.pendingWalletNetwork).toBe('mainnet')
+
+    // Cancel switch
+    act(() => {
+      result.current.cancelNetworkSwitch()
+    })
+
+    expect(result.current.walletNetwork).toBe('testnet')
+    expect(result.current.pendingWalletNetwork).toBeNull()
+
+    // Advance time again to ensure we ignore the same network
+    await act(async () => {
+      vi.advanceTimersByTime(3000)
+      await Promise.resolve()
+    })
+
+    // Should remain null because we ignored 'mainnet'
+    expect(result.current.pendingWalletNetwork).toBeNull()
+  })
+})

--- a/frontend/src/hooks/useNetworkDetection.ts
+++ b/frontend/src/hooks/useNetworkDetection.ts
@@ -9,9 +9,13 @@ import {
 
 export function useNetworkDetection(): NetworkDetectionResult & {
   recheck: () => void
+  confirmNetworkSwitch: () => void
+  cancelNetworkSwitch: () => void
 } {
   const [configuredNetwork] = useState<StellarNetwork>(getConfiguredNetwork)
   const [walletNetwork, setWalletNetwork] = useState<StellarNetwork | null>(null)
+  const [pendingWalletNetwork, setPendingWalletNetwork] = useState<StellarNetwork | null>(null)
+  const [ignoredWalletNetwork, setIgnoredWalletNetwork] = useState<StellarNetwork | null>(null)
   const [checking, setChecking] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -20,8 +24,19 @@ export function useNetworkDetection(): NetworkDetectionResult & {
     setError(null)
     try {
       const walletType = walletManager.getWalletType() ?? undefined
+      if (!walletType) return
       const detected = await detectWalletNetwork(walletType)
-      setWalletNetwork(detected)
+      
+      setWalletNetwork((prev) => {
+        if (prev === null) {
+          return detected
+        }
+        if (detected !== prev && detected !== ignoredWalletNetwork) {
+          setPendingWalletNetwork(detected)
+          return prev
+        }
+        return prev
+      })
     } catch (err) {
       setWalletNetwork(null)
       setError(err instanceof Error ? err.message : 'Failed to detect wallet network')
@@ -32,7 +47,24 @@ export function useNetworkDetection(): NetworkDetectionResult & {
 
   useEffect(() => {
     checkNetwork()
+    const intervalId = setInterval(checkNetwork, 3000)
+    return () => clearInterval(intervalId)
   }, [checkNetwork])
+
+  const confirmNetworkSwitch = useCallback(() => {
+    if (pendingWalletNetwork) {
+      setWalletNetwork(pendingWalletNetwork)
+      setIgnoredWalletNetwork(null)
+      setPendingWalletNetwork(null)
+    }
+  }, [pendingWalletNetwork])
+
+  const cancelNetworkSwitch = useCallback(() => {
+    if (pendingWalletNetwork) {
+      setIgnoredWalletNetwork(pendingWalletNetwork)
+      setPendingWalletNetwork(null)
+    }
+  }, [pendingWalletNetwork])
 
   const mismatch =
     !checking &&
@@ -44,9 +76,12 @@ export function useNetworkDetection(): NetworkDetectionResult & {
   return {
     configuredNetwork,
     walletNetwork,
+    pendingWalletNetwork,
     mismatch,
     checking,
     error,
     recheck: checkNetwork,
+    confirmNetworkSwitch,
+    cancelNetworkSwitch,
   }
 }

--- a/frontend/src/utils/networkDetection.ts
+++ b/frontend/src/utils/networkDetection.ts
@@ -6,6 +6,7 @@ export interface NetworkDetectionResult {
   mismatch: boolean
   checking: boolean
   error: string | null
+  pendingWalletNetwork?: StellarNetwork | null
 }
 
 const STELLAR_NETWORK_PASSPHRASES: Record<string, StellarNetwork> = {


### PR DESCRIPTION
Closes #1475 
## Description
Resolves issue: Add testnet/mainnet switch confirmation modal

This PR implements a confirmation modal that surfaces when a network switch is detected from the user's wallet, ensuring that app-wide state changes (like switching to the Mainnet) are only applied with explicit user consent.

### Implementation Details:
- **Network Polling**: Updated `useNetworkDetection.ts` with a polling interval to continuously monitor the active wallet network for changes against the currently accepted network.
- **Confirmation Modal**: Created a new `NetworkSwitchModal.tsx` UI component that prompts the user before applying a detected network switch.
- **Real-Funds Warning**: Added an explicit, highlighted warning in the modal when switching to `mainnet` to caution users about the real-funds implications.
- **App Integration**: Hooked the modal into `App.tsx` to handle the pending network state. Users can choose to either cancel the switch (remaining on the current network) or proceed with it (triggering query invalidation to reload app-wide state).
- **Testing**: Added unit tests in `useNetworkDetection.test.tsx` and `NetworkSwitchModal.test.tsx` to verify the pending state logic and confirm the modal renders correctly during simulated network change events.

### Acceptance Criteria Met:
- [x] Switching networks (especially to mainnet) requires explicit user confirmation
- [x] Users can cancel a detected network switch and remain on the current network
- [x] Test confirms the confirmation modal triggers correctly on a simulated switch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wallet network detection with periodic checks.
  * Added a confirmation modal when a network change is detected.
  * Users can review the current and pending networks, then confirm or cancel the switch.
  * Added a warning when switching to mainnet, where real funds may be involved.

* **Tests**
  * Added coverage for network detection, confirmation, cancellation, and modal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->