### PR TITLE
feat(frontend): add portfolio heatmap view

### DIFF
--- a/frontend/src/components/PortfolioHeatmap.test.tsx
+++ b/frontend/src/components/PortfolioHeatmap.test.tsx
@@ -1,0 +1,115 @@
+import { describe, expect, it, afterEach } from 'vitest'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import PortfolioHeatmap, { heatmapTileColor, type HeatmapAsset } from './PortfolioHeatmap'
+
+const sampleAssets: HeatmapAsset[] = [
+  { name: 'XLM', allocation: 40, change: 2.5, color: '#3B82F6' },
+  { name: 'USDC', allocation: 30, change: 0, color: '#10B981' },
+  { name: 'BTC', allocation: 20, change: -3.75, color: '#F59E0B' },
+  { name: 'ETH', allocation: 10, change: 1.1, color: '#8B5CF6' },
+]
+
+afterEach(cleanup)
+
+describe('heatmapTileColor', () => {
+  it('returns a neutral gray for zero change', () => {
+    expect(heatmapTileColor(0)).toBe('rgb(229, 231, 235)')
+  })
+
+  it('maps positive change to a green scale', () => {
+    const positive = heatmapTileColor(10)
+    expect(positive).toMatch(/^rgb\(\d+, 255, \d+\)$/)
+  })
+
+  it('maps negative change to a red scale', () => {
+    const negative = heatmapTileColor(-10)
+    expect(negative).toMatch(/^rgb\(255, \d+, \d+\)$/)
+  })
+
+  it('treats non-finite input as neutral', () => {
+    expect(heatmapTileColor(Number.NaN)).toBe('rgb(229, 231, 235)')
+  })
+})
+
+describe('PortfolioHeatmap', () => {
+  it('renders one tile per asset with allocation and change text', () => {
+    render(<PortfolioHeatmap assets={sampleAssets} />)
+
+    const grid = screen.getByTestId('portfolio-heatmap-grid')
+    const tiles = within(grid).getAllByRole('gridcell')
+    expect(tiles).toHaveLength(sampleAssets.length)
+
+    const xlmTile = screen.getByTestId('portfolio-heatmap-tile-XLM')
+    expect(xlmTile).toHaveTextContent('XLM')
+    expect(xlmTile).toHaveTextContent('40%')
+    expect(xlmTile).toHaveTextContent('+2.50%')
+  })
+
+  it('supplements color with an accessible label so meaning does not rely on color alone', () => {
+    render(<PortfolioHeatmap assets={sampleAssets} />)
+
+    expect(
+      screen.getByRole('gridcell', {
+        name: 'BTC: 20% allocation, -3.75% 24h change',
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it('sizes tiles proportionally to allocation via flexGrow', () => {
+    render(<PortfolioHeatmap assets={sampleAssets} />)
+
+    const xlm = screen.getByTestId('portfolio-heatmap-tile-XLM')
+    const eth = screen.getByTestId('portfolio-heatmap-tile-ETH')
+
+    const xlmGrow = Number.parseFloat(xlm.style.flexGrow)
+    const ethGrow = Number.parseFloat(eth.style.flexGrow)
+
+    expect(xlmGrow).toBeGreaterThan(ethGrow)
+    expect(xlmGrow).toBe(40)
+    expect(ethGrow).toBe(10)
+  })
+
+  it('opens a detail modal for the clicked asset', () => {
+    render(<PortfolioHeatmap assets={sampleAssets} />)
+
+    fireEvent.click(screen.getByTestId('portfolio-heatmap-tile-BTC'))
+
+    expect(screen.getByRole('dialog', { name: /BTC detail/i })).toBeInTheDocument()
+    const dialog = screen.getByRole('dialog', { name: /BTC detail/i })
+    expect(within(dialog).getByText('20%')).toBeInTheDocument()
+    expect(within(dialog).getByText('-3.75%')).toBeInTheDocument()
+  })
+
+  it('caps rendering at 10 assets', () => {
+    const manyAssets: HeatmapAsset[] = Array.from({ length: 14 }, (_, index) => ({
+      name: `A${index + 1}`,
+      allocation: 5,
+      change: index % 2 === 0 ? 1 : -1,
+    }))
+
+    render(<PortfolioHeatmap assets={manyAssets} />)
+
+    expect(screen.getAllByRole('gridcell')).toHaveLength(10)
+    expect(screen.queryByTestId('portfolio-heatmap-tile-A11')).not.toBeInTheDocument()
+  })
+
+  it('renders an empty state when no assets are provided', () => {
+    render(<PortfolioHeatmap assets={[]} />)
+
+    expect(screen.getByTestId('portfolio-heatmap-empty')).toBeInTheDocument()
+    expect(screen.queryByRole('gridcell')).not.toBeInTheDocument()
+  })
+
+  it('skips assets with zero or negative allocation', () => {
+    const mixed: HeatmapAsset[] = [
+      { name: 'XLM', allocation: 50, change: 1 },
+      { name: 'GHOST', allocation: 0, change: 5 },
+      { name: 'USDC', allocation: 50, change: -1 },
+    ]
+
+    render(<PortfolioHeatmap assets={mixed} />)
+
+    expect(screen.getAllByRole('gridcell')).toHaveLength(2)
+    expect(screen.queryByTestId('portfolio-heatmap-tile-GHOST')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/PortfolioHeatmap.tsx
+++ b/frontend/src/components/PortfolioHeatmap.tsx
@@ -1,0 +1,202 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { Modal } from './ui/Modal'
+
+export interface HeatmapAsset {
+  name: string
+  allocation: number
+  change: number
+  color?: string
+}
+
+interface PortfolioHeatmapProps {
+  assets: HeatmapAsset[]
+  title?: string
+}
+
+const MAX_ASSETS = 10
+const CHANGE_SATURATION_CAP = 10
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min
+  return Math.max(min, Math.min(max, value))
+}
+
+export function heatmapTileColor(change: number): string {
+  if (!Number.isFinite(change) || change === 0) {
+    return 'rgb(229, 231, 235)'
+  }
+
+  const magnitude = Math.min(Math.abs(change), CHANGE_SATURATION_CAP) / CHANGE_SATURATION_CAP
+
+  if (change < 0) {
+    const channel = Math.round(255 - 135 * magnitude)
+    return `rgb(255, ${channel}, ${channel})`
+  }
+
+  const channel = Math.round(255 - 135 * magnitude)
+  return `rgb(${channel}, 255, ${channel})`
+}
+
+function formatChange(change: number): string {
+  if (!Number.isFinite(change)) return 'N/A'
+  const sign = change > 0 ? '+' : ''
+  return `${sign}${change.toFixed(2)}%`
+}
+
+function formatAllocation(allocation: number): string {
+  return `${allocation.toFixed(allocation >= 10 ? 0 : 1)}%`
+}
+
+const PortfolioHeatmap: React.FC<PortfolioHeatmapProps> = ({ assets, title = 'Portfolio Heatmap' }) => {
+  const [selected, setSelected] = useState<HeatmapAsset | null>(null)
+
+  const visibleAssets = useMemo(() => {
+    return assets
+      .filter((asset) => asset.allocation > 0)
+      .slice(0, MAX_ASSETS)
+  }, [assets])
+
+  const totalAllocation = useMemo(
+    () => visibleAssets.reduce((sum, asset) => sum + asset.allocation, 0),
+    [visibleAssets],
+  )
+
+  const closeModal = useCallback(() => setSelected(null), [])
+
+  return (
+    <section
+      className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm"
+      aria-labelledby="portfolio-heatmap-title"
+    >
+      <div className="flex flex-col gap-1 mb-5">
+        <h2
+          id="portfolio-heatmap-title"
+          className="text-lg font-semibold text-gray-900 dark:text-white"
+        >
+          {title}
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Tile size reflects allocation. Color shows 24h price change.
+        </p>
+      </div>
+
+      {visibleAssets.length === 0 ? (
+        <div
+          className="flex items-center justify-center h-40 rounded-lg border border-dashed border-gray-300 dark:border-gray-600 text-sm text-gray-500 dark:text-gray-400"
+          data-testid="portfolio-heatmap-empty"
+        >
+          No assets to display
+        </div>
+      ) : (
+        <div
+          className="flex flex-wrap gap-2"
+          role="grid"
+          aria-label="Portfolio asset heatmap"
+          data-testid="portfolio-heatmap-grid"
+        >
+          {visibleAssets.map((asset) => {
+            const share = totalAllocation > 0 ? asset.allocation / totalAllocation : 0
+            const flexGrow = clampNumber(asset.allocation, 1, 100)
+            const flexBasis = `${Math.max(6, Math.round(share * 100))}rem`
+            const label = `${asset.name}: ${formatAllocation(asset.allocation)} allocation, ${formatChange(asset.change)} 24h change`
+
+            return (
+              <button
+                key={asset.name}
+                type="button"
+                role="gridcell"
+                onClick={() => setSelected(asset)}
+                aria-label={label}
+                title={label}
+                data-testid={`portfolio-heatmap-tile-${asset.name}`}
+                data-change={asset.change.toFixed(2)}
+                className="relative min-w-[6rem] min-h-[5.5rem] rounded-lg border border-gray-200 dark:border-gray-700 p-3 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-shadow hover:shadow-md"
+                style={{
+                  flexGrow,
+                  flexBasis,
+                  backgroundColor: heatmapTileColor(asset.change),
+                }}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="font-semibold text-sm text-gray-900">{asset.name}</span>
+                  <span className="text-xs font-medium text-gray-800">
+                    {formatAllocation(asset.allocation)}
+                  </span>
+                </div>
+                <div className="mt-2 text-sm font-semibold text-gray-900">
+                  {formatChange(asset.change)}
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-gray-600 dark:text-gray-300">
+        <span className="inline-flex items-center gap-1">
+          <span
+            className="h-3 w-5 rounded-sm border border-gray-200"
+            style={{ backgroundColor: heatmapTileColor(-CHANGE_SATURATION_CAP) }}
+          />
+          {`Down ${CHANGE_SATURATION_CAP}%+`}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span
+            className="h-3 w-5 rounded-sm border border-gray-200"
+            style={{ backgroundColor: heatmapTileColor(0) }}
+          />
+          Flat
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span
+            className="h-3 w-5 rounded-sm border border-gray-200"
+            style={{ backgroundColor: heatmapTileColor(CHANGE_SATURATION_CAP) }}
+          />
+          {`Up ${CHANGE_SATURATION_CAP}%+`}
+        </span>
+      </div>
+
+      <Modal open={!!selected} onClose={closeModal} title={selected ? `${selected.name} detail` : undefined}>
+        {selected && (
+          <dl className="space-y-3 text-sm">
+            <div className="flex items-center justify-between">
+              <dt className="text-gray-500 dark:text-gray-400">Allocation</dt>
+              <dd className="font-semibold text-gray-900 dark:text-white">
+                {formatAllocation(selected.allocation)}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt className="text-gray-500 dark:text-gray-400">24h change</dt>
+              <dd
+                className="font-semibold px-2 py-0.5 rounded"
+                style={{
+                  color: selected.change > 0 ? '#166534' : selected.change < 0 ? '#991b1b' : '#374151',
+                  backgroundColor: heatmapTileColor(selected.change),
+                }}
+              >
+                {formatChange(selected.change)}
+              </dd>
+            </div>
+            {selected.color && (
+              <div className="flex items-center justify-between">
+                <dt className="text-gray-500 dark:text-gray-400">Asset color</dt>
+                <dd className="inline-flex items-center gap-2">
+                  <span
+                    className="h-4 w-4 rounded-full border border-gray-200"
+                    style={{ backgroundColor: selected.color }}
+                    aria-hidden
+                  />
+                  <span className="font-mono text-xs text-gray-700 dark:text-gray-200">
+                    {selected.color}
+                  </span>
+                </dd>
+              </div>
+            )}
+          </dl>
+        )}
+      </Modal>
+    </section>
+  )
+}
+
+export default PortfolioHeatmap


### PR DESCRIPTION
# Description

Adds a new `PortfolioHeatmap` component that shows a grid of asset tiles color-coded by 24h price change, with tile size proportional to allocation percentage. Clicking a tile opens a detail modal with the asset's allocation and 24h change.

Fixes #1001

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] This PR links to an issue or provides a rationale for no issue
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Implementation notes

- New file: `frontend/src/components/PortfolioHeatmap.tsx`
- Colocated test: `frontend/src/components/PortfolioHeatmap.test.tsx`
- Grid caps at 10 assets per the acceptance criteria; extras are ignored.
- Color scale: red for negative 24h change, green for positive, neutral gray at 0%. Saturation caps at plus/minus 10% so very volatile days do not wash out the palette.
- Accessibility: each tile is a `role="gridcell"` button with an `aria-label` that includes the asset name, allocation, and 24h change, so meaning is not conveyed by color alone. The tile body also shows the change as text.
- Tile size uses `flex-grow` set to the allocation value with a shared min-width, matching the "grid of tiles sized by allocation" wording in the issue.
- Detail panel reuses the existing `ui/Modal` component for keyboard trapping and focus restore, consistent with `CorrelationHeatmap`.

## Test coverage

The Vitest suite covers:
- Tile-per-asset rendering with allocation and change text
- Accessible label supplementing the color signal
- Proportional sizing via `flexGrow`
- Click-to-open detail modal with correct asset context
- 10-asset cap
- Empty-state rendering
- Skipping zero-allocation entries
- Color helper: neutral for 0, red scale for negative, green scale for positive, neutral for non-finite input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive portfolio heatmap showing up to 10 positively allocated assets.
  * Tiles are sized by allocation and colored by 24-hour performance.
  * Added asset details in an interactive modal, accessibility labels, and a color legend.
  * Added empty-state handling and allocation filtering.

* **Tests**
  * Added comprehensive coverage for rendering, color mapping, sizing, accessibility, interactions, limits, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->