### PR TITLE
feat: Add capability-aware disabled-state indicator for update_alloca…

### DIFF
--- a/frontend/src/components/AllocationForm.test.tsx
+++ b/frontend/src/components/AllocationForm.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import AllocationForm from './AllocationForm'
+import { describe, it, expect, vi } from 'vitest'
+import { ContractCapabilityReport } from '../lib/contractCapabilities'
+
+describe('AllocationForm', () => {
+    const defaultAllocations = [
+        { asset: 'XLM', percentage: 60 },
+        { asset: 'USDC', percentage: 40 },
+    ]
+
+    const fullyCapableReport: ContractCapabilityReport = {
+        severity: 'ok',
+        title: 'OK',
+        writesEnabled: true,
+        expectedSchemaVersion: 1,
+        availableMethods: ['update_allocations'],
+    }
+
+    const uncapableReport: ContractCapabilityReport = {
+        severity: 'warning',
+        title: 'Warning',
+        writesEnabled: true,
+        expectedSchemaVersion: 1,
+        availableMethods: [], // Missing update_allocations
+    }
+
+    it('renders and allows editing when fully capable', () => {
+        render(<AllocationForm allocations={defaultAllocations} onChange={vi.fn()} contractCapabilityReport={fullyCapableReport} />)
+        const inputs = screen.getAllByRole('spinbutton')
+        expect(inputs[0]).not.toBeDisabled()
+        expect(screen.getByRole('button', { name: /Submit Portfolio/i })).not.toBeDisabled()
+    })
+
+    it('disables controls and shows tooltip when capability is missing', () => {
+        render(<AllocationForm allocations={defaultAllocations} onChange={vi.fn()} contractCapabilityReport={uncapableReport} />)
+        
+        const wrapper = screen.getByTitle(/Block the write; keep the existing allocations visible read-only/i)
+        expect(wrapper).toBeInTheDocument()
+
+        const inputs = screen.getAllByRole('spinbutton')
+        expect(inputs[0]).toBeDisabled()
+        expect(screen.getByRole('button', { name: /Submit Portfolio/i })).toBeDisabled()
+    })
+
+    it('remains enabled if capability report is undefined', () => {
+        render(<AllocationForm allocations={defaultAllocations} onChange={vi.fn()} />)
+        const inputs = screen.getAllByRole('spinbutton')
+        expect(inputs[0]).not.toBeDisabled()
+    })
+})

--- a/frontend/src/components/AllocationForm.tsx
+++ b/frontend/src/components/AllocationForm.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useMemo } from 'react'
 import { AlertCircle, Plus, Trash2 } from 'lucide-react'
+import {
+    type ContractCapabilityReport,
+    canUpdateAllocations,
+    blockedWriteFallback,
+} from '../lib/contractCapabilities'
 
 interface Allocation {
     asset: string
@@ -10,6 +15,7 @@ interface AllocationFormProps {
     allocations: Allocation[]
     onChange: (allocations: Allocation[]) => void
     disabled?: boolean
+    contractCapabilityReport?: ContractCapabilityReport | null
 }
 
 const AVAILABLE_ASSETS = ['XLM', 'USDC', 'BTC', 'ETH', 'SOL', 'ADA', 'DOT', 'ATOM']
@@ -20,7 +26,7 @@ function getAllocationError(percentage: number): string | null {
     return null
 }
 
-export default function AllocationForm({ allocations, onChange, disabled }: AllocationFormProps) {
+export default function AllocationForm({ allocations, onChange, disabled, contractCapabilityReport }: AllocationFormProps) {
     const totalPercentage = useMemo(
         () => allocations.reduce((sum, a) => sum + a.percentage, 0),
         [allocations],
@@ -60,10 +66,19 @@ export default function AllocationForm({ allocations, onChange, disabled }: Allo
         onChange(updated)
     }, [allocations, onChange])
 
-    const canSubmit = isValidTotal && !hasAnyFieldError && !disabled
+    const capabilitiesLoaded = contractCapabilityReport !== undefined
+    const allocationsSupported = capabilitiesLoaded
+        ? canUpdateAllocations(contractCapabilityReport)
+        : true
+    const fallbackMessage = capabilitiesLoaded
+        ? blockedWriteFallback(contractCapabilityReport, 'update_allocations')
+        : null
+
+    const isFormDisabled = disabled || !allocationsSupported
+    const canSubmit = isValidTotal && !hasAnyFieldError && !isFormDisabled
 
     return (
-        <div className="space-y-4">
+        <div className="space-y-4" title={!allocationsSupported ? (fallbackMessage || 'Action not supported') : undefined}>
             <div className="flex items-center justify-between">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
                     Asset Allocations
@@ -71,7 +86,7 @@ export default function AllocationForm({ allocations, onChange, disabled }: Allo
                 <button
                     type="button"
                     onClick={addAllocation}
-                    disabled={unusedAssets.length === 0 || disabled}
+                    disabled={unusedAssets.length === 0 || isFormDisabled}
                     className="flex items-center gap-1 rounded-lg bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300 dark:disabled:bg-gray-600"
                 >
                     <Plus className="h-4 w-4" />
@@ -88,7 +103,7 @@ export default function AllocationForm({ allocations, onChange, disabled }: Allo
                                 <select
                                     value={allocation.asset}
                                     onChange={(e) => updateAllocation(index, 'asset', e.target.value)}
-                                    disabled={disabled}
+                                    disabled={isFormDisabled}
                                     className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
                                 >
                                     {AVAILABLE_ASSETS.map((asset) => (
@@ -106,7 +121,7 @@ export default function AllocationForm({ allocations, onChange, disabled }: Allo
                                     step="0.01"
                                     value={allocation.percentage}
                                     onChange={(e) => updateAllocation(index, 'percentage', parseFloat(e.target.value))}
-                                    disabled={disabled}
+                                    disabled={isFormDisabled}
                                     aria-label={`${allocation.asset} allocation percentage`}
                                     className="w-full accent-blue-600"
                                 />
@@ -119,7 +134,7 @@ export default function AllocationForm({ allocations, onChange, disabled }: Allo
                                     step="0.01"
                                     value={allocation.percentage}
                                     onChange={(e) => updateAllocation(index, 'percentage', Number.isFinite(Number.parseFloat(e.target.value)) ? Number(Number.parseFloat(e.target.value).toFixed(2)) : 0)}
-                                    disabled={disabled}
+                                    disabled={isFormDisabled}
                                     aria-invalid={!!fieldError}
                                     aria-describedby={fieldError ? `alloc-error-${index}` : undefined}
                                     className={`w-full rounded-lg border px-3 py-2 text-sm focus:ring-2 focus:border-transparent ${
@@ -136,7 +151,7 @@ export default function AllocationForm({ allocations, onChange, disabled }: Allo
                                 <button
                                     type="button"
                                     onClick={() => removeAllocation(index)}
-                                    disabled={disabled}
+                                    disabled={isFormDisabled}
                                     aria-label={`Remove ${allocation.asset} allocation`}
                                     className="rounded-lg p-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30"
                                 >

--- a/frontend/src/lib/contractCapabilities.ts
+++ b/frontend/src/lib/contractCapabilities.ts
@@ -254,6 +254,11 @@ export function isCapabilitySupported(
     return report.availableMethods.includes(method)
 }
 
+/** Whether the deployment supports updating target allocations natively. */
+export function canUpdateAllocations(report: ContractCapabilityReport | null): boolean {
+    return isCapabilitySupported(report, 'update_allocations')
+}
+
 /**
  * Guard a write before it is attempted. Returns the matrix entry's `fallback`
  * string when the write must be skipped, or `null` when it is safe to proceed.


### PR DESCRIPTION
Closes #1482 
## Description
Adds capability awareness for the `update_allocations` contract capability.

## Implementation details
- Adds `canUpdateAllocations` helper to `contractCapabilities.ts`.
- Updates `AllocationForm` to take a `contractCapabilityReport` and disable inputs appropriately when the capability is not supported.
- Adds an explanatory tooltip indicating that writes are blocked and allocations remain read-only.
- Adds tests verifying this behavior in `AllocationForm.test.tsx`.