### PR TITLE
feat: add useBulkImport mutation hook with per-row validation error handling (#1476)

### DIFF
--- a/frontend/src/context/ThemeContext.test.tsx
+++ b/frontend/src/context/ThemeContext.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
 import { ThemeProvider, useTheme, bootstrapThemeBeforeHydration } from './ThemeContext'
 

--- a/frontend/src/context/ThemeContext.test.tsx
+++ b/frontend/src/context/ThemeContext.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
 import { ThemeProvider, useTheme, bootstrapThemeBeforeHydration } from './ThemeContext'
 
@@ -108,5 +108,37 @@ describe('ThemeContext', () => {
         expect(screen.getByTestId('preference')).toHaveTextContent('light')
         fireEvent.click(screen.getByRole('button', { name: 'cycle' }))
         expect(screen.getByTestId('preference')).toHaveTextContent('dark')
+    })
+
+    it('cleans up media query listener on unmount', () => {
+        const before = matchMediaListeners.length
+        const { unmount } = render(
+            <ThemeProvider>
+                <ThemeProbe />
+            </ThemeProvider>,
+        )
+        // After mount there should be at least one listener for the system theme
+        expect(matchMediaListeners.length).toBeGreaterThan(before)
+
+        unmount()
+        // After unmount all listeners should have been removed
+        expect(matchMediaListeners.length).toBe(before)
+    })
+
+    it('stops responding to system theme changes after unmount', () => {
+        const { unmount } = render(
+            <ThemeProvider>
+                <ThemeProbe />
+            </ThemeProvider>,
+        )
+        unmount()
+
+        const prevListeners = matchMediaListeners.length
+        act(() => {
+            prefersDark = true
+            matchMediaListeners.forEach((handler) => handler())
+        })
+
+        expect(matchMediaListeners.length).toBe(prevListeners)
     })
 })

--- a/frontend/src/hooks/mutations/useBulkImport.test.tsx
+++ b/frontend/src/hooks/mutations/useBulkImport.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useBulkImport } from './useBulkImport'
+import type { BulkImportSuccessResponse, BulkImportRowError } from './useBulkImport'
+
+const mockApiRequest = vi.hoisted(() => vi.fn())
+
+vi.mock('../../config/api', () => ({
+  apiRequest: mockApiRequest,
+  ENDPOINTS: {
+    PORTFOLIO_IMPORT: '/api/v1/portfolio/import',
+  },
+}))
+
+function createTestClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function withClient(qc: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useBulkImport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('exposes success response on successful bulk import', async () => {
+    const successResponse: BulkImportSuccessResponse = {
+      portfolioId: 'portfolio-abc',
+      status: 'created',
+    }
+    mockApiRequest.mockResolvedValue(successResponse)
+
+    const qc = createTestClient()
+    const { result } = renderHook(() => useBulkImport(), {
+      wrapper: withClient(qc),
+    })
+
+    const csvContent = 'asset,allocation_pct\nXLM,50\nUSDC,50\n'
+
+    result.current.mutate({
+      content: csvContent,
+      contentType: 'text/csv',
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(result.current.data).toEqual(successResponse)
+    expect(result.current.isError).toBe(false)
+  })
+
+  it('surfaces per-row validation errors in the error object', async () => {
+    const rowErrors: BulkImportRowError[] = [
+      { row: 0, field: 'asset', message: 'Invalid asset symbol' },
+      { row: 1, field: 'allocation_pct', message: 'Allocations must sum to 100' },
+    ]
+    const apiError = new Error('Import failed: validation errors') as any
+    apiError.status = 400
+    apiError.code = 'VALIDATION_ERROR'
+    apiError.details = {
+      error: 'VALIDATION_ERROR',
+      message: 'Import failed: validation errors',
+      errors: rowErrors,
+      meta: { totalRows: 2, validRows: 0 },
+    }
+    mockApiRequest.mockRejectedValue(apiError)
+
+    const qc = createTestClient()
+    const { result } = renderHook(() => useBulkImport(), {
+      wrapper: withClient(qc),
+    })
+
+    const jsonContent = JSON.stringify([
+      { asset: 'INVALID', allocation_pct: 60 },
+      { asset: 'XLM', allocation_pct: 50 },
+    ])
+
+    result.current.mutate({
+      content: jsonContent,
+      contentType: 'application/json',
+    })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+
+    expect(result.current.error?.rowErrors).toEqual(rowErrors)
+    expect(result.current.error?.totalRows).toBe(2)
+    expect(result.current.error?.validRows).toBe(0)
+    expect(result.current.error?.message).toContain('validation errors')
+  })
+
+  it('handles generic API errors without rowErrors', async () => {
+    const genericError = new Error('Network error')
+    mockApiRequest.mockRejectedValue(genericError)
+
+    const qc = createTestClient()
+    const { result } = renderHook(() => useBulkImport(), {
+      wrapper: withClient(qc),
+    })
+
+    result.current.mutate({
+      content: 'bad data',
+      contentType: 'application/json',
+    })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+
+    expect(result.current.error?.rowErrors).toBeUndefined()
+    expect(result.current.error?.message).toBe('Network error')
+  })
+
+  it('resolves after the API call completes', async () => {
+    let resolvePromise: (value: BulkImportSuccessResponse) => void = () => {}
+    const pendingPromise = new Promise<BulkImportSuccessResponse>((resolve) => {
+      resolvePromise = resolve
+    })
+    mockApiRequest.mockReturnValue(pendingPromise)
+
+    const qc = createTestClient()
+    const { result } = renderHook(() => useBulkImport(), {
+      wrapper: withClient(qc),
+    })
+
+    act(() => {
+      result.current.mutate({
+        content: 'XLM,50\nUSDC,50\n',
+        contentType: 'text/csv',
+      })
+    })
+
+    act(() => {
+      resolvePromise({ portfolioId: 'p-1', status: 'created' })
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+  })
+})

--- a/frontend/src/hooks/mutations/useBulkImport.ts
+++ b/frontend/src/hooks/mutations/useBulkImport.ts
@@ -1,0 +1,72 @@
+import { useMutation } from '@tanstack/react-query'
+import { apiRequest, ENDPOINTS } from '../../config/api'
+import type { ApiClientError } from '../../config/api'
+
+export type BulkImportRowError = {
+  row: number
+  field: string
+  message: string
+}
+
+export type BulkImportValidationError = {
+  error: 'VALIDATION_ERROR' | string
+  message?: string
+  code?: string
+  errors?: BulkImportRowError[]
+  meta?: {
+    totalRows?: number
+    validRows?: number
+  }
+}
+
+export type BulkImportSuccessResponse = {
+  portfolioId: string
+  status: 'created'
+}
+
+export type BulkImportPayload = {
+  content: string
+  contentType: 'application/json' | 'text/csv'
+}
+
+export function useBulkImport() {
+  return useMutation<
+    BulkImportSuccessResponse,
+    Error & { rowErrors?: BulkImportRowError[]; totalRows?: number; validRows?: number },
+    BulkImportPayload
+  >({
+    mutationFn: async ({ content, contentType }) => {
+      try {
+        const data = await apiRequest<BulkImportSuccessResponse>(
+          ENDPOINTS.PORTFOLIO_IMPORT,
+          {
+            method: 'POST',
+            headers: {
+              Accept: 'application/json',
+              'Content-Type': contentType,
+            },
+            body: content,
+          },
+        )
+        return data
+      } catch (err: unknown) {
+        const apiErr = err as ApiClientError
+        if (apiErr.details) {
+          const validation = apiErr.details as BulkImportValidationError
+          const combined = new Error(
+            validation.message || apiErr.message || 'Import failed',
+          ) as Error & {
+            rowErrors?: BulkImportRowError[]
+            totalRows?: number
+            validRows?: number
+          }
+          combined.rowErrors = validation.errors
+          combined.totalRows = validation.meta?.totalRows
+          combined.validRows = validation.meta?.validRows
+          throw combined
+        }
+        throw err
+      }
+    },
+  })
+}


### PR DESCRIPTION
Closes #1476

## Summary

Creates a reusable `useBulkImport` mutation hook that wraps the `POST /api/v1/portfolio/import` endpoint, following the project's existing mutation hook conventions (react-query `useMutation`, expose loading/error/data).

## Changes

### New: `frontend/src/hooks/mutations/useBulkImport.ts`

- **`useBulkImport()`** — returns `{ mutate, data, isPending, isError, error }` consumable by `BulkPortfolioImport.tsx`
- Accepts **`BulkImportPayload`** with `content: string` (raw CSV or JSON text) and `contentType: 'application/json' | 'text/csv'`
- Passes the raw content directly as the request body (no JSON wrapping) so the backend receives the file text verbatim
- **Per-row validation errors**: when the backend returns a `400 VALIDATION_ERROR` with `errors[]` and `meta`, the hook surfaces them on the error object:
  - `error.rowErrors` — array of `{ row, field, message }`
  - `error.totalRows` / `error.validRows` — from response meta
- Generic API errors (network, server errors) propagate as-is without rowErrors

### Exported types

| Type | Description |
| --- | --- |
| `BulkImportRowError` | Per-row validation failure `{ row, field, message }` |
| `BulkImportValidationError` | Full validation error envelope with `errors[]` and `meta` |
| `BulkImportSuccessResponse` | Success shape `{ portfolioId, status: 'created' }` |
| `BulkImportPayload` | Input shape `{ content, contentType }` |

### Test: `frontend/src/hooks/mutations/useBulkImport.test.tsx`

4 tests, all passing:

| Test | What it verifies |
| --- | --- |
| exposes success response on successful bulk import | Hook returns `{ portfolioId, status }` after API resolves |
| surfaces per-row validation errors in the error object | `error.rowErrors`, `error.totalRows`, `error.validRows` populated from 400 response |
| handles generic API errors without rowErrors | Plain `Error` propagates with no rowErrors |
| resolves after the API call completes | Mutation eventually reaches `isSuccess: true` |

### Usage

```tsx
const { mutate, isPending, error } = useBulkImport()

const csvContent = `asset,allocation_pct
XLM,50
USDC,50`

mutate({ content: csvContent, contentType: 'text/csv' })

// On validation error:
if (error?.rowErrors) {
  error.rowErrors.forEach(({ row, field, message }) => {
    console.error(`Row ${row}, ${field}: ${message}`)
  })
}
```

## Acceptance Criteria

- [x] A reusable mutation hook exists for triggering bulk import and reading its result
- [x] Hook correctly surfaces per-row validation errors alongside overall success/failure
- [x] Test confirms correct state exposure for both mocked success and error responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bulk portfolio import support.
  - Import results now report successful completion and detailed row-level validation issues, including totals for valid and invalid rows.
  - General import failures preserve clear error messages.

- **Bug Fixes**
  - Improved theme system monitoring so listeners are properly removed when the theme provider is closed.

- **Tests**
  - Added coverage for bulk import success, validation errors, asynchronous completion, general failures, and theme listener cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->