### PR TITLE
docs: Add ADR 0003 for on-chain strategy execution

### DIFF
--- a/docs/adr/0003-on-chain-strategy-execution.md
+++ b/docs/adr/0003-on-chain-strategy-execution.md
@@ -1,0 +1,32 @@
+# ADR 0003: On-Chain Strategy Execution Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+The stellar-portfolio-rebalancer needs to execute rebalancing strategies such as periodic, volatility, and custom strategies. We need to decide whether to implement these strategies fully on-chain via smart contracts or purely in a centralized backend that triggers transactions. 
+Key considerations involve gas costs, the trust model required by users, and the flexibility needed to upgrade or change strategies over time.
+
+## Decision
+
+We have decided to implement the rebalancing strategies on-chain. The strategy logic is encapsulated within specific contract modules.
+
+This approach was chosen over a purely backend-driven model because it provides a superior trust model. Users can independently verify the logic and rules of the rebalancing strategies on the blockchain, eliminating the need to trust a centralized off-chain entity to calculate and execute the rebalances fairly and accurately.
+
+## Consequences
+
+Positive:
+* **Trust Model:** High transparency and trustlessness. Strategy rules are verifiable on-chain.
+* **Security:** Decentralized execution prevents a single point of failure (a centralized backend) from compromising strategy execution.
+
+Negative:
+* **Gas Cost:** Executing complex strategies on-chain incurs higher transaction fees (gas costs) for users compared to off-chain computation.
+* **Upgrade Flexibility:** On-chain contracts are inherently more difficult to upgrade. Changes to strategy logic require careful contract upgrades or the deployment of new strategy contracts, unlike a backend where code can be updated seamlessly.
+
+## Implementation Context
+
+* `strategies/periodic.rs`
+* `strategies/volatility.rs`
+* `strategies/custom.rs`


### PR DESCRIPTION
Closes #1506 
## Description
Resolves issue: Add ADR for on-chain strategy execution architecture. 

This PR adds ADR 0003, which documents the architectural decision to implement the periodic, volatility, and custom rebalancing strategies fully on-chain rather than maintaining them purely in the backend. 

## Changes Made
* Created `docs/adr/0003-on-chain-strategy-execution.md` following the established numbering and template conventions.
* Documented the primary tradeoffs considered, specifically regarding gas costs, trust models, and upgrade flexibility.
* Referenced the relevant on-chain contract modules (`strategies/periodic.rs`, `strategies/volatility.rs`, `strategies/custom.rs`) as implementation context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record documenting on-chain execution for rebalancing strategies.
  * Outlined the trade-offs between transparency, decentralized execution, gas costs, and upgrade flexibility.
  * Documented supported strategy types, including periodic, volatility-based, and custom strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->