### PR TITLE
fix(security): gate debug routes mount behind ENABLE_DEBUG_ROUTES flag

### DIFF
--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -9,6 +9,8 @@ import { consentRouter } from './consent.routes.js'
 import { assetsRouter } from './assets.routes.js'
 import { analyticsRouter } from './analytics.routes.js'
 import { adminRouter } from './admin.routes.js'
+import { getFeatureFlags } from '../config/featureFlags.js'
+import { logger } from '../utils/logger.js'
 
 
 export const portfolioRouter = Router()
@@ -18,7 +20,22 @@ portfolioRouter.use(portfolioImportRouter)
 portfolioRouter.use(rebalancingRouter)
 portfolioRouter.use(opsRouter)
 portfolioRouter.use(notificationsRouter)
-portfolioRouter.use(debugRouter)
+
+// Debug routes are mounted ONLY when explicitly enabled via ENABLE_DEBUG_ROUTES=true
+// and NODE_ENV is not production. This is a defense-in-depth double check on top of
+// the per-route blockDebugInProduction middleware.
+const environment = (process.env.NODE_ENV || 'development').trim().toLowerCase()
+const isProduction = environment === 'production'
+const debugRoutesEnabled = getFeatureFlags().enableDebugRoutes && !isProduction
+
+if (debugRoutesEnabled) {
+    logger.warn('[SECURITY] Debug routes are ENABLED (ENABLE_DEBUG_ROUTES=true). ' +
+        'These endpoints expose internal state and must never be enabled in production.')
+    portfolioRouter.use(debugRouter)
+} else {
+    logger.info(`[SECURITY] Debug routes disabled (enableDebugRoutes=${getFeatureFlags().enableDebugRoutes}, NODE_ENV=${environment})`)
+}
+
 portfolioRouter.use(consentRouter)
 portfolioRouter.use(assetsRouter)
 portfolioRouter.use(analyticsRouter)

--- a/backend/src/test/debugRoutesMount.test.ts
+++ b/backend/src/test/debugRoutesMount.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeAll, vi, afterAll } from 'vitest'
+import express, { Express } from 'express'
+import request from 'supertest'
+
+// Debug router must only be mounted when ENABLE_DEBUG_ROUTES=true and NODE_ENV is not production.
+// These tests exercise the conditional mount logic in routes.ts.
+const originalEnv = { ...process.env }
+
+vi.mock('../middleware/auth.js', () => ({
+    requireAdmin: (_req: any, _res: any, next: any) => next(),
+    requireAuth: (_req: any, _res: any, next: any) => next(),
+    optionalAuth: (_req: any, _res: any, next: any) => next(),
+}))
+
+vi.mock('../middleware/rateLimit.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../middleware/rateLimit.js')>()
+    return {
+        ...actual,
+        adminRateLimiter: (_req: any, _res: any, next: any) => next(),
+        protectedWriteLimiter: [(_req: any, _res: any, next: any) => next()],
+        protectedCriticalLimiter: [(_req: any, _res: any, next: any) => next()],
+    }
+})
+
+vi.mock('../utils/logger.js', () => ({
+    logger: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+    }
+}))
+
+async function buildApp(): Promise<Express> {
+    vi.resetModules()
+    const { portfolioRouter } = await import('../api/routes.js')
+    const app = express()
+    app.use(express.json())
+    app.use('/api', portfolioRouter)
+    return app
+}
+
+describe('debug routes conditional mount (issue #1427)', () => {
+    beforeAll(() => {
+        delete process.env.ENABLE_DEBUG_ROUTES
+        process.env.NODE_ENV = 'test'
+    })
+
+    afterAll(() => {
+        process.env = { ...originalEnv }
+    })
+
+    it('returns 404 when ENABLE_DEBUG_ROUTES is unset (disabled by default)', async () => {
+        delete process.env.ENABLE_DEBUG_ROUTES
+        const app = await buildApp()
+        const res = await request(app).get('/api/debug/env')
+        expect(res.status).toBe(404)
+    })
+
+    it('returns 404 when ENABLE_DEBUG_ROUTES=false', async () => {
+        process.env.ENABLE_DEBUG_ROUTES = 'false'
+        const app = await buildApp()
+        const res = await request(app).get('/api/debug/env')
+        expect(res.status).toBe(404)
+    })
+
+    it('mounts debug routes when ENABLE_DEBUG_ROUTES=true in non-production', async () => {
+        process.env.ENABLE_DEBUG_ROUTES = 'true'
+        process.env.NODE_ENV = 'test'
+        const app = await buildApp()
+        const res = await request(app).get('/api/debug/env')
+        expect(res.status).toBe(200)
+        expect(res.body.data).toHaveProperty('environment')
+    })
+})


### PR DESCRIPTION
## Summary

Closes #1427 — gates the **mount** of `debug.routes.ts` behind an explicit `ENABLE_DEBUG_ROUTES=true` env flag **and** non-production `NODE_ENV`, as a defense-in-depth double check on top of the existing per-route `blockDebugInProduction` middleware.

## Changes

- **`backend/src/api/routes.ts`**: `debugRouter` is now mounted conditionally — only when `ENABLE_DEBUG_ROUTES=true` AND `NODE_ENV != production`. Previously it was always mounted (routes existed but returned 404 via middleware); now they don't exist at all unless explicitly enabled.
- **Startup warning**: logs a prominent `[SECURITY]` warning when debug routes are enabled, and an info line when disabled (with the resolved flag + env for observability).
- **`backend/src/test/debugRoutesMount.test.ts`** (new): asserts:
  - debug routes return 404 when `ENABLE_DEBUG_ROUTES` is unset (disabled by default)
  - 404 when explicitly `false`
  - mounted and reachable only when `true` in non-production

## Verification

- `npx vitest run src/test/debugRoutesMount.test.ts` → 3/3 pass
- `debugGate.test.ts` → pass
- No new failures vs baseline on `main` (pre-existing failures in debug.routes.test.ts redaction cases are unrelated — confirmed identical on clean `main`)

## Notes

- The per-route middleware stays in place — defense in depth.
- In production, even with the flag set, debug routes remain unmounted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debug endpoints are now available only when explicitly enabled outside production environments.
  * A security warning is logged whenever debug endpoints are enabled.
  * Debug endpoints are omitted when disabled or running in production.

* **Tests**
  * Added coverage verifying debug endpoint availability across supported environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->