### PR TITLE
feat: add ElastiCache Multi-AZ failover

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -95,8 +95,10 @@ RATE_LIMIT_BURST_MAX=20
 RATE_LIMIT_WRITE_BURST_MAX=3
 
 # --- Queue and caching ---
-# Redis URL for BullMQ queues/workers | URL | # Optional (default: redis://localhost:6379)
+# Redis URL for BullMQ queues/workers. In AWS, point this at the ElastiCache replication-group primary endpoint so automatic failover follows the promoted primary. | URL | # Optional (default: redis://localhost:6379)
 REDIS_URL=redis://localhost:6379
+# Redis host:port injected by Terraform ECS as an alternative to REDIS_URL | host:port | # Optional (default: empty)
+REDIS_HOST=
 # Toggle in-memory portfolio cache for experiments | boolean | # Optional (default: false)
 USE_MEMORY_CACHE=false
 

--- a/backend/src/config/credentialManager.ts
+++ b/backend/src/config/credentialManager.ts
@@ -125,7 +125,8 @@ class CredentialManager {
             return this.redisCredsCache;
         }
 
-        const rawUrl = process.env.REDIS_URL?.trim() || 'redis://localhost:6379';
+        const rawHost = process.env.REDIS_HOST?.trim();
+        const rawUrl = process.env.REDIS_URL?.trim() || (rawHost ? edis:// : 'redis://localhost:6379');
         const authToken = (process.env.REDIS_AUTH_TOKEN || process.env.REDIS_PASSWORD)?.trim();
 
         let url = rawUrl;
@@ -161,7 +162,8 @@ class CredentialManager {
                 if (secretValue) {
                     const parsed = JSON.parse(secretValue);
                     const authToken = parsed.auth_token || parsed.authToken || parsed.password || '';
-                    const rawUrl = process.env.REDIS_URL?.trim() || 'redis://localhost:6379';
+                    const rawHost = process.env.REDIS_HOST?.trim();
+        const rawUrl = process.env.REDIS_URL?.trim() || (rawHost ? edis:// : 'redis://localhost:6379');
                     let url = rawUrl;
                     if (authToken && !url.includes('@')) {
                         url = url.replace(/^(rediss?:\/\/)/, `$1:${encodeURIComponent(authToken)}@`);

--- a/backend/src/config/credentialManager.ts
+++ b/backend/src/config/credentialManager.ts
@@ -126,7 +126,7 @@ class CredentialManager {
         }
 
         const rawHost = process.env.REDIS_HOST?.trim();
-        const rawUrl = process.env.REDIS_URL?.trim() || (rawHost ? edis:// : 'redis://localhost:6379');
+        const rawUrl = process.env.REDIS_URL?.trim() || (rawHost ? 'redis://' + rawHost : 'redis://localhost:6379');
         const authToken = (process.env.REDIS_AUTH_TOKEN || process.env.REDIS_PASSWORD)?.trim();
 
         let url = rawUrl;
@@ -163,7 +163,7 @@ class CredentialManager {
                     const parsed = JSON.parse(secretValue);
                     const authToken = parsed.auth_token || parsed.authToken || parsed.password || '';
                     const rawHost = process.env.REDIS_HOST?.trim();
-        const rawUrl = process.env.REDIS_URL?.trim() || (rawHost ? edis:// : 'redis://localhost:6379');
+        const rawUrl = process.env.REDIS_URL?.trim() || (rawHost ? 'redis://' + rawHost : 'redis://localhost:6379');
                     let url = rawUrl;
                     if (authToken && !url.includes('@')) {
                         url = url.replace(/^(rediss?:\/\/)/, `$1:${encodeURIComponent(authToken)}@`);

--- a/deployment/terraform/modules/elasticache/main.tf
+++ b/deployment/terraform/modules/elasticache/main.tf
@@ -30,7 +30,7 @@ resource "random_password" "redis_auth" {
 
 resource "aws_secretsmanager_secret" "redis_auth" {
   name                    = "${var.name_prefix}-redis-auth-token"
-  description             = "Redis AUTH token for ElastiCache cluster"
+  description             = "Redis AUTH token for ElastiCache replication group"
   recovery_window_in_days = 0
 
   tags = {
@@ -39,13 +39,14 @@ resource "aws_secretsmanager_secret" "redis_auth" {
 }
 
 resource "aws_secretsmanager_secret_version" "redis_auth" {
-  secret_id     = aws_secretsmanager_secret.redis_auth.id
+  secret_id = aws_secretsmanager_secret.redis_auth.id
   secret_string = jsonencode({
     auth_token = random_password.redis_auth.result
   })
 }
 
 resource "aws_secretsmanager_secret_rotation" "redis_auth" {
+  count               = var.secret_rotation_lambda_arn == null ? 0 : 1
   secret_id           = aws_secretsmanager_secret.redis_auth.id
   rotation_lambda_arn = var.secret_rotation_lambda_arn
 
@@ -54,18 +55,23 @@ resource "aws_secretsmanager_secret_rotation" "redis_auth" {
   }
 }
 
-resource "aws_elasticache_cluster" "main" {
-  cluster_id                 = "${var.name_prefix}-redis"
+resource "aws_elasticache_replication_group" "main" {
+  replication_group_id       = "${var.name_prefix}-redis"
+  description                = "Redis replication group for ${var.name_prefix}"
   engine                     = "redis"
-  node_type                  = var.node_type
-  num_cache_nodes            = 1
-  parameter_group_name       = "default.redis7"
   engine_version             = "7.0"
+  node_type                  = var.node_type
   port                       = 6379
+  parameter_group_name       = "default.redis7"
   subnet_group_name          = aws_elasticache_subnet_group.main.name
   security_group_ids         = [aws_security_group.redis.id]
+  num_cache_clusters         = var.replica_count + 1
+  automatic_failover_enabled = var.replica_count > 0
+  multi_az_enabled           = var.replica_count > 0
   transit_encryption_enabled = var.transit_encryption_enabled
+  at_rest_encryption_enabled = var.at_rest_encryption_enabled
   auth_token                 = var.auth_token_enabled ? random_password.redis_auth.result : null
+  apply_immediately          = var.apply_immediately
 
   tags = {
     Name = "${var.name_prefix}-redis"

--- a/deployment/terraform/modules/elasticache/outputs.tf
+++ b/deployment/terraform/modules/elasticache/outputs.tf
@@ -1,5 +1,21 @@
 output "redis_endpoint" {
-  value = "${aws_elasticache_cluster.main.cache_nodes[0].address}:${aws_elasticache_cluster.main.cache_nodes[0].port}"
+  value       = "${aws_elasticache_replication_group.main.primary_endpoint_address}:${aws_elasticache_replication_group.main.port}"
+  description = "Primary Redis replication-group endpoint used by backend writers and BullMQ."
+}
+
+output "redis_primary_endpoint_address" {
+  value       = aws_elasticache_replication_group.main.primary_endpoint_address
+  description = "Primary Redis endpoint address for write traffic and automatic failover."
+}
+
+output "redis_reader_endpoint_address" {
+  value       = aws_elasticache_replication_group.main.reader_endpoint_address
+  description = "Reader endpoint address for read-only Redis clients."
+}
+
+output "redis_replication_group_id" {
+  value       = aws_elasticache_replication_group.main.id
+  description = "ElastiCache replication group ID."
 }
 
 output "redis_secret_arn" {
@@ -10,5 +26,5 @@ output "redis_secret_arn" {
 output "redis_auth_token" {
   value       = random_password.redis_auth.result
   sensitive   = true
-  description = "The Redis AUTH token generated for the cluster"
+  description = "The Redis AUTH token generated for the replication group"
 }

--- a/deployment/terraform/modules/elasticache/variables.tf
+++ b/deployment/terraform/modules/elasticache/variables.tf
@@ -37,3 +37,25 @@ variable "auth_token_enabled" {
   type        = bool
   default     = true
 }
+variable "replica_count" {
+  description = "Number of Redis read replicas. Set to at least 1 to enable automatic failover and Multi-AZ placement."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.replica_count >= 1
+    error_message = "replica_count must be at least 1 so ElastiCache can fail over to a replica in another subnet/AZ."
+  }
+}
+
+variable "at_rest_encryption_enabled" {
+  description = "Enable at-rest encryption for the Redis replication group."
+  type        = bool
+  default     = true
+}
+
+variable "apply_immediately" {
+  description = "Apply Redis replication group changes immediately instead of during the next maintenance window."
+  type        = bool
+  default     = true
+}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -30,6 +30,17 @@ The alert clears automatically once the backlog drains below the threshold.
 
 ## Redis and queues
 
+### ElastiCache Multi-AZ Failover
+
+Production Terraform now provisions Redis as an ElastiCache replication group with automatic failover enabled and at least one read replica. The backend should connect to the replication group's primary endpoint through `REDIS_URL` or the Terraform-injected `REDIS_HOST`; after an AZ failure, AWS promotes a replica and keeps the primary endpoint stable for reconnecting clients.
+
+Expected client behavior during failover:
+
+- Existing BullMQ and Redis connections may see a brief disconnect while the replica is promoted.
+- Backend probes call `getRedisUrl(true)` on retry paths so rotated credentials and endpoint-derived URLs are refreshed.
+- Queue workers should reconnect using `getConnectionOptions()` instead of pinning a single cache node hostname.
+- If Redis remains unavailable, queue-backed features degrade and idempotency falls back to the database-backed store.
+
 - **BullMQ** drives scheduled work: portfolio checks, rebalance jobs, analytics snapshots, and idempotency key cleanup.
 - **Connection:** `REDIS_URL` (default `redis://localhost:6379`). If Redis is unreachable, `probeRedis()` reports unavailable and the HTTP API still starts; queue-backed features are degraded.
 - **Scheduler:** When Redis is up, `startQueueScheduler()` (from `backend/src/queue/scheduler.ts`) registers repeatable cron jobs and enqueues one-off startup jobs (portfolio check, analytics snapshot, idempotency cleanup).


### PR DESCRIPTION
Closes #1485

## Summary

This PR adds Multi-AZ Redis failover support for the deployment Terraform and aligns the backend Redis endpoint handling with the replication-group setup.

## Changes

- Replaces the single-node `aws_elasticache_cluster` with an `aws_elasticache_replication_group`.
- Enables automatic failover and Multi-AZ placement with at least one replica by default.
- Adds module variables for replica count, at-rest encryption, and immediate application of Redis changes.
- Exposes the primary, reader, and replication-group endpoints from the Terraform module.
- Keeps ECS wired to the stable primary endpoint for writer/BullMQ traffic.
- Updates backend credential resolution so `REDIS_HOST` from Terraform can be converted into a Redis URL when `REDIS_URL` is not set.
- Documents expected ElastiCache failover behavior and reconnect expectations for queue workers.

## Verification

- Reviewed the remote branch diff and key changed snippets through GitHub API inspection.
- Did not run Terraform, install dependencies, build, tests, or CI per instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Multi-AZ Redis deployment with automatic failover and read replicas.
  * Added configurable replica count, encryption at rest, and immediate-apply settings.
  * Added Redis primary, reader, and replication group outputs.
  * Added support for connecting through `REDIS_HOST` when `REDIS_URL` is unavailable.
  * Made secret rotation optional when no rotation service is configured.

* **Documentation**
  * Documented Redis failover behavior, connection recovery, and queue feature degradation during outages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->