### PR TITLE
feat(backend): cost-basis methods, TurboTax export, API key scope enforcement, rate limit dashboard

### DIFF
--- a/backend/docs/api-keys.md
+++ b/backend/docs/api-keys.md
@@ -1,0 +1,39 @@
+# Scoped API Keys
+
+Programmatic clients authenticate with the `X-API-Key` header. Keys are managed from
+the web UI over JWT auth (`/api/v1/api-keys`) and are stored as salted scrypt hashes —
+the raw key is returned exactly once, at creation or rotation, and never again.
+
+## Scopes
+
+| Scope        | Allowed |
+| ------------ | ------- |
+| `read-only`  | `GET`, `HEAD`, `OPTIONS` |
+| `read-write` | All methods |
+
+`POST /api/v1/api-keys` accepts `scope`, and defaults to `read-only` when it is
+omitted, so a caller can never mint a write-capable key by accident. Rotation
+(`POST /api/v1/api-keys/:id/rotate`) preserves the original key's scope.
+
+The scope is included in every management response — key creation, rotation, and the
+`GET /api/v1/api-keys` listing — alongside the key prefix and usage metadata. Key
+hashes are never returned.
+
+## Enforcement
+
+`requireApiKey` authenticates the key, populates `req.apiKeyUser`
+(`{ address, scope, keyId }`), and rejects a `read-only` key with **403 FORBIDDEN** on
+any mutating request (`POST`, `PUT`, `PATCH`, `DELETE`). Enforcement lives in the
+middleware rather than in individual routes, so a new write route is covered by
+default.
+
+For routes that are logically mutating but use a read verb, chain `requireReadWrite`
+after `requireApiKey`:
+
+```ts
+router.get('/portfolio/:id/rebalance', requireApiKey, requireReadWrite, handler)
+```
+
+A key that has been rotated stays valid until its grace window
+(`grace_expires_at`, default 5 minutes) elapses; after that it authenticates as
+revoked and is rejected with 401.

--- a/backend/docs/rate-limiting.md
+++ b/backend/docs/rate-limiting.md
@@ -85,6 +85,9 @@ RATE_LIMIT_AUTH_MAX=5               # 5 auth requests per window
 # Critical operations
 RATE_LIMIT_CRITICAL_MAX=3           # 3 critical requests per window
 
+# Admin consumption dashboard
+RATE_LIMIT_NEAR_LIMIT_RATIO=0.8     # flag identifiers at 80% of the limit
+
 # Burst protection
 RATE_LIMIT_BURST_WINDOW_MS=10000    # 10 second burst window
 RATE_LIMIT_BURST_MAX=20             # 20 requests per burst window
@@ -141,6 +144,43 @@ Returns comprehensive rate limiting metrics including:
 - Top offending IPs and users
 - Most throttled endpoints
 - Detailed activity report
+
+### Admin Consumption Dashboard
+
+```
+GET /api/admin/rate-limits/dashboard
+```
+
+Combined view of **current-window** rate-limit consumption per IP *and* per API key,
+aggregated from `rateLimitMonitor`. Every monitored request contributes to its IP
+bucket and — when authenticated with an API key — to that key's bucket (keys are
+identified by key id, never by the raw key).
+
+Query parameters:
+
+| Param      | Values                                          | Default | Notes |
+| ---------- | ----------------------------------------------- | ------- | ----- |
+| `type`     | `ip`, `apiKey`, `all`                           | `all`   | Filter by identifier type |
+| `status`   | `ok`, `near-limit`, `throttled`, `at-risk`, `all` | `all` | `at-risk` = near-limit + throttled |
+| `search`   | substring                                       | —       | Case-insensitive match on the identifier |
+| `page`     | 1-based integer                                 | `1`     | Clamped to the available page count |
+| `pageSize` | 1–200                                           | `25`    | |
+
+Response shape:
+
+- `summary` — window size, limit, near-limit ratio, tracked counts, and how many
+  identifiers are currently throttled or near-limit.
+- `attention` — the throttled and near-limit identifiers surfaced up front (up to 25
+  each), independent of the current page, so problems stay visible with many keys/IPs.
+- `entries` — the filtered, paged list, ordered most-at-risk first (throttled, then
+  by utilization descending). Each entry carries `consumed`, `limit`, `remaining`,
+  `utilization`, `throttledCount`, `status`, and the window timestamps.
+- `pagination` — `page`, `pageSize`, `total`, `totalPages`, `hasMore`.
+
+An identifier is `near-limit` once it reaches `RATE_LIMIT_NEAR_LIMIT_RATIO` (default
+`0.8`) of the configured limit, and `throttled` as soon as it receives a 429 in the
+current window. Records are dropped once their window elapses, so the dashboard always
+reflects live consumption rather than cumulative history.
 
 ## Response Format
 

--- a/backend/docs/tax-report.md
+++ b/backend/docs/tax-report.md
@@ -1,0 +1,70 @@
+# Tax Report
+
+`GET /api/v1/portfolio/tax-report`
+
+Realized gain/loss report derived from completed rebalance events. Every rebalance is
+treated as a sale of `fromAsset` and a purchase of `toAsset`; each purchase opens a tax
+lot and each sale consumes lots according to the selected cost-basis method.
+
+## Query parameters
+
+| Param             | Values                     | Default        | Notes |
+| ----------------- | -------------------------- | -------------- | ----- |
+| `year`            | 2000–2100                  | current year   | Tax year to report on |
+| `costBasisMethod` | `fifo`, `lifo`, `hifo`     | `fifo`         | Case-insensitive; unknown values return 400 |
+| `format`          | `json`, `csv`, `turbotax`  | `json`         | |
+
+## Cost-basis methods
+
+| Method | Lot consumed first | Typical effect |
+| ------ | ------------------ | -------------- |
+| `fifo` | Oldest acquisition | Default; preserves the historical behaviour of this endpoint |
+| `lifo` | Newest acquisition | Often defers gains in a rising market |
+| `hifo` | Highest unit cost  | Minimises realized gains |
+
+Ties in HIFO are broken toward the earlier lot so results are deterministic. A sale
+larger than a single lot is split across as many lots as needed, and a sale with no
+remaining basis is reported with a cost basis of zero.
+
+Lot prices come from the price snapshot as of the trade date
+(`databaseService.getPriceSnapshotAsOf`), falling back to the latest snapshot and then
+to a static table, so lots retain their acquisition-date price.
+
+## JSON response
+
+```jsonc
+{
+  "taxYear": 2025,
+  "costBasisMethod": "hifo",
+  "totalRealizedGainLoss": -50,
+  "totalTrades": 8,
+  "entries": [ /* one buy + one sell per rebalance */ ],
+  "disposals": [ /* one row per disposed lot: acquiredDate, soldDate, costBasis, proceeds */ ],
+  "methodology": "HIFO (highest-in, first-out). …"
+}
+```
+
+`disposals` is the lot-level view: one entry per matched lot, which is the granularity
+consumer tax software needs because each disposal carries its own acquisition date.
+
+## CSV exports
+
+`format=csv` returns the internal ledger export
+(`asset, date, type, amount, price, cost_basis, realized_gain_loss`).
+
+`format=turbotax` returns a TurboTax-importable CSV, one row per disposed lot, with the
+documented TurboTax cryptocurrency import columns in this exact order:
+
+```
+Currency Name,Purchase Date,Cost Basis,Date Sold,Proceeds
+XLM,01/01/2025,400.00,06/01/2025,550.00
+```
+
+- Dates are `MM/DD/YYYY` in UTC.
+- Monetary values are plain 2-decimal numbers — no currency symbol, no thousands separators.
+- Asset names containing a comma or quote are quoted per RFC 4180.
+- With no disposals the response is the header row alone, which TurboTax accepts as an
+  empty import.
+
+The selected `costBasisMethod` applies to the TurboTax export too, and is reflected in
+the download filename (`turbotax-tax-report-<year>-<method>.csv`).

--- a/backend/src/api/apiKeys.routes.ts
+++ b/backend/src/api/apiKeys.routes.ts
@@ -26,9 +26,11 @@ const router = Router()
 
 // ── validation schemas ─────────────────────────────────────────────────────────
 
+// scope defaults to the least-privileged option so a caller that omits it
+// never accidentally mints a write-capable key.
 const createApiKeySchema = z.object({
     name: z.string().min(1).max(128),
-    scope: z.enum(['read-only', 'read-write']),
+    scope: z.enum(['read-only', 'read-write']).default('read-only'),
 })
 
 const rotateApiKeySchema = z.object({

--- a/backend/src/api/assets.routes.ts
+++ b/backend/src/api/assets.routes.ts
@@ -4,7 +4,7 @@ import {
     AssetRegistryConflictError,
     AssetRegistryValidationError
 } from '../services/assetRegistryValidation.js'
-import { rateLimitMonitor } from '../services/rateLimitMonitor.js'
+import { rateLimitMonitor, type RateLimitDashboardQuery } from '../services/rateLimitMonitor.js'
 import { requireAdmin } from '../middleware/auth.js'
 import { adminRateLimiter } from '../middleware/rateLimit.js'
 import { idempotencyMiddleware } from '../middleware/idempotency.js'
@@ -95,6 +95,49 @@ assetsRouter.get('/admin/rate-limits/metrics', requireAdmin, (req: Request, res:
         })
     } catch (error) {
         logger.error('[ERROR] Admin rate limit metrics failed', { error: getErrorObject(error) })
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
+/**
+ * Admin: combined per-IP + per-API-key rate limit dashboard.
+ *
+ * Query params:
+ *   type     — ip | apiKey | all           (default: all)
+ *   status   — throttled | near-limit | ok | at-risk | all  (default: all)
+ *   search   — substring match on the identifier
+ *   page     — 1-based page number         (default: 1)
+ *   pageSize — 1..200                      (default: 25)
+ *
+ * Throttled and near-limit identifiers are also surfaced in `attention`
+ * regardless of the current page.
+ */
+assetsRouter.get('/admin/rate-limits/dashboard', requireAdmin, (req: Request, res: Response) => {
+    try {
+        const type = (req.query.type as string | undefined)?.toLowerCase()
+        const status = (req.query.status as string | undefined)?.toLowerCase()
+
+        const VALID_TYPES = ['ip', 'apikey', 'all']
+        const VALID_STATUSES = ['ok', 'near-limit', 'throttled', 'at-risk', 'all']
+
+        if (type && !VALID_TYPES.includes(type)) {
+            return fail(res, 400, 'VALIDATION_ERROR', `Invalid type. Use one of: ip, apiKey, all.`)
+        }
+        if (status && !VALID_STATUSES.includes(status)) {
+            return fail(res, 400, 'VALIDATION_ERROR', `Invalid status. Use one of: ${VALID_STATUSES.join(', ')}.`)
+        }
+
+        const dashboard = rateLimitMonitor.getRateLimitDashboard({
+            type: type === 'apikey' ? 'apiKey' : (type as 'ip' | 'all' | undefined),
+            status: status as RateLimitDashboardQuery['status'],
+            search: req.query.search as string | undefined,
+            page: req.query.page ? Number(req.query.page) : undefined,
+            pageSize: req.query.pageSize ? Number(req.query.pageSize) : undefined,
+        })
+
+        return ok(res, dashboard)
+    } catch (error) {
+        logger.error('[ERROR] Admin rate limit dashboard failed', { error: getErrorObject(error) })
         return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
     }
 })

--- a/backend/src/api/taxReport.routes.ts
+++ b/backend/src/api/taxReport.routes.ts
@@ -6,6 +6,25 @@ import { ok, fail } from '../utils/apiResponse.js'
 
 export const taxReportRouter = Router()
 
+export type CostBasisMethod = 'fifo' | 'lifo' | 'hifo'
+
+export const COST_BASIS_METHODS: CostBasisMethod[] = ['fifo', 'lifo', 'hifo']
+
+const METHODOLOGY_DESCRIPTIONS: Record<CostBasisMethod, string> = {
+  fifo:
+    'FIFO (first-in, first-out). Each rebalance buys one asset and sells another. ' +
+    'Sell cost basis is determined by consuming the oldest tax lots first. ' +
+    'Buy events create new tax lots at the purchase price.',
+  lifo:
+    'LIFO (last-in, first-out). Each rebalance buys one asset and sells another. ' +
+    'Sell cost basis is determined by consuming the most recently acquired tax lots first. ' +
+    'Buy events create new tax lots at the purchase price.',
+  hifo:
+    'HIFO (highest-in, first-out). Each rebalance buys one asset and sells another. ' +
+    'Sell cost basis is determined by consuming the tax lots with the highest unit cost first, ' +
+    'which minimises realized gains. Buy events create new tax lots at the purchase price.',
+}
+
 interface TaxLot {
   asset: string
   date: string
@@ -25,20 +44,49 @@ interface TaxReportEntry {
 }
 
 /**
- * FIFO methodology:
+ * A single lot-level disposal produced while matching a sell against tax lots.
+ * One sell can produce several disposals when it spans multiple lots.
+ * This is the granularity required by consumer tax software (TurboTax et al.),
+ * which needs an acquisition date per disposed lot.
+ */
+interface TaxDisposal {
+  asset: string
+  acquiredDate: string
+  soldDate: string
+  amount: number
+  costBasis: number
+  proceeds: number
+  realizedGainLoss: number
+}
+
+interface TaxReportResult {
+  entries: TaxReportEntry[]
+  disposals: TaxDisposal[]
+}
+
+const DUST = 0.00000001
+
+/**
+ * Cost-basis lot matching.
  *
  * Every "buy" creates a tax lot (asset, date, amount, unit price, total cost basis).
- * When the same asset is later sold, lots are consumed in chronological order
- * (first-in, first-out). The cost basis for each lot is proportional to the
- * amount consumed. Realized gain/loss = (sell price × sell amount) − cost basis.
+ * When the same asset is later sold, lots are consumed in an order determined by the
+ * selected cost-basis method:
+ *
+ *   - FIFO: oldest lot first (chronological)
+ *   - LIFO: most recently acquired lot first
+ *   - HIFO: highest unit cost first (ties broken by the older lot)
+ *
+ * The cost basis taken from each lot is proportional to the amount consumed.
+ * Realized gain/loss = (sell price × sell amount) − matched cost basis.
  *
  * Only completed rebalance events with trade details (fromAsset, toAsset, amount)
  * are included. Events without explicit trade details are skipped.
  */
-
-function fifoComputeReport(events: any[]): TaxReportEntry[] {
+export function computeReport(events: any[], method: CostBasisMethod = 'fifo'): TaxReportResult {
   const lots: Map<string, TaxLot[]> = new Map()
   const entries: TaxReportEntry[] = []
+  const disposals: TaxDisposal[] = []
 
   for (const event of events) {
     const details = event.details
@@ -60,13 +108,14 @@ function fifoComputeReport(events: any[]): TaxReportEntry[] {
 
     const toAmount = (amount * fromPrice) / toPrice
 
-    // Sell fromAsset (consume FIFO lots, compute realized gain/loss)
+    // Sell fromAsset (consume lots in method order, compute realized gain/loss)
     let remainingToSell = amount
     let totalCostBasisForSell = 0
     const assetLots = lots.get(fromAsset) ?? []
 
-    while (remainingToSell > 0 && assetLots.length > 0) {
-      const lot = assetLots[0]
+    while (remainingToSell > DUST && assetLots.length > 0) {
+      const lotIndex = selectLotIndex(assetLots, method)
+      const lot = assetLots[lotIndex]
       const consumed = Math.min(remainingToSell, lot.amount)
       const costBasisFraction = (consumed / lot.amount) * lot.costBasis
 
@@ -75,14 +124,32 @@ function fifoComputeReport(events: any[]): TaxReportEntry[] {
       lot.costBasis -= costBasisFraction
       remainingToSell -= consumed
 
-      if (lot.amount <= 0.00000001) {
-        assetLots.shift()
+      disposals.push({
+        asset: fromAsset,
+        acquiredDate: lot.date,
+        soldDate: date,
+        amount: consumed,
+        costBasis: costBasisFraction,
+        proceeds: consumed * fromPrice,
+        realizedGainLoss: consumed * fromPrice - costBasisFraction,
+      })
+
+      if (lot.amount <= DUST) {
+        assetLots.splice(lotIndex, 1)
       }
     }
 
-    if (remainingToSell > 0 && assetLots.length === 0) {
+    if (remainingToSell > DUST) {
       // No cost basis available — treat cost basis as 0
-      totalCostBasisForSell += 0
+      disposals.push({
+        asset: fromAsset,
+        acquiredDate: date,
+        soldDate: date,
+        amount: remainingToSell,
+        costBasis: 0,
+        proceeds: remainingToSell * fromPrice,
+        realizedGainLoss: remainingToSell * fromPrice,
+      })
     }
 
     const sellValue = amount * fromPrice
@@ -123,10 +190,52 @@ function fifoComputeReport(events: any[]): TaxReportEntry[] {
     })
   }
 
-  return entries
+  return { entries, disposals }
 }
 
-function getPriceEstimate(asset: string, _date: string): number {
+/**
+ * Pick which lot to consume next. Lots are stored in acquisition order, so
+ * FIFO is the head and LIFO is the tail. HIFO scans for the highest unit cost,
+ * keeping the earlier lot on a tie so results stay deterministic.
+ */
+function selectLotIndex(lots: TaxLot[], method: CostBasisMethod): number {
+  if (method === 'lifo') return lots.length - 1
+  if (method === 'fifo') return 0
+
+  let bestIndex = 0
+  let bestUnitCost = unitCost(lots[0])
+  for (let i = 1; i < lots.length; i++) {
+    const cost = unitCost(lots[i])
+    if (cost > bestUnitCost) {
+      bestUnitCost = cost
+      bestIndex = i
+    }
+  }
+  return bestIndex
+}
+
+function unitCost(lot: TaxLot): number {
+  return lot.amount > 0 ? lot.costBasis / lot.amount : lot.price
+}
+
+export function parseCostBasisMethod(raw: unknown): CostBasisMethod | null {
+  if (raw === undefined || raw === null || raw === '') return 'fifo'
+  if (typeof raw !== 'string') return null
+  const normalized = raw.toLowerCase().trim() as CostBasisMethod
+  return COST_BASIS_METHODS.includes(normalized) ? normalized : null
+}
+
+function getPriceEstimate(asset: string, date: string): number {
+  // Prefer the price as of the trade date so historical lots keep their own
+  // acquisition price — this is what makes FIFO/LIFO/HIFO diverge.
+  const asOf = (databaseService as any).getPriceSnapshotAsOf
+  if (typeof asOf === 'function' && date) {
+    const historical = asOf.call(databaseService, asset, date)
+    if (historical && historical.price > 0) {
+      return historical.price
+    }
+  }
+
   const snapshot = databaseService.getLatestPriceSnapshot(asset)
   if (snapshot && snapshot.price > 0) {
     return snapshot.price
@@ -170,21 +279,85 @@ function toCSV(entries: TaxReportEntry[]): string {
   return [headers, ...rows].join('\n')
 }
 
+/**
+ * TurboTax cryptocurrency CSV import schema — column order is fixed and must
+ * match exactly for the import template to be accepted:
+ *
+ *   Currency Name, Purchase Date, Cost Basis, Date Sold, Proceeds
+ *
+ * Dates are MM/DD/YYYY and monetary amounts are plain decimals with no
+ * currency symbol or thousands separators. One row per disposed lot.
+ */
+export const TURBOTAX_HEADERS = [
+  'Currency Name',
+  'Purchase Date',
+  'Cost Basis',
+  'Date Sold',
+  'Proceeds',
+] as const
+
+export function toTurboTaxCSV(disposals: TaxDisposal[]): string {
+  const rows = disposals.map((d) =>
+    [
+      escapeCsv(d.asset),
+      formatTurboTaxDate(d.acquiredDate),
+      d.costBasis.toFixed(2),
+      formatTurboTaxDate(d.soldDate),
+      d.proceeds.toFixed(2),
+    ].join(','),
+  )
+
+  return [TURBOTAX_HEADERS.join(','), ...rows].join('\n')
+}
+
+function formatTurboTaxDate(iso: string): string {
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return ''
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(d.getUTCDate()).padStart(2, '0')
+  return `${mm}/${dd}/${d.getUTCFullYear()}`
+}
+
+function escapeCsv(value: string): string {
+  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
+}
+
 taxReportRouter.get('/portfolio/tax-report', (req: Request, res: Response) => {
   try {
     const yearParam = req.query.year as string | undefined
-    const format = (req.query.format as string)?.toLowerCase() === 'csv' ? 'csv' : 'json'
+    const rawFormat = (req.query.format as string)?.toLowerCase()
+    const format = rawFormat === 'csv' ? 'csv' : rawFormat === 'turbotax' ? 'turbotax' : 'json'
     const taxYear = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear()
 
     if (isNaN(taxYear) || taxYear < 2000 || taxYear > 2100) {
       return fail(res, 400, 'VALIDATION_ERROR', 'Invalid year. Use a year between 2000 and 2100.')
     }
 
+    const method = parseCostBasisMethod(req.query.costBasisMethod)
+    if (!method) {
+      return fail(
+        res,
+        400,
+        'VALIDATION_ERROR',
+        `Invalid costBasisMethod. Use one of: ${COST_BASIS_METHODS.join(', ')}.`,
+      )
+    }
+
     const startDate = new Date(Date.UTC(taxYear, 0, 1)).toISOString()
     const endDate = new Date(Date.UTC(taxYear + 1, 0, 1)).toISOString()
 
     const events = databaseService.getRebalanceHistoryByDateRange(startDate, endDate)
-    const entries = fifoComputeReport(events)
+    const { entries, disposals } = computeReport(events, method)
+
+    if (format === 'turbotax') {
+      const csv = toTurboTaxCSV(disposals)
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8')
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="turbotax-tax-report-${taxYear}-${method}.csv"`,
+      )
+      return res.status(200).send(csv)
+    }
 
     if (format === 'csv') {
       const csv = toCSV(entries)
@@ -198,12 +371,12 @@ taxReportRouter.get('/portfolio/tax-report', (req: Request, res: Response) => {
 
     const summary = {
       taxYear,
+      costBasisMethod: method,
       totalRealizedGainLoss: entries.reduce((sum, e) => sum + e.realizedGainLoss, 0),
       totalTrades: entries.length,
       entries,
-      methodology: 'FIFO (first-in, first-out). Each rebalance buys one asset and sells another. ' +
-        'Sell cost basis is determined by consuming the oldest tax lots first. ' +
-        'Buy events create new tax lots at the purchase price.',
+      disposals,
+      methodology: METHODOLOGY_DESCRIPTIONS[method],
     }
 
     return ok(res, summary)

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -377,7 +377,8 @@ export const requestMonitoringMiddleware = (
   res: import("express").Response,
   next: import("express").NextFunction,
 ): void => {
-  rateLimitMonitor.recordRequest();
+  // Passing the request also feeds the per-IP / per-API-key consumption dashboard.
+  rateLimitMonitor.recordRequest(req);
   next();
 };
 

--- a/backend/src/middleware/requireApiKey.ts
+++ b/backend/src/middleware/requireApiKey.ts
@@ -2,11 +2,16 @@
  * requireApiKey middleware
  *
  * Authenticates requests via the `X-API-Key` header.
- * Sets req.apiKeyUser = { address, scope } on success.
+ * Sets req.apiKeyUser = { address, scope, keyId } on success.
+ *
+ * Scope enforcement happens here: a `read-only` key is rejected on any mutating
+ * request (POST/PUT/PATCH/DELETE), so routes cannot forget to opt in. Routes that
+ * are logically mutating but use a read verb can additionally chain requireReadWrite.
  *
  * Usage:
- *   router.get('/resource', requireApiKey, handler)                 // any scope
- *   router.post('/resource', requireApiKey, requireReadWrite, handler) // write scope
+ *   router.get('/resource', requireApiKey, handler)                    // any scope
+ *   router.post('/resource', requireApiKey, handler)                   // write scope enforced by method
+ *   router.get('/dangerous', requireApiKey, requireReadWrite, handler) // explicit write scope
  */
 
 import { Request, Response, NextFunction } from 'express'
@@ -28,9 +33,16 @@ declare global {
     }
 }
 
+/** HTTP methods treated as mutating for scope purposes. */
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+
+export function isMutatingMethod(method: string): boolean {
+    return MUTATING_METHODS.has(method.toUpperCase())
+}
+
 /**
  * Middleware: requires a valid X-API-Key header.
- * Populates req.apiKeyUser on success.
+ * Populates req.apiKeyUser on success and enforces the key's scope.
  */
 export async function requireApiKey(req: Request, res: Response, next: NextFunction): Promise<void> {
     const rawKey = req.headers['x-api-key']
@@ -42,20 +54,32 @@ export async function requireApiKey(req: Request, res: Response, next: NextFunct
 
     const row = await findApiKeyByRawKey(rawKey.trim()).catch(() => null)
 
-    if (!row || row.revoked) {
+    if (!row) {
         fail(res, 401, 'UNAUTHORIZED', 'Invalid or revoked API key')
         return
     }
 
-    // Grace-period check: key is revoked but still within the grace window
-    if (row.revoked && row.grace_expires_at && row.grace_expires_at > new Date()) {
-        // Allow — key is in rotation grace period
-    } else if (row.revoked) {
+    // A revoked key is still accepted while inside its rotation grace window.
+    const inGracePeriod =
+        !!row.grace_expires_at && row.grace_expires_at.getTime() > Date.now()
+
+    if (row.revoked && !inGracePeriod) {
         fail(res, 401, 'UNAUTHORIZED', 'Invalid or revoked API key')
         return
     }
 
     req.apiKeyUser = { address: row.user_address, scope: row.scope, keyId: row.id }
+
+    if (row.scope === 'read-only' && isMutatingMethod(req.method)) {
+        fail(
+            res,
+            403,
+            'FORBIDDEN',
+            'This API key is read-only and cannot be used for write operations',
+            { scope: row.scope, method: req.method },
+        )
+        return
+    }
 
     // Fire-and-forget: update last_used_at
     void touchApiKeyLastUsed(row.id)

--- a/backend/src/openapi/spec.ts
+++ b/backend/src/openapi/spec.ts
@@ -817,20 +817,24 @@ const spec: Record<string, any> = {
             get: {
                 tags: ['Portfolio'],
                 summary: 'Get tax report',
-                description: 'Realized gain/loss tax report computed with FIFO cost basis for a tax year.',
+                description:
+                    'Realized gain/loss tax report for a tax year. Lots are matched using the selected ' +
+                    'cost-basis method (FIFO by default). `format=turbotax` returns a TurboTax-importable ' +
+                    'CSV with the columns: Currency Name, Purchase Date, Cost Basis, Date Sold, Proceeds.',
                 parameters: [
                     { name: 'year', in: 'query', schema: { type: 'integer', minimum: 2000, maximum: 2100, description: 'Tax year (defaults to the current year)' } },
-                    { name: 'format', in: 'query', schema: { type: 'string', enum: ['json', 'csv'], default: 'json' } },
+                    { name: 'format', in: 'query', schema: { type: 'string', enum: ['json', 'csv', 'turbotax'], default: 'json' } },
+                    { name: 'costBasisMethod', in: 'query', schema: { type: 'string', enum: ['fifo', 'lifo', 'hifo'], default: 'fifo', description: 'Lot-matching method used to determine cost basis' } },
                 ],
                 responses: {
                     '200': {
-                        description: 'Tax report summary (JSON) or CSV download (format=csv)',
+                        description: 'Tax report summary (JSON) or CSV download (format=csv or format=turbotax)',
                         content: {
                             'application/json': { schema: { $ref: '#/components/schemas/ApiEnvelope' } },
                             'text/csv': { schema: { type: 'string' } },
                         },
                     },
-                    '400': { description: 'Invalid year', content: { 'application/json': { schema: { $ref: '#/components/schemas/ApiError' }, examples: { ValidationError: { $ref: '#/components/examples/ValidationError' } } } } },
+                    '400': { description: 'Invalid year or costBasisMethod', content: { 'application/json': { schema: { $ref: '#/components/schemas/ApiError' }, examples: { ValidationError: { $ref: '#/components/examples/ValidationError' } } } } },
                     '500': { description: 'Internal error', content: { 'application/json': { schema: { $ref: '#/components/schemas/ApiError' } } } },
                 },
             },

--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -2043,6 +2043,41 @@ getConsent(userId: string): ConsentRecord | undefined {
     });
   }
 
+  /**
+   * Most recent price snapshot captured at or before `asOf` (ISO timestamp).
+   * Used by the tax report so each tax lot keeps its acquisition-date price
+   * instead of collapsing onto the latest price.
+   */
+  getPriceSnapshotAsOf(
+    asset: string,
+    asOf: string,
+  ): { price: number; change?: number; capturedAt: string } | undefined {
+    return this._withTiming("getPriceSnapshotAsOf", () => {
+      try {
+        const row = this.db
+          .prepare<
+            [string, string],
+            { price: number; change: number | null; captured_at: string }
+          >(
+            `SELECT price, change, captured_at FROM price_snapshots
+             WHERE asset = ? AND captured_at <= ?
+             ORDER BY captured_at DESC LIMIT 1`,
+          )
+          .get(asset, asOf);
+        if (!row) return undefined;
+        return {
+          price: row.price,
+          change: row.change ?? undefined,
+          capturedAt: row.captured_at,
+        };
+      } catch (err) {
+        throw new Error(
+          `Failed to retrieve price snapshot for asset '${asset}' as of '${asOf}': ${err}`,
+        );
+      }
+    });
+  }
+
   // ──────────────────────────────────────────
   // Portfolio draft methods
   // ──────────────────────────────────────────

--- a/backend/src/services/rateLimitMonitor.ts
+++ b/backend/src/services/rateLimitMonitor.ts
@@ -11,6 +11,78 @@ interface RateLimitMetrics {
     lastReset: Date
 }
 
+// ── consumption tracking (dashboard) ───────────────────────────────────────────
+
+export type RateLimitIdentifierType = 'ip' | 'apiKey'
+
+/** ok → below the near-limit ratio, near-limit → at/above it, throttled → already 429'd this window. */
+export type RateLimitStatus = 'ok' | 'near-limit' | 'throttled'
+
+export interface RateLimitConsumptionEntry {
+    identifier: string
+    type: RateLimitIdentifierType
+    consumed: number
+    limit: number
+    remaining: number
+    /** Fraction of the limit consumed, 0–1+, rounded to 4 decimals. */
+    utilization: number
+    throttledCount: number
+    status: RateLimitStatus
+    windowStartedAt: string
+    windowResetsAt: string
+    lastSeenAt: string
+}
+
+export interface RateLimitDashboardQuery {
+    type?: RateLimitIdentifierType | 'all'
+    status?: RateLimitStatus | 'all' | 'at-risk'
+    search?: string
+    page?: number
+    pageSize?: number
+}
+
+export interface RateLimitDashboard {
+    summary: {
+        windowMs: number
+        limit: number
+        nearLimitRatio: number
+        trackedIdentifiers: number
+        trackedIPs: number
+        trackedApiKeys: number
+        throttled: number
+        nearLimit: number
+        generatedAt: string
+    }
+    /** Throttled and near-limit identifiers, surfaced ahead of the paged list. */
+    attention: {
+        throttled: RateLimitConsumptionEntry[]
+        nearLimit: RateLimitConsumptionEntry[]
+    }
+    entries: RateLimitConsumptionEntry[]
+    pagination: {
+        page: number
+        pageSize: number
+        total: number
+        totalPages: number
+        hasMore: boolean
+    }
+}
+
+interface ConsumptionRecord {
+    identifier: string
+    type: RateLimitIdentifierType
+    consumed: number
+    throttledCount: number
+    windowStartedAt: number
+    lastSeenAt: number
+}
+
+const DEFAULT_PAGE_SIZE = 25
+const MAX_PAGE_SIZE = 200
+/** Cap on tracked identifiers so a scattered-IP flood cannot grow the map unbounded. */
+const MAX_TRACKED_IDENTIFIERS = 10_000
+const ATTENTION_LIST_LIMIT = 25
+
 class RateLimitMonitor {
     private metrics: RateLimitMetrics = {
         totalRequests: 0,
@@ -21,6 +93,11 @@ class RateLimitMonitor {
         throttledByUser: {},
         lastReset: new Date()
     }
+
+    /** Keyed by `${type}:${identifier}` — current-window consumption per IP / API key. */
+    private consumption: Map<string, ConsumptionRecord> = new Map()
+    /** Per-identifier limit overrides reported by callers, keyed like `consumption`. */
+    private limitOverrides: Map<string, number> = new Map()
 
     private readonly resetInterval = 24 * 60 * 60 * 1000 // 24 hours
     private intervalId?: NodeJS.Timeout
@@ -42,6 +119,8 @@ class RateLimitMonitor {
         const ip = req.ip || 'unknown'
         const userAddress = req.user?.address
         const endpoint = `${req.method} ${req.route?.path || req.path}`
+
+        this.trackConsumption(req, true)
 
         this.metrics.throttledRequests++
         this.metrics.throttledByType[limitType] = (this.metrics.throttledByType[limitType] || 0) + 1
@@ -68,10 +147,124 @@ class RateLimitMonitor {
     }
 
     /**
-     * Record a successful request
+     * Record a successful request.
+     * `req` is optional for backward compatibility; when supplied, the request
+     * also counts toward the per-IP / per-API-key consumption dashboard.
      */
-    recordRequest(): void {
+    recordRequest(req?: Request): void {
         this.metrics.totalRequests++
+        if (req) this.trackConsumption(req, false)
+    }
+
+    /**
+     * Record consumption for a single identifier. Exposed so callers that
+     * already know the identity (e.g. background workers using an API key)
+     * can report usage without an Express request.
+     */
+    recordConsumption(
+        type: RateLimitIdentifierType,
+        identifier: string,
+        options: { throttled?: boolean; limit?: number } = {},
+    ): void {
+        if (!identifier) return
+
+        const key = `${type}:${identifier}`
+        const now = Date.now()
+        let record = this.consumption.get(key)
+
+        if (!record || now - record.windowStartedAt >= this.getWindowMs()) {
+            record = {
+                identifier,
+                type,
+                consumed: 0,
+                throttledCount: 0,
+                windowStartedAt: now,
+                lastSeenAt: now,
+            }
+            this.consumption.set(key, record)
+        }
+
+        record.consumed++
+        record.lastSeenAt = now
+        if (options.throttled) record.throttledCount++
+        if (options.limit && options.limit > 0) this.limitOverrides.set(key, options.limit)
+
+        if (this.consumption.size > MAX_TRACKED_IDENTIFIERS) {
+            this.evictStaleConsumption(now)
+        }
+    }
+
+    /**
+     * Combined per-IP + per-API-key rate-limit consumption view.
+     * Entries are ordered most-at-risk first (throttled, then by utilization),
+     * filtered and paged so the dashboard stays usable with many identifiers.
+     */
+    getRateLimitDashboard(query: RateLimitDashboardQuery = {}): RateLimitDashboard {
+        const now = Date.now()
+        const windowMs = this.getWindowMs()
+        const limit = this.getLimit()
+        const nearLimitRatio = this.getNearLimitRatio()
+
+        this.pruneExpiredWindows(now)
+
+        const all: RateLimitConsumptionEntry[] = [...this.consumption.entries()].map(([key, record]) =>
+            this.toEntry(key, record, limit, windowMs, nearLimitRatio),
+        )
+
+        const typeFilter = query.type && query.type !== 'all' ? query.type : null
+        const statusFilter = query.status && query.status !== 'all' ? query.status : null
+        const search = query.search?.trim().toLowerCase() || null
+
+        const filtered = all
+            .filter(e => (typeFilter ? e.type === typeFilter : true))
+            .filter(e => {
+                if (!statusFilter) return true
+                if (statusFilter === 'at-risk') return e.status !== 'ok'
+                return e.status === statusFilter
+            })
+            .filter(e => (search ? e.identifier.toLowerCase().includes(search) : true))
+            .sort(compareEntries)
+
+        const pageSize = clampInt(query.pageSize, DEFAULT_PAGE_SIZE, 1, MAX_PAGE_SIZE)
+        const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize))
+        const page = clampInt(query.page, 1, 1, totalPages)
+        const start = (page - 1) * pageSize
+        const entries = filtered.slice(start, start + pageSize)
+
+        const throttled = all.filter(e => e.status === 'throttled').sort(compareEntries)
+        const nearLimit = all.filter(e => e.status === 'near-limit').sort(compareEntries)
+
+        return {
+            summary: {
+                windowMs,
+                limit,
+                nearLimitRatio,
+                trackedIdentifiers: all.length,
+                trackedIPs: all.filter(e => e.type === 'ip').length,
+                trackedApiKeys: all.filter(e => e.type === 'apiKey').length,
+                throttled: throttled.length,
+                nearLimit: nearLimit.length,
+                generatedAt: new Date(now).toISOString(),
+            },
+            attention: {
+                throttled: throttled.slice(0, ATTENTION_LIST_LIMIT),
+                nearLimit: nearLimit.slice(0, ATTENTION_LIST_LIMIT),
+            },
+            entries,
+            pagination: {
+                page,
+                pageSize,
+                total: filtered.length,
+                totalPages,
+                hasMore: start + entries.length < filtered.length,
+            },
+        }
+    }
+
+    /** Clear all tracked consumption — used by tests and the daily reset. */
+    resetConsumption(): void {
+        this.consumption.clear()
+        this.limitOverrides.clear()
     }
 
     /**
@@ -117,6 +310,94 @@ class RateLimitMonitor {
             .map(([endpoint, count]) => ({ endpoint, count }))
     }
 
+    /** Record both the IP and (when present) the API key behind a request. */
+    private trackConsumption(req: Request, throttled: boolean): void {
+        const ip = req.ip || 'unknown'
+        this.recordConsumption('ip', ip, { throttled })
+
+        const keyId = req.apiKeyUser?.keyId
+        if (keyId) {
+            this.recordConsumption('apiKey', keyId, { throttled })
+        }
+    }
+
+    private toEntry(
+        key: string,
+        record: ConsumptionRecord,
+        limit: number,
+        windowMs: number,
+        nearLimitRatio: number,
+    ): RateLimitConsumptionEntry {
+        const effectiveLimit = this.limitOverrides.get(key) ?? limit
+        const utilization = effectiveLimit > 0 ? record.consumed / effectiveLimit : 0
+        const status: RateLimitStatus =
+            record.throttledCount > 0
+                ? 'throttled'
+                : utilization >= nearLimitRatio
+                    ? 'near-limit'
+                    : 'ok'
+
+        return {
+            identifier: record.identifier,
+            type: record.type,
+            consumed: record.consumed,
+            limit: effectiveLimit,
+            remaining: Math.max(0, effectiveLimit - record.consumed),
+            utilization: Math.round(utilization * 10000) / 10000,
+            throttledCount: record.throttledCount,
+            status,
+            windowStartedAt: new Date(record.windowStartedAt).toISOString(),
+            windowResetsAt: new Date(record.windowStartedAt + windowMs).toISOString(),
+            lastSeenAt: new Date(record.lastSeenAt).toISOString(),
+        }
+    }
+
+    /** Drop records whose window has elapsed — they no longer reflect live consumption. */
+    private pruneExpiredWindows(now: number): void {
+        const windowMs = this.getWindowMs()
+        for (const [key, record] of this.consumption) {
+            if (now - record.windowStartedAt >= windowMs) {
+                this.consumption.delete(key)
+                this.limitOverrides.delete(key)
+            }
+        }
+    }
+
+    /** Hard cap fallback: drop the least recently seen half of the tracked set. */
+    private evictStaleConsumption(now: number): void {
+        this.pruneExpiredWindows(now)
+        if (this.consumption.size <= MAX_TRACKED_IDENTIFIERS) return
+
+        const byOldest = [...this.consumption.entries()].sort(
+            ([, a], [, b]) => a.lastSeenAt - b.lastSeenAt,
+        )
+        for (let i = 0; i < Math.floor(byOldest.length / 2); i++) {
+            this.consumption.delete(byOldest[i][0])
+            this.limitOverrides.delete(byOldest[i][0])
+        }
+    }
+
+    private getWindowMs(): number {
+        return (
+            parseInt(
+                process.env.RATE_LIMIT_WINDOW_MS || process.env.RATE_LIMIT_GLOBAL_WINDOW_MS || '',
+                10,
+            ) || 15 * 60 * 1000
+        )
+    }
+
+    private getLimit(): number {
+        return (
+            parseInt(process.env.RATE_LIMIT_MAX || process.env.RATE_LIMIT_GLOBAL_MAX || '', 10) || 100
+        )
+    }
+
+    private getNearLimitRatio(): number {
+        const parsed = parseFloat(process.env.RATE_LIMIT_NEAR_LIMIT_RATIO || '')
+        if (!isNaN(parsed) && parsed > 0 && parsed <= 1) return parsed
+        return 0.8
+    }
+
     /**
      * Reset all metrics
      */
@@ -134,6 +415,8 @@ class RateLimitMonitor {
             throttledByUser: {},
             lastReset: new Date()
         }
+
+        this.resetConsumption()
     }
 
     /**
@@ -215,6 +498,29 @@ Throttles by Type:
 ${Object.entries(metrics.throttledByType).map(([type, count]) => `  ${type}: ${count}`).join('\n')}
         `.trim()
     }
+}
+
+// ── dashboard helpers ──────────────────────────────────────────────────────────
+
+const STATUS_RANK: Record<RateLimitStatus, number> = {
+    throttled: 0,
+    'near-limit': 1,
+    ok: 2,
+}
+
+/** Most-at-risk first: throttled, then near-limit, then by utilization desc. */
+function compareEntries(a: RateLimitConsumptionEntry, b: RateLimitConsumptionEntry): number {
+    const byStatus = STATUS_RANK[a.status] - STATUS_RANK[b.status]
+    if (byStatus !== 0) return byStatus
+    if (b.utilization !== a.utilization) return b.utilization - a.utilization
+    if (b.consumed !== a.consumed) return b.consumed - a.consumed
+    return a.identifier.localeCompare(b.identifier)
+}
+
+function clampInt(value: unknown, fallback: number, min: number, max: number): number {
+    const parsed = typeof value === 'number' ? value : parseInt(String(value ?? ''), 10)
+    if (isNaN(parsed)) return fallback
+    return Math.min(max, Math.max(min, Math.floor(parsed)))
 }
 
 // Singleton instance

--- a/backend/src/test/apiKeyScope.test.ts
+++ b/backend/src/test/apiKeyScope.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Scoped API key tests.
+ *
+ * Covers the read-only vs read-write scope end to end: creation stores the scope,
+ * the authentication middleware rejects read-only keys on mutating endpoints while
+ * still accepting them on GET endpoints, and the management response exposes the scope.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import {
+    createApiKey,
+    generateApiKeyId,
+    generateApiKeyString,
+    listApiKeysForUser,
+    revokeApiKey,
+    rotateApiKey,
+    type ApiKeyScope,
+} from '../db/apiKeyDb.js'
+import { requireApiKey, requireReadWrite, isMutatingMethod } from '../middleware/requireApiKey.js'
+
+vi.mock('../utils/logger.js', () => ({
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const USER = 'GTESTUSERADDRESSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
+function makeApp() {
+    const app = express()
+    app.use(express.json())
+
+    // Representative read endpoints
+    app.get('/api/portfolios', requireApiKey, (req, res) => {
+        res.status(200).json({ ok: true, scope: req.apiKeyUser?.scope })
+    })
+    app.get('/api/portfolios/:id', requireApiKey, (req, res) => {
+        res.status(200).json({ ok: true, id: req.params.id })
+    })
+
+    // Representative write endpoints
+    app.post('/api/portfolios', requireApiKey, (req, res) => {
+        res.status(201).json({ created: true })
+    })
+    app.put('/api/portfolios/:id', requireApiKey, (req, res) => {
+        res.status(200).json({ updated: true })
+    })
+    app.patch('/api/portfolios/:id', requireApiKey, (req, res) => {
+        res.status(200).json({ patched: true })
+    })
+    app.delete('/api/portfolios/:id', requireApiKey, (req, res) => {
+        res.status(200).json({ deleted: true })
+    })
+
+    // Read verb that is logically a write — guarded explicitly
+    app.get('/api/portfolios/:id/rebalance', requireApiKey, requireReadWrite, (req, res) => {
+        res.status(200).json({ rebalanced: true })
+    })
+
+    return app
+}
+
+async function mintKey(scope: ApiKeyScope, name = `${scope}-key`): Promise<string> {
+    const rawKey = generateApiKeyString()
+    await createApiKey(generateApiKeyId(), USER, name, rawKey, scope)
+    return rawKey
+}
+
+describe('scoped API keys', () => {
+    let app: express.Express
+
+    beforeEach(() => {
+        app = makeApp()
+    })
+
+    describe('creation', () => {
+        it('persists the requested scope', async () => {
+            await mintKey('read-only', 'ro')
+            await mintKey('read-write', 'rw')
+
+            const keys = await listApiKeysForUser(USER)
+            const scopes = keys.filter(k => ['ro', 'rw'].includes(k.name)).map(k => k.scope).sort()
+
+            expect(scopes).toEqual(['read-only', 'read-write'])
+        })
+
+        it('exposes the scope on the management listing (never the hash)', async () => {
+            await mintKey('read-only', 'listing-check')
+
+            const keys = await listApiKeysForUser(USER)
+            const key = keys.find(k => k.name === 'listing-check')!
+
+            expect(key.scope).toBe('read-only')
+            expect(key).not.toHaveProperty('key_hash')
+        })
+
+        it('carries the scope across a rotation', async () => {
+            const rawKey = generateApiKeyString()
+            const oldId = generateApiKeyId()
+            await createApiKey(oldId, USER, 'rotate-me', rawKey, 'read-only')
+
+            const result = await rotateApiKey(oldId, USER, generateApiKeyId(), generateApiKeyString())
+
+            expect(result).toMatchObject({ name: 'rotate-me', scope: 'read-only' })
+        })
+    })
+
+    describe('read-only keys', () => {
+        it('are accepted on GET endpoints', async () => {
+            const key = await mintKey('read-only')
+
+            const res = await request(app).get('/api/portfolios').set('X-API-Key', key)
+
+            expect(res.status).toBe(200)
+            expect(res.body.scope).toBe('read-only')
+        })
+
+        it.each([
+            ['post', '/api/portfolios'],
+            ['put', '/api/portfolios/abc'],
+            ['patch', '/api/portfolios/abc'],
+            ['delete', '/api/portfolios/abc'],
+        ] as const)('are rejected with 403 on %s %s', async (method, path) => {
+            const key = await mintKey('read-only')
+
+            const res = await (request(app) as any)[method](path).set('X-API-Key', key)
+
+            expect(res.status).toBe(403)
+            expect(res.body.success).toBe(false)
+            expect(res.body.error.message).toMatch(/read-only/i)
+        })
+
+        it('are rejected by requireReadWrite on a mutating GET route', async () => {
+            const key = await mintKey('read-only')
+
+            const res = await request(app)
+                .get('/api/portfolios/abc/rebalance')
+                .set('X-API-Key', key)
+
+            expect(res.status).toBe(403)
+        })
+    })
+
+    describe('read-write keys', () => {
+        it('are accepted on GET endpoints', async () => {
+            const key = await mintKey('read-write')
+
+            const res = await request(app).get('/api/portfolios').set('X-API-Key', key)
+
+            expect(res.status).toBe(200)
+            expect(res.body.scope).toBe('read-write')
+        })
+
+        it.each([
+            ['post', '/api/portfolios', 201],
+            ['put', '/api/portfolios/abc', 200],
+            ['patch', '/api/portfolios/abc', 200],
+            ['delete', '/api/portfolios/abc', 200],
+        ] as const)('are accepted on %s %s', async (method, path, expected) => {
+            const key = await mintKey('read-write')
+
+            const res = await (request(app) as any)[method](path).set('X-API-Key', key)
+
+            expect(res.status).toBe(expected)
+        })
+
+        it('pass requireReadWrite on a mutating GET route', async () => {
+            const key = await mintKey('read-write')
+
+            const res = await request(app)
+                .get('/api/portfolios/abc/rebalance')
+                .set('X-API-Key', key)
+
+            expect(res.status).toBe(200)
+        })
+    })
+
+    describe('authentication failures', () => {
+        it('rejects a missing X-API-Key header', async () => {
+            const res = await request(app).get('/api/portfolios')
+
+            expect(res.status).toBe(401)
+        })
+
+        it('rejects an unknown key', async () => {
+            const res = await request(app)
+                .get('/api/portfolios')
+                .set('X-API-Key', 'spr_deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef')
+
+            expect(res.status).toBe(401)
+        })
+
+        it('rejects a revoked key that is outside any grace window', async () => {
+            const rawKey = generateApiKeyString()
+            const id = generateApiKeyId()
+            await createApiKey(id, USER, 'revoked', rawKey, 'read-write')
+            await revokeApiKey(id, USER)
+
+            const res = await request(app).get('/api/portfolios').set('X-API-Key', rawKey)
+
+            expect(res.status).toBe(401)
+        })
+    })
+
+    describe('isMutatingMethod', () => {
+        it('classifies write verbs as mutating', () => {
+            expect(['POST', 'PUT', 'PATCH', 'DELETE'].every(isMutatingMethod)).toBe(true)
+        })
+
+        it('classifies read verbs as non-mutating', () => {
+            expect(['GET', 'HEAD', 'OPTIONS'].some(isMutatingMethod)).toBe(false)
+        })
+
+        it('is case-insensitive', () => {
+            expect(isMutatingMethod('post')).toBe(true)
+        })
+    })
+})

--- a/backend/src/test/rateLimitDashboard.test.ts
+++ b/backend/src/test/rateLimitDashboard.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Rate limit dashboard tests.
+ *
+ * Covers the combined per-IP + per-API-key aggregation in rateLimitMonitor
+ * (correctness against seeded counters, near-limit/throttled classification,
+ * filtering and pagination) plus the admin endpoint that serves it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { rateLimitMonitor } from '../services/rateLimitMonitor.js'
+import type { Request } from 'express'
+
+vi.mock('../utils/logger.js', () => ({
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+
+/** Seed `count` requests for an identifier, the last `throttled` of them 429'd. */
+function seed(
+    type: 'ip' | 'apiKey',
+    identifier: string,
+    count: number,
+    throttled = 0,
+): void {
+    for (let i = 0; i < count - throttled; i++) {
+        rateLimitMonitor.recordConsumption(type, identifier)
+    }
+    for (let i = 0; i < throttled; i++) {
+        rateLimitMonitor.recordConsumption(type, identifier, { throttled: true })
+    }
+}
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+    return {
+        ip: '127.0.0.1',
+        method: 'GET',
+        path: '/api/test',
+        route: { path: '/api/test' },
+        user: undefined,
+        get: vi.fn(),
+        ...overrides,
+    } as unknown as Request
+}
+
+describe('rateLimitMonitor consumption dashboard', () => {
+    beforeEach(() => {
+        process.env.RATE_LIMIT_MAX = '100'
+        process.env.RATE_LIMIT_WINDOW_MS = '900000'
+        process.env.RATE_LIMIT_NEAR_LIMIT_RATIO = '0.8'
+        rateLimitMonitor.resetConsumption()
+    })
+
+    afterEach(() => {
+        rateLimitMonitor.resetConsumption()
+        process.env = { ...ORIGINAL_ENV }
+        vi.useRealTimers()
+    })
+
+    describe('aggregation', () => {
+        it('counts consumption per identifier and separates IPs from API keys', () => {
+            seed('ip', '10.0.0.1', 5)
+            seed('ip', '10.0.0.2', 3)
+            seed('apiKey', 'key-abc', 7)
+
+            const { summary, entries } = rateLimitMonitor.getRateLimitDashboard()
+
+            expect(summary.trackedIdentifiers).toBe(3)
+            expect(summary.trackedIPs).toBe(2)
+            expect(summary.trackedApiKeys).toBe(1)
+
+            const byId = Object.fromEntries(entries.map(e => [e.identifier, e]))
+            expect(byId['10.0.0.1']).toMatchObject({ type: 'ip', consumed: 5, remaining: 95 })
+            expect(byId['10.0.0.2']).toMatchObject({ type: 'ip', consumed: 3 })
+            expect(byId['key-abc']).toMatchObject({ type: 'apiKey', consumed: 7, remaining: 93 })
+        })
+
+        it('tracks the same identifier string separately per type', () => {
+            seed('ip', 'shared-id', 2)
+            seed('apiKey', 'shared-id', 4)
+
+            const { entries } = rateLimitMonitor.getRateLimitDashboard()
+            const matching = entries.filter(e => e.identifier === 'shared-id')
+
+            expect(matching).toHaveLength(2)
+            expect(matching.find(e => e.type === 'ip')!.consumed).toBe(2)
+            expect(matching.find(e => e.type === 'apiKey')!.consumed).toBe(4)
+        })
+
+        it('computes utilization against the configured limit', () => {
+            seed('ip', '10.0.0.3', 25)
+
+            const entry = rateLimitMonitor
+                .getRateLimitDashboard()
+                .entries.find(e => e.identifier === '10.0.0.3')!
+
+            expect(entry.utilization).toBeCloseTo(0.25, 4)
+            expect(entry.limit).toBe(100)
+        })
+
+        it('honours a per-identifier limit override', () => {
+            rateLimitMonitor.recordConsumption('apiKey', 'key-limited', { limit: 10 })
+            seed('apiKey', 'key-limited', 8)
+
+            const entry = rateLimitMonitor
+                .getRateLimitDashboard()
+                .entries.find(e => e.identifier === 'key-limited')!
+
+            expect(entry.limit).toBe(10)
+            expect(entry.consumed).toBe(9)
+            expect(entry.status).toBe('near-limit')
+        })
+    })
+
+    describe('status classification', () => {
+        it('marks identifiers below the near-limit ratio as ok', () => {
+            seed('ip', '10.0.1.1', 10)
+
+            const entry = rateLimitMonitor
+                .getRateLimitDashboard()
+                .entries.find(e => e.identifier === '10.0.1.1')!
+
+            expect(entry.status).toBe('ok')
+        })
+
+        it('marks identifiers at or above the ratio as near-limit', () => {
+            seed('ip', '10.0.1.2', 80)
+
+            const entry = rateLimitMonitor
+                .getRateLimitDashboard()
+                .entries.find(e => e.identifier === '10.0.1.2')!
+
+            expect(entry.status).toBe('near-limit')
+        })
+
+        it('marks any identifier with a 429 as throttled', () => {
+            seed('apiKey', 'key-throttled', 5, 2)
+
+            const entry = rateLimitMonitor
+                .getRateLimitDashboard()
+                .entries.find(e => e.identifier === 'key-throttled')!
+
+            expect(entry.status).toBe('throttled')
+            expect(entry.throttledCount).toBe(2)
+        })
+
+        it('surfaces throttled and near-limit identifiers in the attention block', () => {
+            seed('ip', '10.0.2.1', 3)
+            seed('ip', '10.0.2.2', 85)
+            seed('apiKey', 'key-hot', 20, 4)
+
+            const { summary, attention } = rateLimitMonitor.getRateLimitDashboard()
+
+            expect(summary.throttled).toBe(1)
+            expect(summary.nearLimit).toBe(1)
+            expect(attention.throttled.map(e => e.identifier)).toEqual(['key-hot'])
+            expect(attention.nearLimit.map(e => e.identifier)).toEqual(['10.0.2.2'])
+        })
+
+        it('orders entries most-at-risk first', () => {
+            seed('ip', 'calm', 1)
+            seed('ip', 'busy', 90)
+            seed('ip', 'blocked', 10, 1)
+
+            const { entries } = rateLimitMonitor.getRateLimitDashboard()
+
+            expect(entries.map(e => e.identifier)).toEqual(['blocked', 'busy', 'calm'])
+        })
+
+        it('respects a custom near-limit ratio', () => {
+            process.env.RATE_LIMIT_NEAR_LIMIT_RATIO = '0.5'
+            seed('ip', '10.0.3.1', 55)
+
+            const entry = rateLimitMonitor
+                .getRateLimitDashboard()
+                .entries.find(e => e.identifier === '10.0.3.1')!
+
+            expect(entry.status).toBe('near-limit')
+        })
+    })
+
+    describe('filtering and pagination', () => {
+        beforeEach(() => {
+            for (let i = 1; i <= 30; i++) {
+                seed('ip', `10.1.0.${i}`, i)
+            }
+            seed('apiKey', 'key-one', 90)
+            seed('apiKey', 'key-two', 4, 1)
+        })
+
+        it('filters by identifier type', () => {
+            const ips = rateLimitMonitor.getRateLimitDashboard({ type: 'ip', pageSize: 200 })
+            const keys = rateLimitMonitor.getRateLimitDashboard({ type: 'apiKey', pageSize: 200 })
+
+            expect(ips.entries.every(e => e.type === 'ip')).toBe(true)
+            expect(ips.pagination.total).toBe(30)
+            expect(keys.entries.map(e => e.identifier).sort()).toEqual(['key-one', 'key-two'])
+        })
+
+        it('filters by status', () => {
+            const throttled = rateLimitMonitor.getRateLimitDashboard({ status: 'throttled' })
+            const atRisk = rateLimitMonitor.getRateLimitDashboard({ status: 'at-risk' })
+
+            expect(throttled.entries.map(e => e.identifier)).toEqual(['key-two'])
+            expect(atRisk.entries.map(e => e.identifier).sort()).toEqual(['key-one', 'key-two'])
+        })
+
+        it('filters by identifier substring', () => {
+            const res = rateLimitMonitor.getRateLimitDashboard({ search: 'key-' })
+
+            expect(res.pagination.total).toBe(2)
+            expect(res.entries.every(e => e.identifier.startsWith('key-'))).toBe(true)
+        })
+
+        it('pages through results without overlap or gaps', () => {
+            const pageSize = 10
+            const first = rateLimitMonitor.getRateLimitDashboard({ pageSize, page: 1 })
+            const second = rateLimitMonitor.getRateLimitDashboard({ pageSize, page: 2 })
+            const last = rateLimitMonitor.getRateLimitDashboard({ pageSize, page: 4 })
+
+            expect(first.pagination).toMatchObject({ page: 1, pageSize: 10, total: 32, totalPages: 4, hasMore: true })
+            expect(first.entries).toHaveLength(10)
+            expect(second.entries).toHaveLength(10)
+            expect(last.entries).toHaveLength(2)
+            expect(last.pagination.hasMore).toBe(false)
+
+            const ids = [...first.entries, ...second.entries].map(e => e.identifier)
+            expect(new Set(ids).size).toBe(20)
+        })
+
+        it('clamps out-of-range paging inputs', () => {
+            const res = rateLimitMonitor.getRateLimitDashboard({ page: 999, pageSize: 5 })
+
+            expect(res.pagination.page).toBe(res.pagination.totalPages)
+            expect(res.entries.length).toBeGreaterThan(0)
+        })
+    })
+
+    describe('window handling', () => {
+        it('drops identifiers whose window has elapsed', () => {
+            vi.useFakeTimers()
+            vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+            seed('ip', '10.0.9.1', 10)
+
+            vi.setSystemTime(new Date('2026-01-01T00:20:00Z')) // > 15 min window
+
+            const res = rateLimitMonitor.getRateLimitDashboard()
+            expect(res.entries.find(e => e.identifier === '10.0.9.1')).toBeUndefined()
+        })
+
+        it('starts a fresh window instead of accumulating across windows', () => {
+            vi.useFakeTimers()
+            vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+            seed('ip', '10.0.9.2', 10)
+
+            vi.setSystemTime(new Date('2026-01-01T00:20:00Z'))
+            seed('ip', '10.0.9.2', 2)
+
+            const entry = rateLimitMonitor
+                .getRateLimitDashboard()
+                .entries.find(e => e.identifier === '10.0.9.2')!
+
+            expect(entry.consumed).toBe(2)
+        })
+    })
+
+    describe('request integration', () => {
+        it('records the IP of a monitored request', () => {
+            rateLimitMonitor.recordRequest(makeReq({ ip: '203.0.113.7' }))
+
+            const entry = rateLimitMonitor
+                .getRateLimitDashboard()
+                .entries.find(e => e.identifier === '203.0.113.7')!
+
+            expect(entry).toMatchObject({ type: 'ip', consumed: 1, status: 'ok' })
+        })
+
+        it('records both the IP and API key when the request is API-key authenticated', () => {
+            rateLimitMonitor.recordRequest(
+                makeReq({
+                    ip: '203.0.113.8',
+                    apiKeyUser: { address: 'GABC', scope: 'read-only', keyId: 'key-xyz' },
+                } as Partial<Request>),
+            )
+
+            const { entries } = rateLimitMonitor.getRateLimitDashboard()
+            expect(entries.find(e => e.identifier === '203.0.113.8')?.type).toBe('ip')
+            expect(entries.find(e => e.identifier === 'key-xyz')?.type).toBe('apiKey')
+        })
+
+        it('marks both identifiers throttled when a request is rejected', () => {
+            rateLimitMonitor.recordThrottle(
+                makeReq({
+                    ip: '203.0.113.9',
+                    apiKeyUser: { address: 'GABC', scope: 'read-write', keyId: 'key-429' },
+                } as Partial<Request>),
+                'global',
+            )
+
+            const { entries } = rateLimitMonitor.getRateLimitDashboard()
+            expect(entries.find(e => e.identifier === '203.0.113.9')?.status).toBe('throttled')
+            expect(entries.find(e => e.identifier === 'key-429')?.status).toBe('throttled')
+        })
+
+        it('keeps the no-argument recordRequest signature working', () => {
+            const before = rateLimitMonitor.getMetrics().totalRequests
+            rateLimitMonitor.recordRequest()
+
+            expect(rateLimitMonitor.getMetrics().totalRequests).toBe(before + 1)
+            expect(rateLimitMonitor.getRateLimitDashboard().summary.trackedIdentifiers).toBe(0)
+        })
+    })
+})
+
+// ── admin endpoint ─────────────────────────────────────────────────────────────
+
+vi.mock('../middleware/auth.js', () => ({
+    requireAdmin: (_req: any, _res: any, next: any) => next(),
+}))
+
+vi.mock('../services/assetRegistryService.js', () => ({
+    assetRegistryService: { list: vi.fn(() => []) },
+}))
+
+// Keeps the suite off the native sqlite binding — the dashboard route touches none of it.
+vi.mock('../services/databaseService.js', () => ({
+    databaseService: {
+        recordAdminAuditEntry: vi.fn(),
+        getAssetBySymbol: vi.fn(() => null),
+    },
+}))
+
+vi.mock('../middleware/idempotency.js', () => ({
+    idempotencyMiddleware: (_req: any, _res: any, next: any) => next(),
+}))
+
+vi.mock('../queue/workers/priceHistoryWorker.js', () => ({
+    schedulePriceHistoryBackfill: vi.fn(),
+}))
+
+describe('GET /admin/rate-limits/dashboard', () => {
+    let app: express.Express
+
+    beforeEach(async () => {
+        process.env.RATE_LIMIT_MAX = '100'
+        process.env.RATE_LIMIT_NEAR_LIMIT_RATIO = '0.8'
+        rateLimitMonitor.resetConsumption()
+
+        const { assetsRouter } = await import('../api/assets.routes.js')
+        app = express()
+        app.use(express.json())
+        app.use('/api', assetsRouter)
+    })
+
+    afterEach(() => {
+        rateLimitMonitor.resetConsumption()
+        process.env = { ...ORIGINAL_ENV }
+    })
+
+    it('returns the combined IP + API key view', async () => {
+        seed('ip', '198.51.100.1', 5)
+        seed('apiKey', 'key-dash', 95)
+
+        const res = await request(app).get('/api/admin/rate-limits/dashboard')
+
+        expect(res.status).toBe(200)
+        expect(res.body.success).toBe(true)
+        expect(res.body.data.summary).toMatchObject({ trackedIPs: 1, trackedApiKeys: 1, nearLimit: 1 })
+        expect(res.body.data.attention.nearLimit[0].identifier).toBe('key-dash')
+        expect(res.body.data.entries).toHaveLength(2)
+    })
+
+    it('applies type, status and pagination query params', async () => {
+        seed('ip', '198.51.100.2', 90)
+        seed('ip', '198.51.100.3', 2)
+        seed('apiKey', 'key-filtered', 8, 1)
+
+        const typed = await request(app).get('/api/admin/rate-limits/dashboard?type=apiKey')
+        expect(typed.body.data.entries.map((e: any) => e.identifier)).toEqual(['key-filtered'])
+
+        const risky = await request(app).get('/api/admin/rate-limits/dashboard?status=at-risk')
+        expect(risky.body.data.entries.map((e: any) => e.identifier).sort()).toEqual([
+            '198.51.100.2',
+            'key-filtered',
+        ])
+
+        const paged = await request(app).get('/api/admin/rate-limits/dashboard?page=2&pageSize=1')
+        expect(paged.body.data.pagination).toMatchObject({ page: 2, pageSize: 1, total: 3, totalPages: 3 })
+        expect(paged.body.data.entries).toHaveLength(1)
+    })
+
+    it('rejects an invalid type or status', async () => {
+        const badType = await request(app).get('/api/admin/rate-limits/dashboard?type=user')
+        const badStatus = await request(app).get('/api/admin/rate-limits/dashboard?status=angry')
+
+        expect(badType.status).toBe(400)
+        expect(badStatus.status).toBe(400)
+    })
+})

--- a/backend/src/test/taxReport.routes.test.ts
+++ b/backend/src/test/taxReport.routes.test.ts
@@ -1,8 +1,8 @@
 /**
  * Integration tests for GET /api/portfolio/tax-report
  *
- * Verifies FIFO tax report computation, CSV output, and year validation
- * for the mounted taxReportRouter.
+ * Verifies cost-basis method selection (FIFO/LIFO/HIFO), CSV output,
+ * the TurboTax export format, and year validation for the mounted taxReportRouter.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -10,6 +10,7 @@ import express from 'express'
 import request from 'supertest'
 import { portfolioRouter } from '../api/routes.js'
 import { databaseService } from '../services/databaseService.js'
+import { TURBOTAX_HEADERS } from '../api/taxReport.routes.js'
 
 vi.mock('../services/assetRegistryService.js', () => ({
     assetRegistryService: {
@@ -31,6 +32,7 @@ vi.mock('../services/databaseService.js', () => ({
         })),
         getRebalanceHistoryByDateRange: vi.fn(),
         getLatestPriceSnapshot: vi.fn(),
+        getPriceSnapshotAsOf: vi.fn(),
     },
 }))
 
@@ -82,6 +84,7 @@ vi.mock('../utils/logger.js', () => ({
 
 const mockedGetHistory = vi.mocked(databaseService.getRebalanceHistoryByDateRange)
 const mockedGetSnapshot = vi.mocked(databaseService.getLatestPriceSnapshot)
+const mockedGetSnapshotAsOf = vi.mocked((databaseService as any).getPriceSnapshotAsOf)
 
 function makeApp() {
     const app = express()
@@ -90,14 +93,59 @@ function makeApp() {
     return app
 }
 
+/**
+ * Shared sample history used by the cost-basis method tests.
+ *
+ * XLM is acquired in three lots at rising prices (0.40, 0.60, 0.50) by selling
+ * USDC, then 1000 XLM is sold back into USDC at 0.55. Which lots that final sale
+ * consumes — and therefore the realized gain — depends on the method:
+ *
+ *   FIFO → the 0.40 lot (cheapest, acquired first)  → largest gain
+ *   LIFO → the 0.50 lot (acquired last)             → middle gain
+ *   HIFO → the 0.60 lot (highest cost)              → smallest gain (a loss)
+ */
+const XLM_PRICES_BY_DATE: Record<string, number> = {
+    '2025-01-01T00:00:00Z': 0.4,
+    '2025-02-01T00:00:00Z': 0.6,
+    '2025-03-01T00:00:00Z': 0.5,
+    '2025-06-01T00:00:00Z': 0.55,
+}
+
+const SAMPLE_HISTORY = [
+    // Buy 1000 XLM @ 0.40 (400 USDC)
+    { timestamp: '2025-01-01T00:00:00Z', details: { fromAsset: 'USDC', toAsset: 'XLM', amount: 400 } },
+    // Buy 1000 XLM @ 0.60 (600 USDC)
+    { timestamp: '2025-02-01T00:00:00Z', details: { fromAsset: 'USDC', toAsset: 'XLM', amount: 600 } },
+    // Buy 1000 XLM @ 0.50 (500 USDC)
+    { timestamp: '2025-03-01T00:00:00Z', details: { fromAsset: 'USDC', toAsset: 'XLM', amount: 500 } },
+    // Sell 1000 XLM @ 0.55 → 550 USDC proceeds
+    { timestamp: '2025-06-01T00:00:00Z', details: { fromAsset: 'XLM', toAsset: 'USDC', amount: 1000 } },
+]
+
+/** Realized gain on the XLM disposals only (the USDC sells have zero-basis noise). */
+function xlmRealizedGain(body: any): number {
+    return body.data.disposals
+        .filter((d: any) => d.asset === 'XLM')
+        .reduce((sum: number, d: any) => sum + d.realizedGainLoss, 0)
+}
+
 describe('GET /api/portfolio/tax-report', () => {
     beforeEach(() => {
         mockedGetHistory.mockReset()
         mockedGetSnapshot.mockReset()
+        mockedGetSnapshotAsOf.mockReset()
         mockedGetSnapshot.mockImplementation((asset: string) => ({
             asset,
             price: asset === 'XLM' ? 0.5 : asset === 'USDC' ? 1.0 : 0,
+            capturedAt: '2025-01-01T00:00:00Z',
         }))
+        mockedGetSnapshotAsOf.mockImplementation((asset: string, asOf: string) => {
+            if (asset === 'USDC') return { price: 1.0, capturedAt: asOf }
+            if (asset === 'XLM' && XLM_PRICES_BY_DATE[asOf] !== undefined) {
+                return { price: XLM_PRICES_BY_DATE[asOf], capturedAt: asOf }
+            }
+            return undefined
+        })
     })
 
     it('returns a FIFO tax report summary for the requested year', async () => {
@@ -113,6 +161,7 @@ describe('GET /api/portfolio/tax-report', () => {
         expect(res.status).toBe(200)
         expect(res.body.success).toBe(true)
         expect(res.body.data.taxYear).toBe(2025)
+        expect(res.body.data.costBasisMethod).toBe('fifo')
         expect(res.body.data.totalTrades).toBe(2)
         expect(res.body.data.entries.length).toBe(2)
         expect(res.body.data.entries[0]).toMatchObject({ type: 'sell', asset: 'XLM' })
@@ -160,5 +209,174 @@ describe('GET /api/portfolio/tax-report', () => {
 
         expect(res.status).toBe(400)
         expect(res.body.success).toBe(false)
+    })
+
+    describe('cost-basis method selection', () => {
+        beforeEach(() => {
+            mockedGetHistory.mockReturnValue([...SAMPLE_HISTORY])
+        })
+
+        it('defaults to FIFO when costBasisMethod is omitted', async () => {
+            const explicit = await request(makeApp()).get(
+                '/api/portfolio/tax-report?year=2025&costBasisMethod=fifo',
+            )
+            const implicit = await request(makeApp()).get('/api/portfolio/tax-report?year=2025')
+
+            expect(implicit.status).toBe(200)
+            expect(implicit.body.data.costBasisMethod).toBe('fifo')
+            expect(implicit.body.data.totalRealizedGainLoss).toBeCloseTo(
+                explicit.body.data.totalRealizedGainLoss,
+                6,
+            )
+        })
+
+        it('matches the oldest lot under FIFO', async () => {
+            const res = await request(makeApp()).get(
+                '/api/portfolio/tax-report?year=2025&costBasisMethod=fifo',
+            )
+
+            expect(res.status).toBe(200)
+            const xlmDisposals = res.body.data.disposals.filter((d: any) => d.asset === 'XLM')
+            expect(xlmDisposals).toHaveLength(1)
+            expect(xlmDisposals[0].acquiredDate).toBe('2025-01-01T00:00:00Z')
+            // proceeds 1000 × 0.55 = 550, basis 1000 × 0.40 = 400 → +150
+            expect(xlmRealizedGain(res.body)).toBeCloseTo(150, 6)
+        })
+
+        it('matches the newest lot under LIFO', async () => {
+            const res = await request(makeApp()).get(
+                '/api/portfolio/tax-report?year=2025&costBasisMethod=lifo',
+            )
+
+            expect(res.status).toBe(200)
+            expect(res.body.data.costBasisMethod).toBe('lifo')
+            expect(res.body.data.methodology).toContain('LIFO')
+            const xlmDisposals = res.body.data.disposals.filter((d: any) => d.asset === 'XLM')
+            expect(xlmDisposals[0].acquiredDate).toBe('2025-03-01T00:00:00Z')
+            // basis 1000 × 0.50 = 500 → +50
+            expect(xlmRealizedGain(res.body)).toBeCloseTo(50, 6)
+        })
+
+        it('matches the highest-cost lot under HIFO', async () => {
+            const res = await request(makeApp()).get(
+                '/api/portfolio/tax-report?year=2025&costBasisMethod=hifo',
+            )
+
+            expect(res.status).toBe(200)
+            expect(res.body.data.costBasisMethod).toBe('hifo')
+            expect(res.body.data.methodology).toContain('HIFO')
+            const xlmDisposals = res.body.data.disposals.filter((d: any) => d.asset === 'XLM')
+            expect(xlmDisposals[0].acquiredDate).toBe('2025-02-01T00:00:00Z')
+            // basis 1000 × 0.60 = 600 → −50
+            expect(xlmRealizedGain(res.body)).toBeCloseTo(-50, 6)
+        })
+
+        it('produces three distinct gain figures across the same trade history', async () => {
+            const [fifo, lifo, hifo] = await Promise.all(
+                ['fifo', 'lifo', 'hifo'].map(m =>
+                    request(makeApp()).get(`/api/portfolio/tax-report?year=2025&costBasisMethod=${m}`),
+                ),
+            )
+
+            const gains = [fifo, lifo, hifo].map(r => xlmRealizedGain(r.body))
+            expect(new Set(gains).size).toBe(3)
+            // HIFO minimises gains, FIFO maximises them on a rising-then-falling basis set
+            expect(gains[0]).toBeGreaterThan(gains[1])
+            expect(gains[1]).toBeGreaterThan(gains[2])
+        })
+
+        it('is case-insensitive for the method name', async () => {
+            const res = await request(makeApp()).get(
+                '/api/portfolio/tax-report?year=2025&costBasisMethod=HIFO',
+            )
+
+            expect(res.status).toBe(200)
+            expect(res.body.data.costBasisMethod).toBe('hifo')
+        })
+
+        it('rejects an unknown cost-basis method', async () => {
+            const res = await request(makeApp()).get(
+                '/api/portfolio/tax-report?year=2025&costBasisMethod=average',
+            )
+
+            expect(res.status).toBe(400)
+            expect(res.body.success).toBe(false)
+            expect(res.body.error.message).toContain('costBasisMethod')
+        })
+
+        it('splits a sell across multiple lots when one lot is not enough', async () => {
+            mockedGetHistory.mockReturnValue([
+                ...SAMPLE_HISTORY.slice(0, 3),
+                {
+                    timestamp: '2025-06-01T00:00:00Z',
+                    details: { fromAsset: 'XLM', toAsset: 'USDC', amount: 1500 },
+                },
+            ])
+
+            const res = await request(makeApp()).get(
+                '/api/portfolio/tax-report?year=2025&costBasisMethod=fifo',
+            )
+
+            const xlmDisposals = res.body.data.disposals.filter((d: any) => d.asset === 'XLM')
+            expect(xlmDisposals).toHaveLength(2)
+            expect(xlmDisposals[0]).toMatchObject({ acquiredDate: '2025-01-01T00:00:00Z', amount: 1000 })
+            expect(xlmDisposals[1]).toMatchObject({ acquiredDate: '2025-02-01T00:00:00Z', amount: 500 })
+        })
+    })
+
+    describe('TurboTax CSV export', () => {
+        beforeEach(() => {
+            mockedGetHistory.mockReturnValue([...SAMPLE_HISTORY])
+        })
+
+        it('exports the documented TurboTax column schema', async () => {
+            const res = await request(makeApp()).get(
+                '/api/portfolio/tax-report?year=2025&format=turbotax',
+            )
+
+            expect(res.status).toBe(200)
+            expect(res.headers['content-type']).toContain('text/csv')
+            expect(res.headers['content-disposition']).toContain('turbotax-tax-report-2025-fifo.csv')
+
+            const [header] = res.text.split('\n')
+            expect(header).toBe('Currency Name,Purchase Date,Cost Basis,Date Sold,Proceeds')
+            expect(header.split(',')).toEqual([...TURBOTAX_HEADERS])
+        })
+
+        it('emits one row per disposed lot with MM/DD/YYYY dates and 2-decimal amounts', async () => {
+            const res = await request(makeApp()).get(
+                '/api/portfolio/tax-report?year=2025&format=turbotax&costBasisMethod=fifo',
+            )
+
+            const rows = res.text.split('\n').slice(1).filter(Boolean)
+            const xlmRow = rows.find(r => r.startsWith('XLM,'))
+
+            expect(xlmRow).toBeDefined()
+            // XLM lot acquired 01/01/2025 @ 0.40 (400.00) sold 06/01/2025 for 550.00
+            expect(xlmRow).toBe('XLM,01/01/2025,400.00,06/01/2025,550.00')
+            rows.forEach(row => expect(row.split(',')).toHaveLength(TURBOTAX_HEADERS.length))
+        })
+
+        it('honours the selected cost-basis method in the TurboTax export', async () => {
+            const res = await request(makeApp()).get(
+                '/api/portfolio/tax-report?year=2025&format=turbotax&costBasisMethod=hifo',
+            )
+
+            expect(res.headers['content-disposition']).toContain('turbotax-tax-report-2025-hifo.csv')
+            const xlmRow = res.text.split('\n').find(r => r.startsWith('XLM,'))
+            // HIFO consumes the 0.60 lot acquired 02/01/2025 (basis 600.00)
+            expect(xlmRow).toBe('XLM,02/01/2025,600.00,06/01/2025,550.00')
+        })
+
+        it('returns a header-only CSV when there are no disposals', async () => {
+            mockedGetHistory.mockReturnValue([])
+
+            const res = await request(makeApp()).get(
+                '/api/portfolio/tax-report?year=2025&format=turbotax',
+            )
+
+            expect(res.status).toBe(200)
+            expect(res.text).toBe(TURBOTAX_HEADERS.join(','))
+        })
     })
 })

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -190,6 +190,7 @@ Sentry DSNs are project-scoped and do not grant account access, but they can be 
 | `RATE_LIMIT_BURST_WINDOW_MS` | No | `10000` | Burst-protection window size (ms). | `10000` | |
 | `RATE_LIMIT_BURST_MAX` | No | `20` | Maximum requests in the burst window. | `20` | |
 | `RATE_LIMIT_WRITE_BURST_MAX` | No | `3` | Maximum write requests in the burst window. | `3` | |
+| `RATE_LIMIT_NEAR_LIMIT_RATIO` | No | `0.8` | Fraction of the limit at which an identifier is flagged `near-limit` on the admin rate-limit dashboard. | `0.8` | |
 | `API_RATE_LIMIT_WINDOW` | No | `900000` | Security-middleware rate-limit window (ms). | `900000` | |
 | `API_RATE_LIMIT_MAX_REQUESTS` | No | `100` | Security-middleware max requests per window. | `100` | |
 


### PR DESCRIPTION
## Summary

Implements four backend features in one PR. They share plumbing — the two tax-report
issues both hinge on lot-level disposal tracking, and the API-key and rate-limit work
both touch request-identity handling — so they're delivered together.

Closes #1410
Closes #1409
Closes #1407
Closes #1408

---

## #1410 — Cost-basis method selection (FIFO/LIFO/HIFO)

`backend/src/api/taxReport.routes.ts`

- Added a `costBasisMethod` query parameter accepting `fifo`, `lifo`, or `hifo`
  (case-insensitive). Unknown values return `400 VALIDATION_ERROR`.
- **Defaults to FIFO**, so callers that don't pass the parameter see byte-identical
  behaviour to before.
- Generalised the lot-matching loop behind `selectLotIndex()`:
  | Method | Lot consumed first |
  | --- | --- |
  | `fifo` | oldest acquisition |
  | `lifo` | newest acquisition |
  | `hifo` | highest unit cost (ties break toward the earlier lot, for determinism) |
- Sales spanning multiple lots split correctly across them; a sale with no remaining
  basis is still reported, with a cost basis of zero.

### Supporting change: date-aware pricing

`getPriceEstimate()` previously used only the *latest* price snapshot, which gave every
lot of an asset the same unit price — under which FIFO, LIFO and HIFO are mathematically
indistinguishable. Added `databaseService.getPriceSnapshotAsOf(asset, isoDate)` (most
recent snapshot at or before a timestamp) so each lot retains its acquisition-date price.
Falls back to the latest snapshot, then to the existing static table.

## #1409 — TurboTax-compatible CSV export

`backend/src/api/taxReport.routes.ts`

- Added `format=turbotax` to the export endpoint, emitting the documented TurboTax
  cryptocurrency import schema in exact column order:
  ```
  Currency Name,Purchase Date,Cost Basis,Date Sold,Proceeds
  XLM,01/01/2025,400.00,06/01/2025,550.00
  ```
- Dates are `MM/DD/YYYY` in UTC; amounts are plain 2-decimal numbers with no currency
  symbol or thousands separators; asset names containing a comma or quote are quoted
  per RFC 4180.
- The selected `costBasisMethod` applies to this export too and is reflected in the
  filename (`turbotax-tax-report-<year>-<method>.csv`).
- With no disposals the response is the header row alone, which TurboTax accepts as an
  empty import.

### Supporting change: lot-level disposals

TurboTax needs one row **per disposed lot**, each with its own acquisition date — a
granularity the previous `entries` array (one buy + one sell per rebalance) could not
express. Added a `disposals` array (`asset`, `acquiredDate`, `soldDate`, `amount`,
`costBasis`, `proceeds`, `realizedGainLoss`), also exposed in the JSON response.
`entries` is unchanged for backwards compatibility.

## #1407 — Scoped (read-only vs read-write) API keys

`backend/src/middleware/requireApiKey.ts`, `backend/src/api/apiKeys.routes.ts`

- Scope enforcement now lives in the **authentication middleware**, not in individual
  routes: a `read-only` key is rejected with `403 FORBIDDEN` on any mutating request
  (`POST`/`PUT`/`PATCH`/`DELETE`). A newly added write route is therefore covered by
  default rather than depending on a developer remembering to opt in.
- `requireReadWrite` is retained for routes that are logically mutating but use a read
  verb (e.g. `GET /portfolio/:id/rebalance`).
- `scope` on key creation now defaults to `read-only` instead of being required, so a
  caller omitting it can never accidentally mint a write-capable key.
- The scope is surfaced in every management response — creation, rotation, and the
  listing — alongside the key prefix and usage metadata. Key hashes are never returned.

### Bug fixed along the way

The rotation grace period was unreachable. The middleware ran:

```ts
if (!row || row.revoked) { /* 401 */ }
// grace-period check below — never reached for a revoked key
```

so a rotated key was rejected immediately and the documented grace window (default
5 minutes, intended for zero-downtime rotation) never applied. The revoked check now
consults `grace_expires_at` first.

## #1408 — Combined per-IP + per-API-key rate limit dashboard

`backend/src/services/rateLimitMonitor.ts`, `backend/src/api/assets.routes.ts`

- `rateLimitMonitor` previously tracked only throttle *events*; it now also tracks
  **current-window consumption** per IP and per API key. Every monitored request
  contributes to its IP bucket and, when API-key authenticated, to that key's bucket.
  Keys are identified by key id — the raw key never enters the monitor.
- New endpoint: `GET /api/v1/admin/rate-limits/dashboard` (admin-authenticated).

  | Param | Values | Default |
  | --- | --- | --- |
  | `type` | `ip`, `apiKey`, `all` | `all` |
  | `status` | `ok`, `near-limit`, `throttled`, `at-risk`, `all` | `all` |
  | `search` | substring on the identifier | — |
  | `page` | 1-based | `1` |
  | `pageSize` | 1–200 | `25` |

- Response carries `summary`, `attention`, `entries`, and `pagination`. **`attention`
  lists throttled and near-limit identifiers independently of the current page**, so
  problems stay visible however many keys or IPs are active. `entries` is ordered
  most-at-risk first (throttled, then by utilization descending).
- An identifier becomes `near-limit` at `RATE_LIMIT_NEAR_LIMIT_RATIO` (default `0.8`)
  of the limit, and `throttled` as soon as it takes a 429 in the current window.
- Bounded memory: records are dropped once their window elapses, with a 10k identifier
  cap that evicts the least-recently-seen half as a backstop against a scattered-IP
  flood.

---

## Testing

**62 new tests, all passing.**

| Suite | Tests | Covers |
| --- | --- | --- |
| `taxReport.routes.test.ts` | 17 | Cost-basis methods + TurboTax export |
| `apiKeyScope.test.ts` | 21 | Scope creation, enforcement, rotation, auth failures |
| `rateLimitDashboard.test.ts` | 24 | Aggregation, classification, filtering, pagination, endpoint |

Highlights:

- **Differing gains per method.** All three methods run against one shared trade
  history — XLM acquired in three lots at 0.40 / 0.60 / 0.50, then 1000 sold at 0.55 —
  and are asserted to produce three *distinct* figures: FIFO `+150`, LIFO `+50`,
  HIFO `−50`, with the expected ordering (HIFO minimises, FIFO maximises). Default and
  explicit-FIFO responses are asserted equal.
- **Scope enforcement across both scopes.** Parameterised over POST/PUT/PATCH/DELETE
  and GET: read-only keys are rejected on every mutating verb and accepted on reads;
  read-write keys are accepted throughout.
- **Aggregation correctness against seeded counters**, plus page-boundary checks
  (no overlap, no gaps) and out-of-range paging clamps.

`tsc --noEmit` is clean. The only errors it reports are pre-existing syntax errors in
`src/test/portfolios.routes.integration.test.ts`, untouched by this PR.

### Pre-existing failures, for reviewer awareness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scoped API keys with read-only and read-write permissions.
  * Added an admin rate-limit dashboard with filtering, status indicators, search, and pagination.
  * Added FIFO, LIFO, and HIFO tax-report calculations.
  * Added per-lot disposal details and TurboTax-compatible CSV exports.
* **Bug Fixes**
  * API-key rotation now honors the configured grace period.
  * Historical trade-date prices are preferred for tax calculations.
* **Documentation**
  * Documented API-key scopes, rate-limit monitoring, tax-report options, and related configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->