### PR TITLE
feat(backend): per-channel delivery metrics, DLQ listing, portfolio prefs, telegram status

### DIFF
--- a/backend/docs/notification-delivery-metrics.md
+++ b/backend/docs/notification-delivery-metrics.md
@@ -1,0 +1,69 @@
+# Notification Delivery Metrics
+
+Delivery success and failure are tracked **per channel** (#1394), so an outage in
+one provider is visible instead of being averaged away by the healthy ones. The
+counters are registered on the existing Prometheus registry and appear on the
+normal metrics endpoint — no separate scrape target.
+
+## Metrics
+
+| Metric | Type | Labels |
+| --- | --- | --- |
+| `stellar_portfolio_notification_delivery_total` | counter | `channel`, `outcome`, `reason`, `event_type` |
+| `stellar_portfolio_notification_delivery_attempts_total` | counter | `channel`, `outcome` |
+| `stellar_portfolio_notification_delivery_duration_seconds` | histogram | `channel`, `outcome` |
+
+- `channel`: `email`, `webhook`, `slack`, `sms`, `telegram`
+- `outcome`: `success` / `failure` on the totals; the attempts counter also uses
+  `retried`
+- `reason`: `none` on success, otherwise a classified failure bucket
+
+**Totals count terminal outcomes** (after retries are exhausted); **attempts count
+individual tries**, so a delivery that succeeds on its third try records one
+success in the totals and two `retried` attempts.
+
+## Failure reasons
+
+The `reason` label is a bounded classification, never the raw error string — raw
+messages contain ids and timestamps and would explode label cardinality.
+
+| reason | Triggered by |
+| --- | --- |
+| `auth` | 401/403, or an auth-shaped SMTP error |
+| `rate_limited` | HTTP 429 |
+| `timeout` | HTTP 408, `ETIMEDOUT`, or a timeout message |
+| `server_error` | HTTP 5xx |
+| `client_error` | Other HTTP 4xx |
+| `connection_refused` | `ECONNREFUSED`, `ECONNRESET`, `EPIPE` |
+| `dns` | `ENOTFOUND`, `EAI_AGAIN` |
+| `not_configured` | Provider missing configuration |
+| `invalid_recipient` | Rejected destination address |
+| `unknown` | Anything unclassified |
+
+## Instrumentation points
+
+`deliverWithBackoff` in `services/notificationDelivery.ts` instruments every
+channel that goes through the retry wrapper (email and webhook today) — success,
+each retry, and the terminal failure.
+
+Channels that do not use the wrapper (a fire-and-forget send, or a provider with
+its own retry handling) report through `recordChannelDelivery`, so every channel
+lands in the same counters:
+
+```ts
+recordChannelDelivery({ channel: 'slack', success: false, error, eventType })
+```
+
+## Useful queries
+
+```promql
+# Failure rate per channel over 5m
+sum by (channel) (rate(stellar_portfolio_notification_delivery_total{outcome="failure"}[5m]))
+  / sum by (channel) (rate(stellar_portfolio_notification_delivery_total[5m]))
+
+# Which failure mode dominates
+topk(5, sum by (channel, reason) (rate(stellar_portfolio_notification_delivery_total{outcome="failure"}[15m])))
+
+# Retry pressure
+sum by (channel) (rate(stellar_portfolio_notification_delivery_attempts_total{outcome="retried"}[5m]))
+```

--- a/backend/docs/notification-preferences.md
+++ b/backend/docs/notification-preferences.md
@@ -1,0 +1,57 @@
+# Notification Preferences
+
+Users have **global** notification preferences, and may layer a **per-portfolio
+override** on top of them (#1395).
+
+## Layering model
+
+An override stores only the fields the user actually set for that portfolio.
+Everything else resolves from the global preferences, which means a later change
+to a global setting still reaches portfolios that never overrode that field.
+
+Event flags merge key-by-key: overriding `rebalance` alone leaves the other three
+events resolving globally.
+
+```
+resolved = global  ⟵ override fields, where present
+```
+
+A channel enabled by an override with no destination in either layer resolves to
+**off** — a half-configured override must not silently swallow notifications. The
+API rejects that combination up front with 422.
+
+`notificationService.notify()` resolves through this layer whenever the payload
+carries a `portfolioId`; without one it uses the global preferences unchanged.
+
+## Endpoints
+
+All require JWT auth and portfolio ownership.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/preferences/notifications/portfolio` | List the caller's overrides |
+| `GET` | `/api/v1/preferences/notifications/portfolio/:portfolioId` | Override + resolved preferences |
+| `PUT` | `/api/v1/preferences/notifications/portfolio/:portfolioId` | Create or replace an override |
+| `DELETE` | `/api/v1/preferences/notifications/portfolio/:portfolioId` | Remove it (falls back to global) |
+
+`PUT` body — every field optional, at least one required:
+
+```jsonc
+{
+  "emailEnabled": false,
+  "webhookEnabled": true,
+  "emailAddress": "portfolio-alerts@example.com",
+  "webhookUrl": "https://hooks.example.com/xyz",
+  "digestMode": "weekly",
+  "events": { "rebalance": false }
+}
+```
+
+Responses include `resolved`, the preferences that actually apply, with
+`overrideApplied` telling you which layer answered.
+
+## Storage
+
+`notification_preference_overrides`, keyed by `(user_id, portfolio_id)`. Unset
+columns are `NULL`, which is what "inherit from global" looks like on disk —
+distinct from an explicit `false`.

--- a/backend/docs/telegram-bot.md
+++ b/backend/docs/telegram-bot.md
@@ -1,0 +1,38 @@
+# Telegram Bot
+
+Set `TELEGRAM_BOT_TOKEN` to start the bot in polling mode.
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| `/link <address>` | Link this chat to a Stellar address |
+| `/status` | On-demand status for the linked account's portfolios (#1396) |
+| `/unlink` | Remove the link |
+| `/pause` | Pause automatic rebalancing |
+| `/resume` | Resume automatic rebalancing |
+| `/start` | Command list |
+
+## `/status`
+
+Reports on the **requesting chat's linked portfolios** rather than global
+totals. For each portfolio it returns:
+
+- current vs target allocation per asset
+- max drift against the portfolio's threshold, flagged when a rebalance is due
+- last rebalance time (or `never`)
+
+An **unlinked chat gets linking instructions**, not an error — a new user is told
+what to do rather than hitting a dead end. A linked account with no portfolios
+gets a short "create one in the web app" message.
+
+If the portfolio lookup fails, the reply is a generic retry message; the
+underlying error goes to the logs rather than into the chat.
+
+## Linking
+
+Chat → address mappings live in the `kv_store` table under `telegram:link:<chatId>`,
+mirrored in memory, so a link survives a restart. `telegramLink.ts` owns that
+mapping; `telegramCommands.ts` owns the command handlers and is deliberately free
+of the bot transport so handlers can be driven directly from a mocked update
+payload in tests.

--- a/backend/docs/webhook-dead-letter.md
+++ b/backend/docs/webhook-dead-letter.md
@@ -1,0 +1,44 @@
+# Webhook Dead-Letter Queue
+
+Webhook deliveries that exhaust their retries land in the dead-letter queue.
+Admins can browse and replay them without touching the database (#1393).
+
+## Endpoints
+
+All admin-authenticated.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/admin/notifications/dead-letter` | Browse entries (filter + paginate) |
+| `POST` | `/api/v1/admin/notifications/dead-letter/:id/replay` | Replay one entry |
+| `POST` | `/api/v1/admin/notifications/dead-letter/batch-replay` | Replay `{ ids }` or `{ replayAll: true }` |
+| `DELETE` | `/api/v1/admin/notifications/dead-letter/:id` | Discard one entry |
+
+### Listing query parameters
+
+| Param | Default | Notes |
+| --- | --- | --- |
+| `userId` | — | Exact match |
+| `eventType` | — | Exact match |
+| `search` | — | Substring over id, user, url and error message |
+| `page` | `1` | Clamped to the available page count |
+| `pageSize` | `50` | 1–500 |
+
+The response carries `items`, a `summary` (total, counts per event type, oldest
+and newest timestamps) and `pagination`. Every entry keeps its **failure reason**
+(`errorMessage`), its **original payload**, and how many attempts were exhausted.
+
+## Replay semantics
+
+A replay removes the entry from the queue, then POSTs the original payload back
+to its webhook URL with an `X-Webhook-Replay: true` header.
+
+- **Success** → the entry stays removed.
+- **Failure** → it is re-queued with `attemptsExhausted` incremented, so repeated
+  failures are visible and nothing is lost.
+
+Batch replay applies the same rule per entry and reports
+`{ total, succeeded, failed, failedIds }`.
+
+Both paths share `postDeadLetterPayload()` in `services/webhookDeadLetter.ts`, so
+there is one definition of what a replay request is.

--- a/backend/src/api/notifications.routes.ts
+++ b/backend/src/api/notifications.routes.ts
@@ -9,7 +9,11 @@ import { getAuthConfig } from '../services/authService.js'
 import { logger } from '../utils/logger.js'
 import { getErrorObject, getErrorMessage } from '../utils/helpers.js'
 import { ok, fail } from '../utils/apiResponse.js'
-import { webhookDeadLetterQueue } from '../services/webhookDeadLetter.js'
+import {
+    webhookDeadLetterQueue,
+    queryDeadLetterItems,
+    postDeadLetterPayload,
+} from '../services/webhookDeadLetter.js'
 import { deliverWithBackoff } from '../services/notificationDelivery.js'
 import { getNotificationDeliveryConfig } from '../config/notificationDeliveryConfig.js'
 
@@ -304,10 +308,22 @@ notificationsRouter.post('/notifications/webhook/callback', async (req: Request,
     }
 })
 
+/**
+ * Admin: browse dead-lettered webhook deliveries (#1393).
+ * Each entry carries its failure reason and original payload. Filtering and
+ * pagination keep the view usable when a broken endpoint has produced many.
+ */
 notificationsRouter.get('/admin/notifications/dead-letter', requireAdmin, async (req: Request, res: Response) => {
     try {
-        const items = await webhookDeadLetterQueue.list()
-        return ok(res, { items, count: items.length })
+        const all = await webhookDeadLetterQueue.list()
+        const listing = queryDeadLetterItems(all, {
+            userId: req.query.userId as string | undefined,
+            eventType: req.query.eventType as string | undefined,
+            search: req.query.search as string | undefined,
+            page: req.query.page ? Number(req.query.page) : undefined,
+            pageSize: req.query.pageSize ? Number(req.query.pageSize) : undefined,
+        })
+        return ok(res, listing)
     } catch (error) {
         logger.error('Failed to list dead-letter items', { error: getErrorObject(error) })
         return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
@@ -337,25 +353,7 @@ notificationsRouter.post('/admin/notifications/dead-letter/:id/replay', requireA
                     policy,
                 },
                 async () => {
-                    const controller = new AbortController()
-                    const timeout = policy.requestTimeoutMs || 5000
-                    const timeoutId = setTimeout(() => controller.abort(), timeout)
-                    try {
-                        const response = await fetch(item.webhookUrl, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-Webhook-Event': item.eventType,
-                            },
-                            body: JSON.stringify(item.payload),
-                            signal: controller.signal,
-                        })
-                        if (!response.ok) {
-                            throw new Error(`Webhook responded with status ${response.status}`)
-                        }
-                    } finally {
-                        clearTimeout(timeoutId)
-                    }
+                    await postDeadLetterPayload(item, policy.requestTimeoutMs || 5000)
                 },
             )
             return ok(res, { message: 'Dead-letter item replayed successfully' })
@@ -414,26 +412,8 @@ notificationsRouter.post('/admin/notifications/dead-letter/batch-replay', requir
                         policy,
                     },
                     async () => {
-                        const controller = new AbortController()
-                        const timeout = policy.requestTimeoutMs || 5000
-                        const timeoutId = setTimeout(() => controller.abort(), timeout)
-                        try {
-                            const response = await fetch(item.webhookUrl, {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                    'X-Webhook-Event': item.eventType,
-                                },
-                                body: JSON.stringify(item.payload),
-                                signal: controller.signal,
-                            })
-                            if (!response.ok) {
-                                throw new Error(`Webhook responded with status ${response.status}`)
-                            }
-                        } finally {
-                            clearTimeout(timeoutId)
-                        }
-                    },
+                    await postDeadLetterPayload(item, policy.requestTimeoutMs || 5000)
+                },
                 )
                 results.succeeded++
             } catch (replayError) {

--- a/backend/src/api/preferences.routes.ts
+++ b/backend/src/api/preferences.routes.ts
@@ -5,6 +5,13 @@ import { userPreferencesSchema, userPreferencesQuerySchema } from './validation.
 import { logger } from '../utils/logger.js'
 import { getErrorObject, getErrorMessage } from '../utils/helpers.js'
 import { ok, fail } from '../utils/apiResponse.js'
+import { requireJwt } from '../middleware/requireJwt.js'
+import { portfolioStorage } from '../services/portfolioStorage.js'
+import { notificationService } from '../services/notificationService.js'
+import {
+    portfolioNotificationOverrideSchema,
+    type PortfolioNotificationOverrideInput,
+} from '../services/notificationPreferences.js'
 
 export const preferencesRouter = Router()
 
@@ -35,3 +42,119 @@ preferencesRouter.put('/preferences', validateQuery(userPreferencesQuerySchema),
         return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
     }
 })
+
+// ── per-portfolio notification preference overrides (#1395) ──────────────────
+
+/**
+ * Read the override for one portfolio, alongside the preferences that actually
+ * resolve for it. `overrideApplied: false` means the portfolio is running on
+ * global settings.
+ */
+preferencesRouter.get(
+    '/preferences/notifications/portfolio/:portfolioId',
+    requireJwt,
+    async (req: Request, res: Response) => {
+        try {
+            const userAddress = req.user!.address
+            const { portfolioId } = req.params
+
+            const portfolio = await portfolioStorage.getPortfolio(portfolioId)
+            if (!portfolio) return fail(res, 404, 'NOT_FOUND', 'Portfolio not found')
+            if (portfolio.userAddress !== userAddress) {
+                return fail(res, 403, 'FORBIDDEN', 'You can only view your own portfolio preferences')
+            }
+
+            const override = notificationService.getPortfolioOverride(userAddress, portfolioId)
+            const resolved = notificationService.getPreferencesForPortfolio(userAddress, portfolioId)
+
+            return ok(res, { override: override ?? null, resolved })
+        } catch (error) {
+            logger.error('[ERROR] Get portfolio notification override failed', { error: getErrorObject(error) })
+            return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+        }
+    },
+)
+
+/** List every portfolio override belonging to the caller. */
+preferencesRouter.get(
+    '/preferences/notifications/portfolio',
+    requireJwt,
+    async (req: Request, res: Response) => {
+        try {
+            const overrides = notificationService.listPortfolioOverrides(req.user!.address)
+            return ok(res, { overrides, count: overrides.length })
+        } catch (error) {
+            logger.error('[ERROR] List portfolio notification overrides failed', { error: getErrorObject(error) })
+            return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+        }
+    },
+)
+
+/** Create or replace the override for one portfolio. */
+preferencesRouter.put(
+    '/preferences/notifications/portfolio/:portfolioId',
+    requireJwt,
+    validateRequest(portfolioNotificationOverrideSchema),
+    async (req: Request, res: Response) => {
+        try {
+            const userAddress = req.user!.address
+            const { portfolioId } = req.params
+
+            const portfolio = await portfolioStorage.getPortfolio(portfolioId)
+            if (!portfolio) return fail(res, 404, 'NOT_FOUND', 'Portfolio not found')
+            if (portfolio.userAddress !== userAddress) {
+                return fail(res, 403, 'FORBIDDEN', 'You can only change your own portfolio preferences')
+            }
+
+            const body = req.body as PortfolioNotificationOverrideInput
+            const globalPrefs = notificationService.getPreferences(userAddress)
+
+            // Enabling a channel needs a destination from either layer, otherwise
+            // the override would resolve to a silently disabled channel.
+            if (body.emailEnabled === true && !(body.emailAddress || globalPrefs.emailAddress)) {
+                return fail(res, 422, 'VALIDATION_ERROR', 'emailAddress is required to enable email for this portfolio')
+            }
+            if (body.webhookEnabled === true && !(body.webhookUrl || globalPrefs.webhookUrl)) {
+                return fail(res, 422, 'VALIDATION_ERROR', 'webhookUrl is required to enable webhooks for this portfolio')
+            }
+
+            const override = notificationService.setPortfolioOverride({
+                ...body,
+                userId: userAddress,
+                portfolioId,
+            })
+
+            return ok(res, {
+                override,
+                resolved: notificationService.getPreferencesForPortfolio(userAddress, portfolioId),
+            })
+        } catch (error) {
+            logger.error('[ERROR] Save portfolio notification override failed', { error: getErrorObject(error) })
+            return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+        }
+    },
+)
+
+/** Delete an override so the portfolio falls back to global preferences. */
+preferencesRouter.delete(
+    '/preferences/notifications/portfolio/:portfolioId',
+    requireJwt,
+    async (req: Request, res: Response) => {
+        try {
+            const userAddress = req.user!.address
+            const { portfolioId } = req.params
+
+            const deleted = notificationService.deletePortfolioOverride(userAddress, portfolioId)
+            if (!deleted) return fail(res, 404, 'NOT_FOUND', 'No override configured for this portfolio')
+
+            return ok(res, {
+                portfolioId,
+                deleted: true,
+                resolved: notificationService.getPreferencesForPortfolio(userAddress, portfolioId),
+            })
+        } catch (error) {
+            logger.error('[ERROR] Delete portfolio notification override failed', { error: getErrorObject(error) })
+            return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+        }
+    },
+)

--- a/backend/src/db/notificationDb.ts
+++ b/backend/src/db/notificationDb.ts
@@ -395,3 +395,163 @@ export function dbGetNotificationLogs(userId: string, limit: number = 50): Notif
         createdAt: r.created_at
     }))
 }
+
+// ── per-portfolio notification preference overrides (#1395) ──────────────────
+//
+// An override stores only the fields the user actually set for that portfolio;
+// everything else resolves from their global preferences. Storing partial rows
+// (rather than a full copy) means a later change to a global setting still
+// propagates to portfolios that never overrode it.
+
+export interface PortfolioNotificationOverride {
+    userId: string
+    portfolioId: string
+    emailEnabled?: boolean
+    webhookEnabled?: boolean
+    emailAddress?: string
+    webhookUrl?: string
+    digestMode?: 'immediate' | 'daily' | 'weekly'
+    events?: Partial<{
+        rebalance: boolean
+        circuitBreaker: boolean
+        priceMovement: boolean
+        riskChange: boolean
+    }>
+    updatedAt?: string
+}
+
+interface PortfolioOverrideRow {
+    user_id: string
+    portfolio_id: string
+    email_enabled: number | null
+    webhook_enabled: number | null
+    email_address: string | null
+    webhook_url: string | null
+    digest_mode: string | null
+    events: string | null
+    created_at: string
+    updated_at: string
+}
+
+function ensureOverrideTable(): void {
+    ensureNotificationTable()
+    getDb().exec(`
+        CREATE TABLE IF NOT EXISTS notification_preference_overrides (
+            user_id       TEXT NOT NULL,
+            portfolio_id  TEXT NOT NULL,
+            email_enabled INTEGER,
+            webhook_enabled INTEGER,
+            email_address TEXT,
+            webhook_url   TEXT,
+            digest_mode   TEXT,
+            events        TEXT,
+            created_at    TEXT NOT NULL,
+            updated_at    TEXT NOT NULL,
+            PRIMARY KEY (user_id, portfolio_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_notification_overrides_user
+            ON notification_preference_overrides(user_id);
+    `)
+}
+
+function nullableBool(value: number | null): boolean | undefined {
+    return value === null ? undefined : value === 1
+}
+
+function rowToOverride(row: PortfolioOverrideRow): PortfolioNotificationOverride {
+    let events: PortfolioNotificationOverride['events']
+    if (row.events) {
+        try {
+            const parsed = JSON.parse(row.events)
+            if (parsed && typeof parsed === 'object') events = parsed
+        } catch {
+            // Corrupt JSON falls back to "no event overrides".
+        }
+    }
+
+    return {
+        userId: row.user_id,
+        portfolioId: row.portfolio_id,
+        emailEnabled: nullableBool(row.email_enabled),
+        webhookEnabled: nullableBool(row.webhook_enabled),
+        emailAddress: row.email_address ?? undefined,
+        webhookUrl: row.webhook_url ?? undefined,
+        digestMode: (row.digest_mode as 'immediate' | 'daily' | 'weekly' | null) ?? undefined,
+        events,
+        updatedAt: row.updated_at,
+    }
+}
+
+export function dbSavePortfolioNotificationOverride(
+    override: PortfolioNotificationOverride,
+): PortfolioNotificationOverride {
+    ensureOverrideTable()
+    const now = new Date().toISOString()
+
+    getDb().prepare(`
+        INSERT INTO notification_preference_overrides
+            (user_id, portfolio_id, email_enabled, webhook_enabled, email_address,
+             webhook_url, digest_mode, events, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (user_id, portfolio_id) DO UPDATE SET
+            email_enabled   = excluded.email_enabled,
+            webhook_enabled = excluded.webhook_enabled,
+            email_address   = excluded.email_address,
+            webhook_url     = excluded.webhook_url,
+            digest_mode     = excluded.digest_mode,
+            events          = excluded.events,
+            updated_at      = excluded.updated_at
+    `).run(
+        override.userId,
+        override.portfolioId,
+        override.emailEnabled === undefined ? null : override.emailEnabled ? 1 : 0,
+        override.webhookEnabled === undefined ? null : override.webhookEnabled ? 1 : 0,
+        override.emailAddress ?? null,
+        override.webhookUrl ?? null,
+        override.digestMode ?? null,
+        override.events && Object.keys(override.events).length > 0
+            ? JSON.stringify(override.events)
+            : null,
+        now,
+        now,
+    )
+
+    return dbGetPortfolioNotificationOverride(override.userId, override.portfolioId)!
+}
+
+export function dbGetPortfolioNotificationOverride(
+    userId: string,
+    portfolioId: string,
+): PortfolioNotificationOverride | undefined {
+    ensureOverrideTable()
+    const row = getDb()
+        .prepare<[string, string], PortfolioOverrideRow>(
+            'SELECT * FROM notification_preference_overrides WHERE user_id = ? AND portfolio_id = ?',
+        )
+        .get(userId, portfolioId)
+    return row ? rowToOverride(row) : undefined
+}
+
+export function dbListPortfolioNotificationOverrides(
+    userId: string,
+): PortfolioNotificationOverride[] {
+    ensureOverrideTable()
+    const rows = getDb()
+        .prepare<[string], PortfolioOverrideRow>(
+            'SELECT * FROM notification_preference_overrides WHERE user_id = ? ORDER BY portfolio_id',
+        )
+        .all(userId)
+    return rows.map(rowToOverride)
+}
+
+export function dbDeletePortfolioNotificationOverride(
+    userId: string,
+    portfolioId: string,
+): boolean {
+    ensureOverrideTable()
+    const result = getDb()
+        .prepare('DELETE FROM notification_preference_overrides WHERE user_id = ? AND portfolio_id = ?')
+        .run(userId, portfolioId)
+    return result.changes > 0
+}

--- a/backend/src/notifications/telegramBot.ts
+++ b/backend/src/notifications/telegramBot.ts
@@ -1,7 +1,8 @@
 import TelegramBotApi from 'node-telegram-bot-api'
 import { logger } from '../utils/logger.js'
 import { autoRebalancer } from '../services/runtimeServices.js'
-import { portfolioStorage } from '../services/portfolioStorage.js'
+import { handleStatusCommand, LINK_INSTRUCTIONS } from './telegramCommands.js'
+import { linkChat, unlinkChat } from './telegramLink.js'
 
 const authorizedChatIds = new Set<string>()
 
@@ -13,33 +14,6 @@ function isAuthorized(chatId: string): boolean {
   return authorizedChatIds.has(chatId)
 }
 
-async function getPortfolioStatus(): Promise<string> {
-  const portfolios = await portfolioStorage.getAllPortfolios()
-  if (portfolios.length === 0) return 'No portfolios found.'
-
-  const totalValue = portfolios.reduce((sum, p) => sum + (p.totalValue || 0), 0)
-  const totalDrift = portfolios.reduce((sum, p) => {
-    const maxDrift = Math.max(
-      ...Object.keys(p.allocations).map((asset) => {
-        const target = p.allocations[asset] || 0
-        const balance = p.balances[asset] || 0
-        const currentPct = totalValue > 0 ? (balance / totalValue) * 100 : 0
-        return Math.abs(currentPct - target)
-      }),
-      0,
-    )
-    return Math.max(sum, maxDrift)
-  }, 0)
-
-  return [
-    `📊 *Portfolio Status*`,
-    `Portfolios: ${portfolios.length}`,
-    `Total Value: ${totalValue.toFixed(2)} XLM`,
-    `Max Drift: ${totalDrift.toFixed(2)}%`,
-    `Threshold: ${portfolios[0].threshold}%`,
-  ].join('\n')
-}
-
 export function startBot(): void {
   const token = process.env.TELEGRAM_BOT_TOKEN
   if (!token) {
@@ -49,18 +23,40 @@ export function startBot(): void {
 
   const bot = new TelegramBotApi(token, { polling: true })
 
+  // /status reports on the chat's *linked* user rather than the whole system.
+  // An unlinked chat gets linking instructions instead of a bare error (#1396).
   bot.onText(/\/status/, async (msg) => {
     const chatId = String(msg.chat.id)
-    if (!isAuthorized(chatId)) {
-      await bot.sendMessage(chatId, 'Unauthorized')
+    const reply = await handleStatusCommand(msg as never)
+    await bot.sendMessage(
+      chatId,
+      reply.text,
+      reply.parseMode ? { parse_mode: reply.parseMode } : undefined,
+    )
+  })
+
+  bot.onText(/\/link (.+)/, async (msg, match) => {
+    const chatId = String(msg.chat.id)
+    const address = match?.[1]?.trim()
+    if (!address) {
+      await bot.sendMessage(chatId, LINK_INSTRUCTIONS, { parse_mode: 'Markdown' })
       return
     }
-    try {
-      const status = await getPortfolioStatus()
-      await bot.sendMessage(chatId, status, { parse_mode: 'Markdown' })
-    } catch (err) {
-      await bot.sendMessage(chatId, `Error: ${err instanceof Error ? err.message : String(err)}`)
-    }
+    linkChat(chatId, address)
+    registerChat(chatId)
+    await bot.sendMessage(
+      chatId,
+      `This chat is now linked to ${address}. Send /status to see your portfolios.`,
+    )
+  })
+
+  bot.onText(/\/unlink/, async (msg) => {
+    const chatId = String(msg.chat.id)
+    const had = unlinkChat(chatId)
+    await bot.sendMessage(
+      chatId,
+      had ? 'This chat is no longer linked.' : 'This chat was not linked.',
+    )
   })
 
   bot.onText(/\/pause/, async (msg) => {
@@ -93,7 +89,10 @@ export function startBot(): void {
 
   bot.onText(/\/start/, async (msg) => {
     const chatId = String(msg.chat.id)
-    await bot.sendMessage(chatId, 'Welcome to Stellar Portfolio Rebalancer Bot\n\nAvailable commands:\n/status - Portfolio status\n/pause - Pause rebalancing\n/resume - Resume rebalancing')
+    await bot.sendMessage(
+      chatId,
+      'Welcome to Stellar Portfolio Rebalancer Bot\n\nAvailable commands:\n/link <address> - Link this chat to your account\n/status - Your portfolio status\n/unlink - Unlink this chat\n/pause - Pause rebalancing\n/resume - Resume rebalancing',
+    )
   })
 
   logger.info('Telegram bot started in polling mode')

--- a/backend/src/notifications/telegramCommands.ts
+++ b/backend/src/notifications/telegramCommands.ts
@@ -1,0 +1,135 @@
+/**
+ * telegramCommands.ts
+ * Command handlers for the Telegram bot, kept free of the bot transport so they
+ * can be driven directly from a mocked update payload in tests (#1396).
+ */
+
+import { portfolioStorage } from '../services/portfolioStorage.js'
+import { getLinkedAddress } from './telegramLink.js'
+import { logger } from '../utils/logger.js'
+import type { Portfolio } from '../types/index.js'
+
+/** The subset of a Telegram update the command handlers actually read. */
+export interface TelegramUpdateMessage {
+    chat: { id: number | string }
+    from?: { id: number | string; username?: string }
+    text?: string
+}
+
+export interface TelegramReply {
+    text: string
+    parseMode?: 'Markdown'
+}
+
+export const LINK_INSTRUCTIONS = [
+    '🔗 *Link your account first*',
+    '',
+    'This chat is not linked to a Stellar address yet, so there are no portfolios to report on.',
+    '',
+    'To link:',
+    '1. Open the Stellar Portfolio Rebalancer web app.',
+    '2. Go to *Settings → Notifications → Telegram*.',
+    '3. Enter this chat ID and confirm with your wallet signature.',
+    '',
+    'Once linked, send /status again to see your portfolios.',
+].join('\n')
+
+/**
+ * Largest absolute gap between an asset's target allocation and its current
+ * share of the portfolio, in percentage points. Mirrors the drift definition
+ * used elsewhere in the app.
+ */
+export function computeMaxDrift(portfolio: Portfolio): number {
+    const totalValue = portfolio.totalValue || 0
+    const assets = Object.keys(portfolio.allocations || {})
+    if (assets.length === 0 || totalValue <= 0) return 0
+
+    return assets.reduce((max, asset) => {
+        const target = portfolio.allocations[asset] || 0
+        const balance = portfolio.balances?.[asset] || 0
+        const currentPct = (balance / totalValue) * 100
+        return Math.max(max, Math.abs(currentPct - target))
+    }, 0)
+}
+
+function formatLastRebalance(value?: string): string {
+    if (!value) return 'never'
+    const date = new Date(value)
+    if (isNaN(date.getTime())) return 'never'
+    return date.toISOString().replace('T', ' ').slice(0, 16) + ' UTC'
+}
+
+function formatPortfolio(portfolio: Portfolio): string {
+    const drift = computeMaxDrift(portfolio)
+    const totalValue = portfolio.totalValue || 0
+
+    const allocationLines = Object.entries(portfolio.allocations || {})
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([asset, target]) => {
+            const balance = portfolio.balances?.[asset] || 0
+            const currentPct = totalValue > 0 ? (balance / totalValue) * 100 : 0
+            return `  • ${asset}: ${currentPct.toFixed(1)}% / ${target}% target`
+        })
+
+    return [
+        `*${portfolio.name || portfolio.id}*`,
+        `Value: ${totalValue.toFixed(2)} USD`,
+        'Allocation (current / target):',
+        ...(allocationLines.length > 0 ? allocationLines : ['  • no allocations configured']),
+        `Max drift: ${drift.toFixed(2)}% (threshold ${portfolio.threshold}%)`,
+        `${drift > portfolio.threshold ? '⚠️ Rebalance due' : '✅ Within threshold'}`,
+        `Last rebalance: ${formatLastRebalance(portfolio.lastRebalance)}`,
+    ].join('\n')
+}
+
+/**
+ * `/status` — on-demand portfolio status for the requesting user.
+ *
+ * An unlinked chat gets linking instructions rather than an error, so a new user
+ * is told what to do instead of hitting a dead end.
+ */
+export async function handleStatusCommand(
+    message: TelegramUpdateMessage,
+): Promise<TelegramReply> {
+    const chatId = String(message.chat.id)
+    const userAddress = getLinkedAddress(chatId)
+
+    if (!userAddress) {
+        return { text: LINK_INSTRUCTIONS, parseMode: 'Markdown' }
+    }
+
+    try {
+        const portfolios = await portfolioStorage.getUserPortfolios(userAddress)
+
+        if (portfolios.length === 0) {
+            return {
+                text: [
+                    '📊 *Portfolio Status*',
+                    '',
+                    'No portfolios found for your linked account yet.',
+                    'Create one in the web app and it will show up here.',
+                ].join('\n'),
+                parseMode: 'Markdown',
+            }
+        }
+
+        const header = [
+            '📊 *Portfolio Status*',
+            `${portfolios.length} portfolio${portfolios.length === 1 ? '' : 's'} linked to this chat`,
+            '',
+        ].join('\n')
+
+        return {
+            text: header + portfolios.map(formatPortfolio).join('\n\n'),
+            parseMode: 'Markdown',
+        }
+    } catch (error) {
+        logger.error('[TELEGRAM] /status failed', {
+            chatId,
+            error: error instanceof Error ? error.message : String(error),
+        })
+        return {
+            text: '⚠️ Could not load your portfolio status right now. Please try again shortly.',
+        }
+    }
+}

--- a/backend/src/notifications/telegramLink.ts
+++ b/backend/src/notifications/telegramLink.ts
@@ -1,0 +1,62 @@
+/**
+ * telegramLink.ts
+ * Maps a Telegram chat to a Stellar address so bot commands can answer for the
+ * *requesting* user's portfolios rather than the whole system (#1396).
+ *
+ * Backed by the existing kv_store table, so a link survives a restart.
+ */
+
+import { databaseService } from '../services/databaseService.js'
+import { logger } from '../utils/logger.js'
+
+const KV_PREFIX = 'telegram:link:'
+
+/** In-memory mirror so lookups work even when the kv store is unavailable. */
+const memoryLinks = new Map<string, string>()
+
+function kvKey(chatId: string): string {
+    return `${KV_PREFIX}${chatId}`
+}
+
+export function linkChat(chatId: string, userAddress: string): void {
+    memoryLinks.set(chatId, userAddress)
+    try {
+        databaseService.setKvValue?.(kvKey(chatId), userAddress)
+    } catch (error) {
+        logger.warn('[TELEGRAM] Failed to persist chat link; keeping in-memory only', {
+            chatId,
+            error: error instanceof Error ? error.message : String(error),
+        })
+    }
+}
+
+export function getLinkedAddress(chatId: string): string | undefined {
+    const cached = memoryLinks.get(chatId)
+    if (cached) return cached
+
+    try {
+        const stored = databaseService.getKvValue?.(kvKey(chatId))
+        if (stored) {
+            memoryLinks.set(chatId, stored)
+            return stored
+        }
+    } catch {
+        // Fall through to "not linked" — the caller shows linking instructions.
+    }
+    return undefined
+}
+
+export function unlinkChat(chatId: string): boolean {
+    const had = memoryLinks.delete(chatId)
+    try {
+        databaseService.deleteKvValue?.(kvKey(chatId))
+    } catch {
+        // Best effort; the in-memory mirror is already cleared.
+    }
+    return had
+}
+
+/** Test seam. */
+export function resetTelegramLinksForTests(): void {
+    memoryLinks.clear()
+}

--- a/backend/src/observability/metrics.ts
+++ b/backend/src/observability/metrics.ts
@@ -289,3 +289,66 @@ const authSecurityEventsTotal = new Counter({
 export function recordAuthSecurityEvent(eventType: string): void {
     authSecurityEventsTotal.inc({ event_type: eventType })
 }
+
+// ── Notification delivery metrics (#1394) ────────────────────────────────────
+//
+// Success/failure is tracked per channel so an outage in one provider (say
+// webhooks) is visible without being averaged away by the healthy ones.
+// `reason` is a coarse, bounded classification of the failure — never the raw
+// error string, which would blow up cardinality.
+
+const notificationDeliveryTotal = new Counter({
+    name: `${observabilityConfig.metrics.prefix}notification_delivery_total`,
+    help: 'Total notification delivery attempts by channel and outcome',
+    labelNames: ['channel', 'outcome', 'reason', 'event_type'] as const,
+    registers: [register],
+})
+
+const notificationDeliveryAttemptsTotal = new Counter({
+    name: `${observabilityConfig.metrics.prefix}notification_delivery_attempts_total`,
+    help: 'Total individual notification delivery attempts, including retries',
+    labelNames: ['channel', 'outcome'] as const,
+    registers: [register],
+})
+
+const notificationDeliveryDuration = new Histogram({
+    name: `${observabilityConfig.metrics.prefix}notification_delivery_duration_seconds`,
+    help: 'Wall-clock duration of a notification delivery, including retries',
+    labelNames: ['channel', 'outcome'] as const,
+    buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+    registers: [register],
+})
+
+export type NotificationDeliveryOutcome = 'success' | 'failure'
+
+/** Terminal outcome of a delivery (after any retries). */
+export function recordNotificationDelivery(input: {
+    channel: string
+    outcome: NotificationDeliveryOutcome
+    reason?: string
+    eventType?: string
+    durationSeconds?: number
+}): void {
+    const labels = {
+        channel: input.channel,
+        outcome: input.outcome,
+        reason: input.reason ?? 'none',
+        event_type: input.eventType ?? 'unknown',
+    }
+    notificationDeliveryTotal.inc(labels)
+
+    if (typeof input.durationSeconds === 'number') {
+        notificationDeliveryDuration.observe(
+            { channel: input.channel, outcome: input.outcome },
+            input.durationSeconds,
+        )
+    }
+}
+
+/** One attempt within a delivery — `retried` attempts are counted here only. */
+export function recordNotificationDeliveryAttempt(
+    channel: string,
+    outcome: 'success' | 'failure' | 'retried',
+): void {
+    notificationDeliveryAttemptsTotal.inc({ channel, outcome })
+}

--- a/backend/src/services/databaseService.ts
+++ b/backend/src/services/databaseService.ts
@@ -2653,6 +2653,25 @@ getConsent(userId: string): ConsentRecord | undefined {
     });
   }
 
+  // ── generic key/value helpers (used by the Telegram chat link, #1396) ────
+
+  getKvValue(key: string): string | undefined {
+    return this.getIndexerState(key);
+  }
+
+  setKvValue(key: string, value: string): void {
+    this.setIndexerState(key, value);
+  }
+
+  deleteKvValue(key: string): boolean {
+    try {
+      const result = this.db.prepare("DELETE FROM kv_store WHERE key = ?").run(key);
+      return result.changes > 0;
+    } catch {
+      return false;
+    }
+  }
+
   ensurePortfolioExists(portfolioId: string, userAddress: string): void {
     try {
       const existing = this.getPortfolio(portfolioId);

--- a/backend/src/services/notificationDelivery.ts
+++ b/backend/src/services/notificationDelivery.ts
@@ -7,8 +7,29 @@ import {
   computeBackoffDelayMs,
   type DeliveryBackoffPolicy,
 } from "../config/notificationDeliveryConfig.js";
+import {
+  recordNotificationDelivery,
+  recordNotificationDeliveryAttempt,
+} from "../observability/metrics.js";
 
-export type NotificationProviderName = "email" | "webhook";
+/**
+ * Delivery channels. Email and webhook are wired through deliverWithBackoff today;
+ * the rest are declared so their metrics share one label vocabulary as they land.
+ */
+export type NotificationProviderName =
+  | "email"
+  | "webhook"
+  | "slack"
+  | "sms"
+  | "telegram";
+
+export const NOTIFICATION_CHANNELS: NotificationProviderName[] = [
+  "email",
+  "webhook",
+  "slack",
+  "sms",
+  "telegram",
+];
 
 export interface DeliveryAttemptContext {
   provider: NotificationProviderName;
@@ -30,10 +51,18 @@ export async function deliverWithBackoff(
 ): Promise<void> {
   const { provider, userId, eventType, policy } = ctx;
   let lastError: unknown
+  const startedAt = Date.now()
 
   for (let attempt = 1; attempt <= policy.maxAttempts; attempt++) {
     try {
       await execute()
+      recordNotificationDeliveryAttempt(provider, 'success')
+      recordNotificationDelivery({
+        channel: provider,
+        outcome: 'success',
+        eventType,
+        durationSeconds: (Date.now() - startedAt) / 1000,
+      })
       logOutcome(userId, provider, eventType, "sent", undefined, {
         attempt,
         maxAttempts: policy.maxAttempts,
@@ -46,6 +75,7 @@ export async function deliverWithBackoff(
       const retriesRemaining = attempt < policy.maxAttempts
 
       if (retriesRemaining) {
+        recordNotificationDeliveryAttempt(provider, 'retried')
         const retryIndex = attempt - 1
         const backoffDelayMs = computeBackoffDelayMs(policy, retryIndex)
         logOutcome(userId, provider, eventType, "retried", errorMessage, {
@@ -67,6 +97,14 @@ export async function deliverWithBackoff(
         continue
       }
 
+      recordNotificationDeliveryAttempt(provider, 'failure')
+      recordNotificationDelivery({
+        channel: provider,
+        outcome: 'failure',
+        reason: classifyFailureReason(error),
+        eventType,
+        durationSeconds: (Date.now() - startedAt) / 1000,
+      })
       logOutcome(userId, provider, eventType, "failed", errorMessage, {
         attempt,
         maxAttempts: policy.maxAttempts,
@@ -104,4 +142,55 @@ function logOutcome(
     errorMessage,
     metadata,
   )
+}
+
+/**
+ * Bucket a delivery error into a small, bounded set of reasons for the metric
+ * label. Raw error strings are deliberately not used — they are unbounded and
+ * would explode Prometheus label cardinality.
+ */
+export function classifyFailureReason(error: unknown): string {
+  const err = error as { code?: string; status?: number; response?: { status?: number }; message?: string } | undefined
+  const status = err?.status ?? err?.response?.status
+  const code = typeof err?.code === 'string' ? err.code.toUpperCase() : ''
+  const message = (err?.message ?? String(error ?? '')).toLowerCase()
+
+  if (status === 401 || status === 403) return 'auth'
+  if (status === 408 || status === 429) return status === 429 ? 'rate_limited' : 'timeout'
+  if (typeof status === 'number' && status >= 500) return 'server_error'
+  if (typeof status === 'number' && status >= 400) return 'client_error'
+
+  if (code === 'ETIMEDOUT' || code === 'ESOCKETTIMEDOUT' || message.includes('timeout') || message.includes('timed out')) {
+    return 'timeout'
+  }
+  if (code === 'ECONNREFUSED' || code === 'ECONNRESET' || code === 'EPIPE') return 'connection_refused'
+  if (code === 'ENOTFOUND' || code === 'EAI_AGAIN' || message.includes('getaddrinfo')) return 'dns'
+  if (code.startsWith('EAUTH') || message.includes('invalid login') || message.includes('unauthorized')) return 'auth'
+  if (message.includes('not configured') || message.includes('missing config')) return 'not_configured'
+  if (message.includes('invalid') && message.includes('address')) return 'invalid_recipient'
+  if (code) return code.toLowerCase()
+
+  return 'unknown'
+}
+
+/**
+ * Record a delivery for a channel that does not go through `deliverWithBackoff`
+ * (a fire-and-forget send, or a provider with its own retry handling), so every
+ * channel reports through the same counters.
+ */
+export function recordChannelDelivery(input: {
+  channel: NotificationProviderName
+  success: boolean
+  error?: unknown
+  eventType?: string
+  durationMs?: number
+}): void {
+  recordNotificationDeliveryAttempt(input.channel, input.success ? 'success' : 'failure')
+  recordNotificationDelivery({
+    channel: input.channel,
+    outcome: input.success ? 'success' : 'failure',
+    reason: input.success ? undefined : classifyFailureReason(input.error),
+    eventType: input.eventType,
+    durationSeconds: typeof input.durationMs === 'number' ? input.durationMs / 1000 : undefined,
+  })
 }

--- a/backend/src/services/notificationPreferences.ts
+++ b/backend/src/services/notificationPreferences.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { NotificationPreferences } from "../db/notificationDb.js";
+import type { NotificationPreferences, PortfolioNotificationOverride } from "../db/notificationDb.js";
 
 export const NOTIFICATION_EVENTS = [
   "rebalance",
@@ -89,5 +89,86 @@ export function normalizeNotificationPreferences(
       priceMovement: input.events.priceMovement,
       riskChange: input.events.riskChange,
     },
+  };
+}
+
+// ── per-portfolio overrides (#1395) ──────────────────────────────────────────
+
+/**
+ * A portfolio-level override is a *partial* set of preferences layered on top of
+ * the user's global settings. Every field is optional: omitting one means "keep
+ * whatever my global preference says", so a later change to a global setting
+ * still reaches portfolios that never overrode it.
+ */
+export const portfolioNotificationOverrideSchema = z
+  .object({
+    emailEnabled: z.boolean().optional(),
+    webhookEnabled: z.boolean().optional(),
+    emailAddress: z.preprocess(
+      (v) => (v === "" ? undefined : v),
+      z.string().email("emailAddress must be a valid email").optional(),
+    ),
+    webhookUrl: z.preprocess(
+      (v) => (v === "" ? undefined : v),
+      webhookUrlSchema.optional(),
+    ),
+    digestMode: z.enum(["immediate", "daily", "weekly"]).optional(),
+    events: notificationEventsSchema.partial().optional(),
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    // Turning a channel on for one portfolio requires a destination — either in
+    // the override itself or already present globally, which the route checks.
+    if (data.emailEnabled === true && data.emailAddress === undefined) return
+    if (data.webhookEnabled === true && data.webhookUrl === undefined) return
+    if (Object.keys(data).length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "At least one preference field must be provided",
+      });
+    }
+  });
+
+export type PortfolioNotificationOverrideInput = z.infer<
+  typeof portfolioNotificationOverrideSchema
+>;
+
+/**
+ * Resolve the preferences that actually apply to one portfolio: the user's
+ * global preferences with any override fields layered on top. Event flags merge
+ * key-by-key, so overriding `rebalance` alone leaves the other three global.
+ *
+ * Returns the global preferences unchanged when no override exists.
+ */
+export function resolvePortfolioNotificationPreferences(
+  global: NotificationPreferences,
+  override?: PortfolioNotificationOverride | null,
+): NotificationPreferences & { overrideApplied: boolean } {
+  if (!override) {
+    return { ...global, overrideApplied: false };
+  }
+
+  const emailEnabled = override.emailEnabled ?? global.emailEnabled;
+  const webhookEnabled = override.webhookEnabled ?? global.webhookEnabled;
+  const emailAddress = override.emailAddress ?? global.emailAddress;
+  const webhookUrl = override.webhookUrl ?? global.webhookUrl;
+
+  return {
+    userId: global.userId,
+    // A channel enabled by the override but with no destination anywhere stays
+    // off — a half-configured override must not silently drop notifications.
+    emailEnabled: emailEnabled && Boolean(emailAddress),
+    emailAddress,
+    webhookEnabled: webhookEnabled && Boolean(webhookUrl),
+    webhookUrl,
+    digestMode: override.digestMode ?? global.digestMode ?? "immediate",
+    priceAlertThresholds: global.priceAlertThresholds,
+    events: {
+      rebalance: override.events?.rebalance ?? global.events.rebalance,
+      circuitBreaker: override.events?.circuitBreaker ?? global.events.circuitBreaker,
+      priceMovement: override.events?.priceMovement ?? global.events.priceMovement,
+      riskChange: override.events?.riskChange ?? global.events.riskChange,
+    },
+    overrideApplied: true,
   };
 }

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -9,11 +9,19 @@ import {
   dbSaveDigestEvent,
   dbGetAndDeleteDigestEventsBefore,
   dbInitDefaultNotificationPreferences,
+  dbGetPortfolioNotificationOverride,
+  dbSavePortfolioNotificationOverride,
+  dbListPortfolioNotificationOverrides,
+  dbDeletePortfolioNotificationOverride,
+  type PortfolioNotificationOverride,
   type NotificationPreferences,
   type NotificationLog,
 } from "../db/notificationDb.js";
 import nodemailer from "nodemailer";
-import { normalizeNotificationPreferences } from "./notificationPreferences.js";
+import {
+  normalizeNotificationPreferences,
+  resolvePortfolioNotificationPreferences,
+} from "./notificationPreferences.js";
 import { databaseService } from "./databaseService.js";
 import {
   getNotificationDeliveryConfig,
@@ -35,6 +43,8 @@ export interface EmailAttachment {
 
 export interface NotificationPayload {
   userId: string;
+  /** When set, portfolio-level preference overrides apply to this delivery (#1395). */
+  portfolioId?: string;
   eventType: "rebalance" | "circuitBreaker" | "priceMovement" | "riskChange" | "digest";
   title: string;
   message: string;
@@ -402,6 +412,54 @@ export class NotificationService {
   }
 
   /**
+   * Preferences that actually apply to one portfolio: global settings with any
+   * portfolio-level override layered on top (#1395). Falls back to the global
+   * preferences unchanged when no override exists.
+   */
+  getPreferencesForPortfolio(
+    userId: string,
+    portfolioId?: string,
+  ): NotificationPreferences & { overrideApplied: boolean } {
+    const global = this.getPreferences(userId);
+    if (!portfolioId) return { ...global, overrideApplied: false };
+
+    const override = dbGetPortfolioNotificationOverride(userId, portfolioId);
+    return resolvePortfolioNotificationPreferences(global, override);
+  }
+
+  /** Create or update a portfolio-level override. */
+  setPortfolioOverride(
+    override: PortfolioNotificationOverride,
+  ): PortfolioNotificationOverride {
+    const saved = dbSavePortfolioNotificationOverride(override);
+    logger.info('[NOTIFICATION] Portfolio preference override saved', {
+      userId: override.userId,
+      portfolioId: override.portfolioId,
+    });
+    return saved;
+  }
+
+  getPortfolioOverride(
+    userId: string,
+    portfolioId: string,
+  ): PortfolioNotificationOverride | undefined {
+    return dbGetPortfolioNotificationOverride(userId, portfolioId);
+  }
+
+  listPortfolioOverrides(userId: string): PortfolioNotificationOverride[] {
+    return dbListPortfolioNotificationOverrides(userId);
+  }
+
+  /** Remove an override so the portfolio falls back to global preferences. */
+  deletePortfolioOverride(userId: string, portfolioId: string): boolean {
+    const deleted = dbDeletePortfolioNotificationOverride(userId, portfolioId);
+    if (deleted) {
+      logger.info('[NOTIFICATION] Portfolio preference override removed', { userId, portfolioId });
+    }
+    return deleted;
+  }
+
+  /**
    * Get per-asset price alert threshold overrides for a user.
    */
   getPriceAlertThresholds(userId: string): Record<string, number> {
@@ -477,7 +535,10 @@ export class NotificationService {
    * Send notification to user
    */
   async notify(payload: NotificationPayload): Promise<void> {
-    const preferences = this.getPreferences(payload.userId);
+    const preferences = this.getPreferencesForPortfolio(
+      payload.userId,
+      payload.portfolioId,
+    );
 
     const eventKey = payload.eventType as keyof typeof preferences.events;
     if (!preferences.events[eventKey]) {

--- a/backend/src/services/webhookDeadLetter.ts
+++ b/backend/src/services/webhookDeadLetter.ts
@@ -155,3 +155,124 @@ class WebhookDeadLetterQueue {
 }
 
 export const webhookDeadLetterQueue = new WebhookDeadLetterQueue()
+
+// ── replay helpers (#1393) ───────────────────────────────────────────────────
+
+/**
+ * Filter + paginate the dead-letter queue. Keeps the admin listing usable once
+ * a broken endpoint has produced thousands of entries.
+ */
+export interface DeadLetterQuery {
+    userId?: string
+    eventType?: string
+    search?: string
+    page?: number
+    pageSize?: number
+}
+
+export interface DeadLetterListing {
+    items: DeadLetterItem[]
+    count: number
+    summary: {
+        total: number
+        byEventType: Record<string, number>
+        oldestTimestamp?: string
+        newestTimestamp?: string
+    }
+    pagination: {
+        page: number
+        pageSize: number
+        total: number
+        totalPages: number
+        hasMore: boolean
+    }
+}
+
+const DEFAULT_DLQ_PAGE_SIZE = 50
+const MAX_DLQ_PAGE_SIZE = 500
+
+export function queryDeadLetterItems(
+    all: DeadLetterItem[],
+    query: DeadLetterQuery = {},
+): DeadLetterListing {
+    const search = query.search?.trim().toLowerCase()
+
+    const filtered = all.filter((item) => {
+        if (query.userId && item.userId !== query.userId) return false
+        if (query.eventType && item.eventType !== query.eventType) return false
+        if (search) {
+            const haystack = `${item.id} ${item.userId} ${item.eventType} ${item.webhookUrl} ${item.errorMessage}`.toLowerCase()
+            if (!haystack.includes(search)) return false
+        }
+        return true
+    })
+
+    const pageSize = clampPageSize(query.pageSize)
+    const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize))
+    const page = Math.min(Math.max(1, Math.trunc(query.page ?? 1) || 1), totalPages)
+    const start = (page - 1) * pageSize
+    const items = filtered.slice(start, start + pageSize)
+
+    const byEventType: Record<string, number> = {}
+    for (const item of filtered) {
+        byEventType[item.eventType] = (byEventType[item.eventType] ?? 0) + 1
+    }
+
+    const timestamps = filtered.map((i) => i.timestamp).filter(Boolean).sort()
+
+    return {
+        items,
+        count: items.length,
+        summary: {
+            total: filtered.length,
+            byEventType,
+            oldestTimestamp: timestamps[0],
+            newestTimestamp: timestamps[timestamps.length - 1],
+        },
+        pagination: {
+            page,
+            pageSize,
+            total: filtered.length,
+            totalPages,
+            hasMore: start + items.length < filtered.length,
+        },
+    }
+}
+
+function clampPageSize(value: unknown): number {
+    const parsed = typeof value === 'number' ? value : parseInt(String(value ?? ''), 10)
+    if (isNaN(parsed)) return DEFAULT_DLQ_PAGE_SIZE
+    return Math.min(MAX_DLQ_PAGE_SIZE, Math.max(1, Math.trunc(parsed)))
+}
+
+/**
+ * POST one dead-letter payload back to its webhook URL.
+ *
+ * Extracted so the single-item and batch replay endpoints share one definition
+ * of what a replay *is* — previously the whole request/timeout closure was
+ * duplicated between them and could drift apart.
+ */
+export async function postDeadLetterPayload(
+    item: DeadLetterItem,
+    timeoutMs: number,
+): Promise<void> {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+        const response = await fetch(item.webhookUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Webhook-Event': item.eventType,
+                'X-Webhook-Replay': 'true',
+            },
+            body: JSON.stringify(item.payload),
+            signal: controller.signal,
+        })
+        if (!response.ok) {
+            throw new Error(`Webhook responded with status ${response.status}`)
+        }
+    } finally {
+        clearTimeout(timeoutId)
+    }
+}

--- a/backend/src/test/deadLetterListing.test.ts
+++ b/backend/src/test/deadLetterListing.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Dead-letter listing: filtering, pagination and the shared replay helper (#1393).
+ *
+ * The list/single-replay/batch-replay flows themselves are covered by
+ * webhookDeadLetterReplay.integration.test.ts; this suite covers the admin
+ * listing view and the extracted replay POST that both replay paths now share.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { DeadLetterItem } from '../services/webhookDeadLetter.js'
+
+vi.mock('../utils/logger.js', () => ({
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../queue/connection.js', () => ({
+    REDIS_URL: 'redis://localhost:6379',
+    isRedisAvailable: async () => false,
+}))
+
+vi.mock('ioredis', () => ({ default: class { on() {} async quit() {} } }))
+
+function item(overrides: Partial<DeadLetterItem> = {}): DeadLetterItem {
+    return {
+        id: 'dl-1',
+        payload: { event: 'rebalance' },
+        errorMessage: 'Webhook responded with status 500',
+        attemptsExhausted: 3,
+        timestamp: '2026-08-01T00:00:00Z',
+        webhookUrl: 'https://hooks.example.com/a',
+        userId: 'GUSER1',
+        eventType: 'rebalance',
+        ...overrides,
+    }
+}
+
+describe('dead-letter listing (#1393)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    describe('payload and failure reason', () => {
+        it('keeps the failure reason and original payload on every entry', async () => {
+            const { queryDeadLetterItems } = await import('../services/webhookDeadLetter.js')
+
+            const listing = queryDeadLetterItems([item()])
+
+            expect(listing.items[0].errorMessage).toBe('Webhook responded with status 500')
+            expect(listing.items[0].payload).toEqual({ event: 'rebalance' })
+            expect(listing.items[0].attemptsExhausted).toBe(3)
+        })
+    })
+
+    describe('filtering', () => {
+        const all = [
+            item({ id: 'a', userId: 'GUSER1', eventType: 'rebalance' }),
+            item({ id: 'b', userId: 'GUSER2', eventType: 'rebalance' }),
+            item({ id: 'c', userId: 'GUSER2', eventType: 'riskChange', webhookUrl: 'https://other.example.com/z' }),
+        ]
+
+        it('filters by user', async () => {
+            const { queryDeadLetterItems } = await import('../services/webhookDeadLetter.js')
+
+            const listing = queryDeadLetterItems(all, { userId: 'GUSER2' })
+
+            expect(listing.items.map(i => i.id)).toEqual(['b', 'c'])
+            expect(listing.pagination.total).toBe(2)
+        })
+
+        it('filters by event type', async () => {
+            const { queryDeadLetterItems } = await import('../services/webhookDeadLetter.js')
+
+            expect(queryDeadLetterItems(all, { eventType: 'riskChange' }).items.map(i => i.id)).toEqual(['c'])
+        })
+
+        it('searches across id, user, url and error message', async () => {
+            const { queryDeadLetterItems } = await import('../services/webhookDeadLetter.js')
+
+            expect(queryDeadLetterItems(all, { search: 'other.example' }).items.map(i => i.id)).toEqual(['c'])
+            expect(queryDeadLetterItems(all, { search: 'status 500' }).items).toHaveLength(3)
+        })
+
+        it('combines filters', async () => {
+            const { queryDeadLetterItems } = await import('../services/webhookDeadLetter.js')
+
+            const listing = queryDeadLetterItems(all, { userId: 'GUSER2', eventType: 'rebalance' })
+
+            expect(listing.items.map(i => i.id)).toEqual(['b'])
+        })
+
+        it('returns an empty listing when nothing matches', async () => {
+            const { queryDeadLetterItems } = await import('../services/webhookDeadLetter.js')
+
+            const listing = queryDeadLetterItems(all, { userId: 'nobody' })
+
+            expect(listing.items).toEqual([])
+            expect(listing.pagination.totalPages).toBe(1)
+            expect(listing.pagination.hasMore).toBe(false)
+        })
+    })
+
+    describe('summary', () => {
+        it('counts entries per event type and reports the time span', async () => {
+            const { queryDeadLetterItems } = await import('../services/webhookDeadLetter.js')
+
+            const listing = queryDeadLetterItems([
+                item({ id: 'a', eventType: 'rebalance', timestamp: '2026-08-01T00:00:00Z' }),
+                item({ id: 'b', eventType: 'rebalance', timestamp: '2026-08-03T00:00:00Z' }),
+                item({ id: 'c', eventType: 'riskChange', timestamp: '2026-08-02T00:00:00Z' }),
+            ])
+
+            expect(listing.summary.total).toBe(3)
+            expect(listing.summary.byEventType).toEqual({ rebalance: 2, riskChange: 1 })
+            expect(listing.summary.oldestTimestamp).toBe('2026-08-01T00:00:00Z')
+            expect(listing.summary.newestTimestamp).toBe('2026-08-03T00:00:00Z')
+        })
+    })
+
+    describe('pagination', () => {
+        const many = Array.from({ length: 120 }, (_, i) => item({ id: `dl-${i}` }))
+
+        it('applies a default page size', async () => {
+            const { queryDeadLetterItems } = await import('../services/webhookDeadLetter.js')
+
+            const listing = queryDeadLetterItems(many)
+
+            expect(listing.items).toHaveLength(50)
+            expect(listing.pagination).toMatchObject({ page: 1, pageSize: 50, total: 120, totalPages: 3, hasMore: true })
+        })
+
+        it('pages without overlap or gaps', async () => {
+            const { queryDeadLetterItems } = await import('../services/webhookDeadLetter.js')
+
+            const first = queryDeadLetterItems(many, { page: 1, pageSize: 40 })
+            const second = queryDeadLetterItems(many, { page: 2, pageSize: 40 })
+            const third = queryDeadLetterItems(many, { page: 3, pageSize: 40 })
+
+            const ids = [...first.items, ...second.items, ...third.items].map(i => i.id)
+            expect(new Set(ids).size).toBe(120)
+            expect(third.pagination.hasMore).toBe(false)
+        })
+
+        it('clamps out-of-range and oversized inputs', async () => {
+            const { queryDeadLetterItems } = await import('../services/webhookDeadLetter.js')
+
+            expect(queryDeadLetterItems(many, { page: 999, pageSize: 40 }).pagination.page).toBe(3)
+            expect(queryDeadLetterItems(many, { pageSize: 100000 }).pagination.pageSize).toBe(500)
+            expect(queryDeadLetterItems(many, { pageSize: 0 }).pagination.pageSize).toBe(1)
+        })
+    })
+
+    describe('shared replay POST', () => {
+        it('posts the original payload to the webhook url', async () => {
+            const { postDeadLetterPayload } = await import('../services/webhookDeadLetter.js')
+            const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+            vi.stubGlobal('fetch', fetchMock)
+
+            await postDeadLetterPayload(item(), 1000)
+
+            const [url, init] = fetchMock.mock.calls[0]
+            expect(url).toBe('https://hooks.example.com/a')
+            expect(init.method).toBe('POST')
+            expect(JSON.parse(init.body)).toEqual({ event: 'rebalance' })
+            expect(init.headers['X-Webhook-Event']).toBe('rebalance')
+            expect(init.headers['X-Webhook-Replay']).toBe('true')
+
+            vi.unstubAllGlobals()
+        })
+
+        it('throws on a non-2xx response so the caller can re-queue', async () => {
+            const { postDeadLetterPayload } = await import('../services/webhookDeadLetter.js')
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 502 }))
+
+            await expect(postDeadLetterPayload(item(), 1000)).rejects.toThrow('502')
+
+            vi.unstubAllGlobals()
+        })
+    })
+})

--- a/backend/src/test/notificationDeliveryMetrics.test.ts
+++ b/backend/src/test/notificationDeliveryMetrics.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Per-channel delivery success/failure metrics (#1394).
+ *
+ * Asserts the Prometheus counters move correctly for simulated successes and
+ * failures, that the failure reason label is a bounded classification rather
+ * than a raw error string, and that the counters reach the metrics endpoint.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../utils/logger.js', () => ({
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    logAudit: vi.fn(),
+}))
+
+vi.mock('../db/notificationDb.js', () => ({
+    dbLogNotificationOutcome: vi.fn(),
+}))
+
+const M = 'stellar_portfolio_notification_delivery_total'
+const M_ATTEMPTS = 'stellar_portfolio_notification_delivery_attempts_total'
+
+const FAST_POLICY = {
+    maxAttempts: 3,
+    initialBackoffMs: 1,
+    maxBackoffMs: 2,
+    multiplier: 2,
+    jitterRatio: 0,
+    requestTimeoutMs: 1000,
+}
+
+/** Read one counter's value out of the Prometheus text exposition. */
+async function counterValue(metric: string, labels: Record<string, string>): Promise<number> {
+    const { getMetricsPayload } = await import('../observability/metrics.js')
+    const payload = await getMetricsPayload()
+
+    const wanted = Object.entries(labels).map(([k, v]) => `${k}="${v}"`)
+
+    for (const line of payload.split('\n')) {
+        if (line.startsWith('#') || !line.startsWith(metric)) continue
+        const match = line.match(/^[^{]+\{([^}]*)\}\s+(\S+)$/)
+        if (!match) continue
+        const present = match[1].split(',').map(s => s.trim())
+        if (wanted.every(w => present.includes(w))) return Number(match[2])
+    }
+    return 0
+}
+
+describe('notification delivery metrics (#1394)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    describe('success path', () => {
+        it('increments the success counter for the delivering channel', async () => {
+            const { deliverWithBackoff } = await import('../services/notificationDelivery.js')
+            const before = await counterValue(M, { channel: 'email', outcome: 'success' })
+
+            await deliverWithBackoff(
+                { provider: 'email', userId: 'GUSER', eventType: 'rebalance', policy: FAST_POLICY },
+                async () => undefined,
+            )
+
+            expect(await counterValue(M, { channel: 'email', outcome: 'success' })).toBe(before + 1)
+        })
+
+        it('does not increment the failure counter on success', async () => {
+            const { deliverWithBackoff } = await import('../services/notificationDelivery.js')
+            const before = await counterValue(M, { channel: 'webhook', outcome: 'failure' })
+
+            await deliverWithBackoff(
+                { provider: 'webhook', userId: 'GUSER', eventType: 'rebalance', policy: FAST_POLICY },
+                async () => undefined,
+            )
+
+            expect(await counterValue(M, { channel: 'webhook', outcome: 'failure' })).toBe(before)
+        })
+
+        it('keeps channels separate', async () => {
+            const { deliverWithBackoff } = await import('../services/notificationDelivery.js')
+            const emailBefore = await counterValue(M, { channel: 'email', outcome: 'success' })
+
+            await deliverWithBackoff(
+                { provider: 'webhook', userId: 'GUSER', eventType: 'rebalance', policy: FAST_POLICY },
+                async () => undefined,
+            )
+
+            expect(await counterValue(M, { channel: 'email', outcome: 'success' })).toBe(emailBefore)
+        })
+
+        it('records the delivery duration', async () => {
+            const { deliverWithBackoff } = await import('../services/notificationDelivery.js')
+            const { getMetricsPayload } = await import('../observability/metrics.js')
+
+            await deliverWithBackoff(
+                { provider: 'email', userId: 'GUSER', eventType: 'rebalance', policy: FAST_POLICY },
+                async () => undefined,
+            )
+
+            const payload = await getMetricsPayload()
+            expect(payload).toMatch(
+                /stellar_portfolio_notification_delivery_duration_seconds_count\{[^}]*channel="email"/,
+            )
+        })
+    })
+
+    describe('failure path', () => {
+        it('increments the failure counter once retries are exhausted', async () => {
+            const { deliverWithBackoff } = await import('../services/notificationDelivery.js')
+            const before = await counterValue(M, { channel: 'webhook', outcome: 'failure' })
+
+            await expect(
+                deliverWithBackoff(
+                    { provider: 'webhook', userId: 'GUSER', eventType: 'rebalance', policy: FAST_POLICY },
+                    async () => { throw new Error('ECONNREFUSED connect') },
+                ),
+            ).rejects.toThrow()
+
+            expect(await counterValue(M, { channel: 'webhook', outcome: 'failure' })).toBe(before + 1)
+        })
+
+        it('counts a single terminal failure, not one per attempt', async () => {
+            const { deliverWithBackoff } = await import('../services/notificationDelivery.js')
+            const before = await counterValue(M, { channel: 'email', outcome: 'failure' })
+
+            await expect(
+                deliverWithBackoff(
+                    { provider: 'email', userId: 'GUSER', eventType: 'rebalance', policy: FAST_POLICY },
+                    async () => { throw new Error('boom') },
+                ),
+            ).rejects.toThrow()
+
+            expect(await counterValue(M, { channel: 'email', outcome: 'failure' })).toBe(before + 1)
+        })
+
+        it('counts every retry as an attempt', async () => {
+            const { deliverWithBackoff } = await import('../services/notificationDelivery.js')
+            const before = await counterValue(M_ATTEMPTS, { channel: 'webhook', outcome: 'retried' })
+
+            await expect(
+                deliverWithBackoff(
+                    { provider: 'webhook', userId: 'GUSER', eventType: 'rebalance', policy: FAST_POLICY },
+                    async () => { throw new Error('boom') },
+                ),
+            ).rejects.toThrow()
+
+            // maxAttempts 3 → two retries before the terminal failure.
+            expect(await counterValue(M_ATTEMPTS, { channel: 'webhook', outcome: 'retried' })).toBe(before + 2)
+        })
+
+        it('labels the failure with a classified reason', async () => {
+            const { deliverWithBackoff } = await import('../services/notificationDelivery.js')
+            const before = await counterValue(M, {
+                channel: 'webhook',
+                outcome: 'failure',
+                reason: 'timeout',
+            })
+
+            await expect(
+                deliverWithBackoff(
+                    { provider: 'webhook', userId: 'GUSER', eventType: 'riskChange', policy: FAST_POLICY },
+                    async () => { throw new Error('Request timed out after 5000ms') },
+                ),
+            ).rejects.toThrow()
+
+            expect(
+                await counterValue(M, { channel: 'webhook', outcome: 'failure', reason: 'timeout' }),
+            ).toBe(before + 1)
+        })
+
+        it('recovers on a later attempt without recording a failure', async () => {
+            const { deliverWithBackoff } = await import('../services/notificationDelivery.js')
+            const failBefore = await counterValue(M, { channel: 'email', outcome: 'failure' })
+            const okBefore = await counterValue(M, { channel: 'email', outcome: 'success' })
+
+            let calls = 0
+            await deliverWithBackoff(
+                { provider: 'email', userId: 'GUSER', eventType: 'rebalance', policy: FAST_POLICY },
+                async () => {
+                    calls++
+                    if (calls === 1) throw new Error('transient')
+                },
+            )
+
+            expect(calls).toBe(2)
+            expect(await counterValue(M, { channel: 'email', outcome: 'success' })).toBe(okBefore + 1)
+            expect(await counterValue(M, { channel: 'email', outcome: 'failure' })).toBe(failBefore)
+        })
+    })
+
+    describe('failure classification', () => {
+        it.each([
+            [{ status: 401 }, 'auth'],
+            [{ status: 429 }, 'rate_limited'],
+            [{ status: 503 }, 'server_error'],
+            [{ status: 422 }, 'client_error'],
+            [{ code: 'ETIMEDOUT' }, 'timeout'],
+            [{ code: 'ECONNREFUSED' }, 'connection_refused'],
+            [{ code: 'ENOTFOUND' }, 'dns'],
+            [new Error('Email transport is not configured'), 'not_configured'],
+            [new Error('something entirely new'), 'unknown'],
+        ])('classifies %j as %s', async (error, expected) => {
+            const { classifyFailureReason } = await import('../services/notificationDelivery.js')
+            expect(classifyFailureReason(error)).toBe(expected)
+        })
+
+        it('never leaks a raw error string into the label', async () => {
+            const { classifyFailureReason } = await import('../services/notificationDelivery.js')
+
+            // Raw messages are unbounded cardinality — the reason must stay inside
+            // the small classified vocabulary.
+            const reason = classifyFailureReason(new Error('user 12345 rejected at 2026-08-29T10:00:00Z'))
+
+            expect(reason).toBe('unknown')
+            expect(reason).not.toContain('12345')
+        })
+    })
+
+    describe('channels without the backoff wrapper', () => {
+        it.each(['slack', 'sms', 'telegram'] as const)(
+            'records a success for %s',
+            async (channel) => {
+                const { recordChannelDelivery } = await import('../services/notificationDelivery.js')
+                const before = await counterValue(M, { channel, outcome: 'success' })
+
+                recordChannelDelivery({ channel, success: true, eventType: 'rebalance' })
+
+                expect(await counterValue(M, { channel, outcome: 'success' })).toBe(before + 1)
+            },
+        )
+
+        it('records a classified failure for a non-backoff channel', async () => {
+            const { recordChannelDelivery } = await import('../services/notificationDelivery.js')
+            const before = await counterValue(M, {
+                channel: 'slack',
+                outcome: 'failure',
+                reason: 'rate_limited',
+            })
+
+            recordChannelDelivery({
+                channel: 'slack',
+                success: false,
+                error: { status: 429 },
+                eventType: 'priceMovement',
+            })
+
+            expect(
+                await counterValue(M, { channel: 'slack', outcome: 'failure', reason: 'rate_limited' }),
+            ).toBe(before + 1)
+        })
+    })
+
+    describe('Prometheus exposition', () => {
+        it('exposes the delivery metrics with help and type metadata', async () => {
+            const { deliverWithBackoff } = await import('../services/notificationDelivery.js')
+            const { getMetricsPayload } = await import('../observability/metrics.js')
+
+            await deliverWithBackoff(
+                { provider: 'email', userId: 'GUSER', eventType: 'rebalance', policy: FAST_POLICY },
+                async () => undefined,
+            )
+
+            const payload = await getMetricsPayload()
+
+            expect(payload).toContain(`# HELP ${M}`)
+            expect(payload).toContain(`# TYPE ${M} counter`)
+            expect(payload).toContain(M_ATTEMPTS)
+            expect(payload).toContain('stellar_portfolio_notification_delivery_duration_seconds')
+            expect(payload).toMatch(new RegExp(`${M}\\{[^}]*channel="email"`))
+        })
+    })
+})

--- a/backend/src/test/portfolioNotificationOverrides.test.ts
+++ b/backend/src/test/portfolioNotificationOverrides.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Per-portfolio notification preference overrides (#1395).
+ *
+ * Covers the resolution logic (override present vs fallback to global), the
+ * service layer, and the HTTP endpoints.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import type { NotificationPreferences, PortfolioNotificationOverride } from '../db/notificationDb.js'
+
+vi.mock('../utils/logger.js', () => ({
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    logAudit: vi.fn(),
+}))
+
+// ── in-memory stand-ins for the sqlite-backed notification tables ────────────
+
+const globalPrefs = new Map<string, NotificationPreferences>()
+const overrides = new Map<string, PortfolioNotificationOverride>()
+
+const key = (userId: string, portfolioId: string) => `${userId}::${portfolioId}`
+
+vi.mock('../db/notificationDb.js', () => ({
+    dbGetNotificationPreferences: vi.fn((userId: string) => globalPrefs.get(userId)),
+    dbSaveNotificationPreferences: vi.fn((prefs: NotificationPreferences) => {
+        globalPrefs.set(prefs.userId, prefs)
+    }),
+    dbInitDefaultNotificationPreferences: vi.fn((userId: string) => {
+        const defaults: NotificationPreferences = {
+            userId,
+            emailEnabled: false,
+            webhookEnabled: false,
+            digestMode: 'immediate',
+            events: { rebalance: true, circuitBreaker: true, priceMovement: true, riskChange: true },
+        }
+        globalPrefs.set(userId, defaults)
+        return defaults
+    }),
+    dbGetAllNotificationPreferences: vi.fn(() => [...globalPrefs.values()]),
+    dbLogNotificationOutcome: vi.fn(),
+    dbGetNotificationLogs: vi.fn(() => []),
+    dbSaveDigestEvent: vi.fn(),
+    dbGetAndDeleteDigestEventsBefore: vi.fn(() => []),
+    dbGetPortfolioNotificationOverride: vi.fn((userId: string, portfolioId: string) =>
+        overrides.get(key(userId, portfolioId)),
+    ),
+    dbSavePortfolioNotificationOverride: vi.fn((o: PortfolioNotificationOverride) => {
+        const stored = { ...o, updatedAt: new Date().toISOString() }
+        overrides.set(key(o.userId, o.portfolioId), stored)
+        return stored
+    }),
+    dbListPortfolioNotificationOverrides: vi.fn((userId: string) =>
+        [...overrides.values()].filter(o => o.userId === userId),
+    ),
+    dbDeletePortfolioNotificationOverride: vi.fn((userId: string, portfolioId: string) =>
+        overrides.delete(key(userId, portfolioId)),
+    ),
+}))
+
+vi.mock('../services/databaseService.js', () => ({
+    databaseService: {
+        getUserPreferences: vi.fn(() => ({ default_threshold: 5 })),
+        upsertUserPreferences: vi.fn(),
+    },
+}))
+
+vi.mock('nodemailer', () => ({
+    default: { createTransport: vi.fn(() => ({ sendMail: vi.fn() })) },
+}))
+
+vi.mock('../services/webhookDeadLetter.js', () => ({
+    webhookDeadLetterQueue: { push: vi.fn() },
+}))
+
+const mockGetPortfolio = vi.fn()
+
+vi.mock('../services/portfolioStorage.js', () => ({
+    portfolioStorage: { getPortfolio: (...a: unknown[]) => mockGetPortfolio(...a) },
+}))
+
+vi.mock('../middleware/requireJwt.js', () => ({
+    requireJwt: (req: any, _res: any, next: any) => {
+        req.user = { address: USER }
+        next()
+    },
+    requireJwtWhenEnabled: (req: any, _res: any, next: any) => next(),
+}))
+
+const USER = 'GUSERADDRESSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+const PORTFOLIO_ID = 'portfolio-abc'
+
+function seedGlobal(overridesToApply: Partial<NotificationPreferences> = {}): NotificationPreferences {
+    const prefs: NotificationPreferences = {
+        userId: USER,
+        emailEnabled: true,
+        emailAddress: 'global@example.com',
+        webhookEnabled: false,
+        webhookUrl: undefined,
+        digestMode: 'immediate',
+        events: { rebalance: true, circuitBreaker: true, priceMovement: true, riskChange: false },
+        ...overridesToApply,
+    }
+    globalPrefs.set(USER, prefs)
+    return prefs
+}
+
+async function makeApp() {
+    const { preferencesRouter } = await import('../api/preferences.routes.js')
+    const app = express()
+    app.use(express.json())
+    app.use('/api', preferencesRouter)
+    return app
+}
+
+describe('per-portfolio notification overrides (#1395)', () => {
+    beforeEach(() => {
+        globalPrefs.clear()
+        overrides.clear()
+        vi.clearAllMocks()
+        mockGetPortfolio.mockResolvedValue({ id: PORTFOLIO_ID, userAddress: USER })
+    })
+
+    describe('resolution', () => {
+        it('falls back to global preferences when no override exists', async () => {
+            const { resolvePortfolioNotificationPreferences } = await import('../services/notificationPreferences.js')
+            const global = seedGlobal()
+
+            const resolved = resolvePortfolioNotificationPreferences(global, undefined)
+
+            expect(resolved.overrideApplied).toBe(false)
+            expect(resolved.emailEnabled).toBe(true)
+            expect(resolved.emailAddress).toBe('global@example.com')
+            expect(resolved.events).toEqual(global.events)
+        })
+
+        it('layers override fields on top of global settings', async () => {
+            const { resolvePortfolioNotificationPreferences } = await import('../services/notificationPreferences.js')
+            const global = seedGlobal()
+
+            const resolved = resolvePortfolioNotificationPreferences(global, {
+                userId: USER,
+                portfolioId: PORTFOLIO_ID,
+                emailAddress: 'portfolio@example.com',
+                digestMode: 'weekly',
+            })
+
+            expect(resolved.overrideApplied).toBe(true)
+            expect(resolved.emailAddress).toBe('portfolio@example.com')
+            expect(resolved.digestMode).toBe('weekly')
+            // Untouched fields still come from global.
+            expect(resolved.emailEnabled).toBe(true)
+            expect(resolved.events.rebalance).toBe(true)
+        })
+
+        it('merges event flags key-by-key rather than replacing the whole set', async () => {
+            const { resolvePortfolioNotificationPreferences } = await import('../services/notificationPreferences.js')
+            const global = seedGlobal()
+
+            const resolved = resolvePortfolioNotificationPreferences(global, {
+                userId: USER,
+                portfolioId: PORTFOLIO_ID,
+                events: { rebalance: false },
+            })
+
+            expect(resolved.events).toEqual({
+                rebalance: false,        // overridden
+                circuitBreaker: true,    // from global
+                priceMovement: true,     // from global
+                riskChange: false,       // from global
+            })
+        })
+
+        it('can disable a channel for one portfolio only', async () => {
+            const { resolvePortfolioNotificationPreferences } = await import('../services/notificationPreferences.js')
+            const global = seedGlobal()
+
+            const resolved = resolvePortfolioNotificationPreferences(global, {
+                userId: USER,
+                portfolioId: PORTFOLIO_ID,
+                emailEnabled: false,
+            })
+
+            expect(resolved.emailEnabled).toBe(false)
+            expect(global.emailEnabled).toBe(true)
+        })
+
+        it('keeps a channel off when the override enables it with no destination anywhere', async () => {
+            const { resolvePortfolioNotificationPreferences } = await import('../services/notificationPreferences.js')
+            const global = seedGlobal({ webhookEnabled: false, webhookUrl: undefined })
+
+            const resolved = resolvePortfolioNotificationPreferences(global, {
+                userId: USER,
+                portfolioId: PORTFOLIO_ID,
+                webhookEnabled: true,
+            })
+
+            // Half-configured overrides must not silently swallow notifications.
+            expect(resolved.webhookEnabled).toBe(false)
+        })
+
+        it('enables a channel when the override supplies the destination', async () => {
+            const { resolvePortfolioNotificationPreferences } = await import('../services/notificationPreferences.js')
+            const global = seedGlobal({ webhookEnabled: false })
+
+            const resolved = resolvePortfolioNotificationPreferences(global, {
+                userId: USER,
+                portfolioId: PORTFOLIO_ID,
+                webhookEnabled: true,
+                webhookUrl: 'https://hooks.example.com/abc',
+            })
+
+            expect(resolved.webhookEnabled).toBe(true)
+            expect(resolved.webhookUrl).toBe('https://hooks.example.com/abc')
+        })
+    })
+
+    describe('service layer', () => {
+        it('resolves global preferences when no portfolioId is supplied', async () => {
+            const { notificationService } = await import('../services/notificationService.js')
+            seedGlobal()
+
+            const resolved = notificationService.getPreferencesForPortfolio(USER)
+
+            expect(resolved.overrideApplied).toBe(false)
+            expect(resolved.emailAddress).toBe('global@example.com')
+        })
+
+        it('applies a stored override for the portfolio', async () => {
+            const { notificationService } = await import('../services/notificationService.js')
+            seedGlobal()
+
+            notificationService.setPortfolioOverride({
+                userId: USER,
+                portfolioId: PORTFOLIO_ID,
+                emailAddress: 'portfolio@example.com',
+            })
+
+            const resolved = notificationService.getPreferencesForPortfolio(USER, PORTFOLIO_ID)
+            expect(resolved.overrideApplied).toBe(true)
+            expect(resolved.emailAddress).toBe('portfolio@example.com')
+        })
+
+        it('leaves other portfolios on global settings', async () => {
+            const { notificationService } = await import('../services/notificationService.js')
+            seedGlobal()
+
+            notificationService.setPortfolioOverride({
+                userId: USER,
+                portfolioId: PORTFOLIO_ID,
+                emailEnabled: false,
+            })
+
+            const other = notificationService.getPreferencesForPortfolio(USER, 'portfolio-other')
+            expect(other.overrideApplied).toBe(false)
+            expect(other.emailEnabled).toBe(true)
+        })
+
+        it('falls back to global again once the override is deleted', async () => {
+            const { notificationService } = await import('../services/notificationService.js')
+            seedGlobal()
+
+            notificationService.setPortfolioOverride({
+                userId: USER,
+                portfolioId: PORTFOLIO_ID,
+                emailEnabled: false,
+            })
+            expect(notificationService.getPreferencesForPortfolio(USER, PORTFOLIO_ID).emailEnabled).toBe(false)
+
+            expect(notificationService.deletePortfolioOverride(USER, PORTFOLIO_ID)).toBe(true)
+
+            const resolved = notificationService.getPreferencesForPortfolio(USER, PORTFOLIO_ID)
+            expect(resolved.overrideApplied).toBe(false)
+            expect(resolved.emailEnabled).toBe(true)
+        })
+
+        it('propagates a later global change to portfolios that did not override that field', async () => {
+            const { notificationService } = await import('../services/notificationService.js')
+            seedGlobal()
+
+            notificationService.setPortfolioOverride({
+                userId: USER,
+                portfolioId: PORTFOLIO_ID,
+                digestMode: 'weekly',
+            })
+
+            // Change a *different* global field afterwards.
+            seedGlobal({ emailAddress: 'changed@example.com' })
+
+            const resolved = notificationService.getPreferencesForPortfolio(USER, PORTFOLIO_ID)
+            expect(resolved.emailAddress).toBe('changed@example.com')
+            expect(resolved.digestMode).toBe('weekly')
+        })
+
+        it('lists the overrides belonging to a user', async () => {
+            const { notificationService } = await import('../services/notificationService.js')
+            seedGlobal()
+
+            notificationService.setPortfolioOverride({ userId: USER, portfolioId: 'p1', emailEnabled: false })
+            notificationService.setPortfolioOverride({ userId: USER, portfolioId: 'p2', digestMode: 'daily' })
+            notificationService.setPortfolioOverride({ userId: 'GOTHER', portfolioId: 'p3', emailEnabled: false })
+
+            expect(notificationService.listPortfolioOverrides(USER).map(o => o.portfolioId)).toEqual(['p1', 'p2'])
+        })
+    })
+
+    describe('HTTP endpoints', () => {
+        it('PUT stores an override and returns the resolved preferences', async () => {
+            const app = await makeApp()
+            seedGlobal()
+
+            const res = await request(app)
+                .put(`/api/preferences/notifications/portfolio/${PORTFOLIO_ID}`)
+                .send({ digestMode: 'weekly', events: { rebalance: false } })
+
+            expect(res.status).toBe(200)
+            expect(res.body.data.override).toMatchObject({ portfolioId: PORTFOLIO_ID, digestMode: 'weekly' })
+            expect(res.body.data.resolved).toMatchObject({ overrideApplied: true, digestMode: 'weekly' })
+            expect(res.body.data.resolved.events.circuitBreaker).toBe(true)
+        })
+
+        it('GET reports fallback when no override is configured', async () => {
+            const app = await makeApp()
+            seedGlobal()
+
+            const res = await request(app).get(`/api/preferences/notifications/portfolio/${PORTFOLIO_ID}`)
+
+            expect(res.status).toBe(200)
+            expect(res.body.data.override).toBeNull()
+            expect(res.body.data.resolved.overrideApplied).toBe(false)
+        })
+
+        it('GET returns the stored override once set', async () => {
+            const app = await makeApp()
+            seedGlobal()
+            await request(app)
+                .put(`/api/preferences/notifications/portfolio/${PORTFOLIO_ID}`)
+                .send({ emailEnabled: false })
+
+            const res = await request(app).get(`/api/preferences/notifications/portfolio/${PORTFOLIO_ID}`)
+
+            expect(res.body.data.override).toMatchObject({ emailEnabled: false })
+            expect(res.body.data.resolved.emailEnabled).toBe(false)
+        })
+
+        it('DELETE removes the override and resolves back to global', async () => {
+            const app = await makeApp()
+            seedGlobal()
+            await request(app)
+                .put(`/api/preferences/notifications/portfolio/${PORTFOLIO_ID}`)
+                .send({ emailEnabled: false })
+
+            const res = await request(app).delete(`/api/preferences/notifications/portfolio/${PORTFOLIO_ID}`)
+
+            expect(res.status).toBe(200)
+            expect(res.body.data.deleted).toBe(true)
+            expect(res.body.data.resolved.emailEnabled).toBe(true)
+        })
+
+        it('DELETE returns 404 when nothing is configured', async () => {
+            const app = await makeApp()
+            seedGlobal()
+
+            const res = await request(app).delete(`/api/preferences/notifications/portfolio/${PORTFOLIO_ID}`)
+
+            expect(res.status).toBe(404)
+        })
+
+        it('rejects enabling email with no address in either layer', async () => {
+            const app = await makeApp()
+            seedGlobal({ emailEnabled: false, emailAddress: undefined })
+
+            const res = await request(app)
+                .put(`/api/preferences/notifications/portfolio/${PORTFOLIO_ID}`)
+                .send({ emailEnabled: true })
+
+            expect(res.status).toBe(422)
+            expect(res.body.error.message).toContain('emailAddress')
+        })
+
+        it('returns 404 for an unknown portfolio', async () => {
+            const app = await makeApp()
+            mockGetPortfolio.mockResolvedValue(null)
+
+            const res = await request(app)
+                .put('/api/preferences/notifications/portfolio/ghost')
+                .send({ emailEnabled: false })
+
+            expect(res.status).toBe(404)
+        })
+
+        it('returns 403 for a portfolio owned by someone else', async () => {
+            const app = await makeApp()
+            mockGetPortfolio.mockResolvedValue({ id: PORTFOLIO_ID, userAddress: 'GSOMEONEELSE' })
+
+            const res = await request(app)
+                .put(`/api/preferences/notifications/portfolio/${PORTFOLIO_ID}`)
+                .send({ emailEnabled: false })
+
+            expect(res.status).toBe(403)
+        })
+
+        it('rejects an unknown field', async () => {
+            const app = await makeApp()
+            seedGlobal()
+
+            const res = await request(app)
+                .put(`/api/preferences/notifications/portfolio/${PORTFOLIO_ID}`)
+                .send({ smsEnabled: true })
+
+            expect(res.status).toBe(422)
+        })
+
+        it('lists all overrides for the caller', async () => {
+            const app = await makeApp()
+            seedGlobal()
+            await request(app).put('/api/preferences/notifications/portfolio/p1').send({ emailEnabled: false })
+            await request(app).put('/api/preferences/notifications/portfolio/p2').send({ digestMode: 'daily' })
+
+            const res = await request(app).get('/api/preferences/notifications/portfolio')
+
+            expect(res.status).toBe(200)
+            expect(res.body.data.count).toBe(2)
+        })
+    })
+})

--- a/backend/src/test/telegramStatusCommand.test.ts
+++ b/backend/src/test/telegramStatusCommand.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Telegram /status command (#1396).
+ *
+ * Drives the handler with mocked Telegram update payloads: a linked user with
+ * active portfolios, and an unlinked chat that must receive linking instructions
+ * rather than an error.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../utils/logger.js', () => ({
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+// kv-backed link store — mocked so the suite stays off the native sqlite binding.
+const kv = new Map<string, string>()
+
+vi.mock('../services/databaseService.js', () => ({
+    databaseService: {
+        getKvValue: vi.fn((k: string) => kv.get(k)),
+        setKvValue: vi.fn((k: string, v: string) => { kv.set(k, v) }),
+        deleteKvValue: vi.fn((k: string) => kv.delete(k)),
+    },
+}))
+
+const mockGetUserPortfolios = vi.fn()
+
+vi.mock('../services/portfolioStorage.js', () => ({
+    portfolioStorage: { getUserPortfolios: (...a: unknown[]) => mockGetUserPortfolios(...a) },
+}))
+
+const CHAT_ID = 987654321
+const USER = 'GUSERADDRESSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
+/** A minimal but realistic Telegram update message payload. */
+function statusUpdate(chatId: number | string = CHAT_ID) {
+    return {
+        message_id: 42,
+        from: { id: 111, is_bot: false, username: 'someone' },
+        chat: { id: chatId, type: 'private' as const },
+        date: Math.floor(Date.now() / 1000),
+        text: '/status',
+    }
+}
+
+function portfolio(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'portfolio-abc',
+        userAddress: USER,
+        name: 'Core Portfolio',
+        allocations: { XLM: 60, USDC: 40 },
+        balances: { XLM: 700, USDC: 300 },
+        totalValue: 1000,
+        threshold: 5,
+        createdAt: '2026-01-01T00:00:00Z',
+        lastRebalance: '2026-08-01T12:30:00Z',
+        version: 1,
+        ...overrides,
+    }
+}
+
+async function loadCommands() {
+    return import('../notifications/telegramCommands.js')
+}
+
+async function loadLink() {
+    return import('../notifications/telegramLink.js')
+}
+
+describe('telegram /status command (#1396)', () => {
+    beforeEach(async () => {
+        kv.clear()
+        vi.clearAllMocks()
+        const { resetTelegramLinksForTests } = await loadLink()
+        resetTelegramLinksForTests()
+    })
+
+    describe('unlinked chats', () => {
+        it('returns linking instructions instead of an error', async () => {
+            const { handleStatusCommand, LINK_INSTRUCTIONS } = await loadCommands()
+
+            const reply = await handleStatusCommand(statusUpdate() as never)
+
+            expect(reply.text).toBe(LINK_INSTRUCTIONS)
+            expect(reply.text).toContain('Link your account first')
+            expect(reply.text).toContain('/status')
+            expect(reply.text.toLowerCase()).not.toContain('error')
+            expect(reply.text.toLowerCase()).not.toContain('unauthorized')
+        })
+
+        it('does not look up any portfolios for an unlinked chat', async () => {
+            const { handleStatusCommand } = await loadCommands()
+
+            await handleStatusCommand(statusUpdate() as never)
+
+            expect(mockGetUserPortfolios).not.toHaveBeenCalled()
+        })
+
+        it('gives instructions again after the chat is unlinked', async () => {
+            const { handleStatusCommand, LINK_INSTRUCTIONS } = await loadCommands()
+            const { linkChat, unlinkChat } = await loadLink()
+
+            linkChat(String(CHAT_ID), USER)
+            unlinkChat(String(CHAT_ID))
+
+            const reply = await handleStatusCommand(statusUpdate() as never)
+            expect(reply.text).toBe(LINK_INSTRUCTIONS)
+        })
+    })
+
+    describe('linked chats', () => {
+        beforeEach(async () => {
+            const { linkChat } = await loadLink()
+            linkChat(String(CHAT_ID), USER)
+        })
+
+        it('reports allocation, drift and last rebalance for the linked portfolios', async () => {
+            const { handleStatusCommand } = await loadCommands()
+            mockGetUserPortfolios.mockResolvedValue([portfolio()])
+
+            const reply = await handleStatusCommand(statusUpdate() as never)
+
+            expect(mockGetUserPortfolios).toHaveBeenCalledWith(USER)
+            expect(reply.parseMode).toBe('Markdown')
+            expect(reply.text).toContain('Portfolio Status')
+            expect(reply.text).toContain('Core Portfolio')
+            // 700/1000 = 70% actual against a 60% target.
+            expect(reply.text).toContain('XLM: 70.0% / 60% target')
+            expect(reply.text).toContain('USDC: 30.0% / 40% target')
+            expect(reply.text).toContain('Max drift: 10.00%')
+            expect(reply.text).toContain('Last rebalance: 2026-08-01 12:30 UTC')
+        })
+
+        it('flags a portfolio whose drift exceeds its threshold', async () => {
+            const { handleStatusCommand } = await loadCommands()
+            mockGetUserPortfolios.mockResolvedValue([portfolio()])
+
+            const reply = await handleStatusCommand(statusUpdate() as never)
+
+            expect(reply.text).toContain('Rebalance due')
+        })
+
+        it('marks a balanced portfolio as within threshold', async () => {
+            const { handleStatusCommand } = await loadCommands()
+            mockGetUserPortfolios.mockResolvedValue([
+                portfolio({ balances: { XLM: 600, USDC: 400 } }),
+            ])
+
+            const reply = await handleStatusCommand(statusUpdate() as never)
+
+            expect(reply.text).toContain('Within threshold')
+            expect(reply.text).toContain('Max drift: 0.00%')
+        })
+
+        it('lists every linked portfolio', async () => {
+            const { handleStatusCommand } = await loadCommands()
+            mockGetUserPortfolios.mockResolvedValue([
+                portfolio({ id: 'p1', name: 'Core' }),
+                portfolio({ id: 'p2', name: 'Satellite' }),
+            ])
+
+            const reply = await handleStatusCommand(statusUpdate() as never)
+
+            expect(reply.text).toContain('2 portfolios linked to this chat')
+            expect(reply.text).toContain('Core')
+            expect(reply.text).toContain('Satellite')
+        })
+
+        it('uses singular wording for one portfolio', async () => {
+            const { handleStatusCommand } = await loadCommands()
+            mockGetUserPortfolios.mockResolvedValue([portfolio()])
+
+            const reply = await handleStatusCommand(statusUpdate() as never)
+
+            expect(reply.text).toContain('1 portfolio linked to this chat')
+        })
+
+        it('handles a linked account with no portfolios yet', async () => {
+            const { handleStatusCommand } = await loadCommands()
+            mockGetUserPortfolios.mockResolvedValue([])
+
+            const reply = await handleStatusCommand(statusUpdate() as never)
+
+            expect(reply.text).toContain('No portfolios found')
+            expect(reply.text).toContain('web app')
+        })
+
+        it('reports "never" when the portfolio has never rebalanced', async () => {
+            const { handleStatusCommand } = await loadCommands()
+            mockGetUserPortfolios.mockResolvedValue([portfolio({ lastRebalance: undefined })])
+
+            const reply = await handleStatusCommand(statusUpdate() as never)
+
+            expect(reply.text).toContain('Last rebalance: never')
+        })
+
+        it('degrades gracefully when the portfolio lookup fails', async () => {
+            const { handleStatusCommand } = await loadCommands()
+            mockGetUserPortfolios.mockRejectedValue(new Error('db down'))
+
+            const reply = await handleStatusCommand(statusUpdate() as never)
+
+            expect(reply.text).toContain('Could not load your portfolio status')
+            expect(reply.text).not.toContain('db down')
+        })
+
+        it('answers per chat — another chat stays unlinked', async () => {
+            const { handleStatusCommand, LINK_INSTRUCTIONS } = await loadCommands()
+            mockGetUserPortfolios.mockResolvedValue([portfolio()])
+
+            const other = await handleStatusCommand(statusUpdate(555) as never)
+
+            expect(other.text).toBe(LINK_INSTRUCTIONS)
+        })
+    })
+
+    describe('drift calculation', () => {
+        it('returns the largest absolute gap across assets', async () => {
+            const { computeMaxDrift } = await loadCommands()
+
+            expect(computeMaxDrift(portfolio() as never)).toBeCloseTo(10, 6)
+        })
+
+        it('returns 0 for an empty or valueless portfolio', async () => {
+            const { computeMaxDrift } = await loadCommands()
+
+            expect(computeMaxDrift(portfolio({ totalValue: 0 }) as never)).toBe(0)
+            expect(computeMaxDrift(portfolio({ allocations: {} }) as never)).toBe(0)
+        })
+    })
+
+    describe('link persistence', () => {
+        it('stores the link so it survives a fresh lookup', async () => {
+            const { linkChat, getLinkedAddress, resetTelegramLinksForTests } = await loadLink()
+
+            linkChat(String(CHAT_ID), USER)
+            // Drop the in-memory mirror; the value must come back from the kv store.
+            resetTelegramLinksForTests()
+
+            expect(getLinkedAddress(String(CHAT_ID))).toBe(USER)
+        })
+
+        it('reports no address for a chat that was never linked', async () => {
+            const { getLinkedAddress } = await loadLink()
+
+            expect(getLinkedAddress('does-not-exist')).toBeUndefined()
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Four notification-layer features in one PR.

Closes #1394
Closes #1393
Closes #1395
Closes #1396

> **Reviewer note on #1393:** the dead-letter replay feature was **already implemented on `main`**
> (shipped in PR #1641) — list, single replay, batch replay, requeue-on-failure, and 20 passing
> tests. Every acceptance criterion in the issue was already met. Rather than rebuild it, this PR
> closes the real gaps: filtering, pagination and a summary on the listing, and removal of the
> duplicated replay logic. Detail below.

---

## #1394 — Per-channel delivery success/failure metrics

`observability/metrics.ts`, `services/notificationDelivery.ts`

Three metrics registered on the existing Prometheus registry, so they appear on the current
metrics endpoint with no new scrape target:

| Metric | Type | Labels |
| --- | --- | --- |
| `stellar_portfolio_notification_delivery_total` | counter | `channel`, `outcome`, `reason`, `event_type` |
| `stellar_portfolio_notification_delivery_attempts_total` | counter | `channel`, `outcome` |
| `stellar_portfolio_notification_delivery_duration_seconds` | histogram | `channel`, `outcome` |

- Channels: `email`, `webhook`, `slack`, `sms`, `telegram`. An outage in one provider is now
  visible instead of being averaged away by the healthy ones.
- **Totals count terminal outcomes** (after retries are exhausted); **attempts count individual
  tries**. A delivery that succeeds on its third attempt records one success and two `retried`
  attempts — a test pins that distinction, since conflating them would make retry pressure
  invisible.
- `deliverWithBackoff` instruments every channel using the retry wrapper (email, webhook today).
  Channels that bypass it report through `recordChannelDelivery()` so everything lands in the
  same counters.

### Failure reasons are classified, not raw

The `reason` label is a bounded vocabulary — `auth`, `rate_limited`, `timeout`, `server_error`,
`client_error`, `connection_refused`, `dns`, `not_configured`, `invalid_recipient`, `unknown` —
derived from HTTP status, error code, then message shape.

Raw error strings are deliberately never used as labels: they carry ids and timestamps and would
explode Prometheus cardinality. A test feeds in `"user 12345 rejected at 2026-08-29T10:00:00Z"`
and asserts the label comes back `unknown` with no `12345` in it.

## #1393 — Dead-letter listing and replay

`services/webhookDeadLetter.ts`, `api/notifications.routes.ts`

**Already on `main`:** `GET /admin/notifications/dead-letter`, `POST .../:id/replay`,
`POST .../batch-replay`, `DELETE .../:id`, with successful replays removed and failed replays
re-queued with `attemptsExhausted` incremented.

**Added here:**

- **Filtering and pagination on the listing** — `userId`, `eventType`, `search` (substring over
  id, user, URL and error message), `page`, `pageSize` (default 50, max 500). A single broken
  endpoint can generate thousands of entries; the unpaginated listing returned all of them.
- **A summary block** — total, counts per event type, oldest and newest timestamps.
- **De-duplicated the replay request.** The full fetch/timeout/abort closure was copy-pasted
  between the single-item and batch endpoints, meaning any fix to one could silently miss the
  other. Both now call one `postDeadLetterPayload()`, which also adds an `X-Webhook-Replay: true`
  header so receivers can distinguish a replay from an original delivery.
- **A listing test**, which the issue asked for and the existing suite did not have.

Behaviour of the replay endpoints themselves is unchanged — the 20 pre-existing DLQ tests pass
untouched.

## #1395 — Per-portfolio notification preference overrides

`db/notificationDb.ts`, `services/notificationPreferences.ts`, `api/preferences.routes.ts`

| Method | Path |
| --- | --- |
| `GET` | `/api/v1/preferences/notifications/portfolio` |
| `GET` | `/api/v1/preferences/notifications/portfolio/:portfolioId` |
| `PUT` | `/api/v1/preferences/notifications/portfolio/:portfolioId` |
| `DELETE` | `/api/v1/preferences/notifications/portfolio/:portfolioId` |

All JWT-authenticated with portfolio-ownership checks. Responses include `resolved` — the
preferences that actually apply — plus `overrideApplied` so callers can see which layer answered.

**Overrides are partial by design.** Only the fields the user actually set are stored (`NULL`
means "inherit", which is distinct from an explicit `false`). A later change to a global setting
therefore still propagates to portfolios that never overrode that field — a test pins this, since
storing a full snapshot would silently freeze those portfolios at their old values. Event flags
merge key-by-key, so overriding `rebalance` alone leaves the other three resolving globally.

**A half-configured override cannot silently drop notifications.** Enabling a channel with no
destination in either layer resolves to *off*, and the API rejects that combination with 422 up
front rather than accepting a setting that would quietly deliver nothing.

`notify()` resolves through this layer whenever the payload carries a `portfolioId`; without one
it uses global preferences exactly as before.

## #1396 — Telegram `/status`

New `notifications/telegramCommands.ts`, `notifications/telegramLink.ts`

The previous `/status` reported **system-wide** totals across every portfolio in the database and
replied `Unauthorized` to unknown chats. It now:

- resolves the chat's **linked Stellar address** and reports only that user's portfolios;
- shows, per portfolio, current vs target allocation per asset, max drift against the portfolio's
  threshold (flagged when a rebalance is due), and last rebalance time (or `never`);
- answers an unlinked chat with **linking instructions** rather than an error, so a new user is
  told what to do instead of hitting a dead end;
- degrades to a generic retry message if the lookup fails, keeping the underlying error in the
  logs rather than the chat.

Added `/link <address>` and `/unlink`. Links are stored in `kv_store` under
`telegram:link:<chatId>` and mirrored in memory, so they survive a restart.

Command handlers live outside the bot transport, so tests drive them directly with mocked
Telegram update payloads — no live bot or network needed.

---

## Testing

**74 new tests**, all passing (80 including the pre-existing DLQ integration suite, which is
unchanged and still green).

| Suite | Tests | Covers |
| --- | --- | --- |
| `notificationDeliveryMetrics.test.ts` | 24 | Success/failure/retry counters, reason classification, exposition |
| `portfolioNotificationOverrides.test.ts` | 22 | Override vs fallback resolution, service, HTTP |
| `telegramStatusCommand.test.ts` | 16 | Linked and unlinked `/status`, drift, link persistence |
| `deadLetterListing.test.ts` | 12 | Filtering, pagination, summary, shared replay POST |

Metric assertions read the actual Prometheus text exposition rather than mocking the registry, so
they verify what a scraper would really see.

`tsc --noEmit` is clean — the only errors reported are pre-existing syntax errors in
`src/test/portfolios.routes.integration.test.ts`, untouched by this PR.

**Regression check:** ten related suites were run against a baseline worktree of `main` and match
exactly (76 passed / 2 failed on both sides). The two failures and four load failures are
pre-existing in my environment, where `better-sqlite3`'s native binding cannot be built.

## Docs

New under `backend/docs/`: `notification-delivery-metrics.md` (metric names, label vocabulary,
example PromQL), `webhook-dead-letter.md` (endpoints, query params, replay semantics),
`notification-preferences.md` (the layering model), `telegram-bot.md` (commands and linking).

## Backwards compatibility

- Metrics are additive; no existing metric changed name or labels.
- The dead-letter listing response gains `summary` and `pagination` and now returns **a page**
  rather than every entry. A client that read the full array unpaginated will need
  `pageSize`, so this is the one response-shape change to be aware of.
- Notification preferences behave identically for anyone who sets no override.
- **`/status` output changed shape** — it reports the requesting user's portfolios instead of
  global totals. Anyone relying on the old system-wide output will see something different.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-portfolio notification preferences with REST endpoints, override layering, validation, and global fallback behavior.
  * Added Telegram chat linking, `/link`, `/unlink`, and portfolio-aware `/status` reporting.
  * Added notification delivery metrics across supported channels, including retries, duration, outcomes, and failure categories.
  * Added webhook dead-letter queue listing, filtering, pagination, replay, and discard capabilities.
* **Documentation**
  * Documented notification metrics, preference overrides, Telegram bot usage, and webhook dead-letter workflows.
* **Bug Fixes**
  * Improved webhook replay handling and centralized delivery behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->