### PR TITLE
Operator role, schema-versioned upgrades, dependency-free CSV parser, DEX rollback

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -55,6 +55,7 @@ export async function main(argv: string[] = process.argv): Promise<void> {
     app.use(requestContextMiddleware)
     app.use(metricsMiddleware)
     app.use(express.json({ limit: '10mb' }))
+    app.use(express.text({ type: ['text/csv', 'application/csv'], limit: '25mb' }))
     app.use(express.urlencoded({ extended: true, limit: '10mb' }))
     app.set('trust proxy', 1)
 

--- a/backend/src/services/dex.ts
+++ b/backend/src/services/dex.ts
@@ -8,6 +8,7 @@ import {
     Memo
 } from '@stellar/stellar-sdk'
 import { Dec } from '../utils/decimal.js'
+import { logger } from '../utils/logger.js'
 import type { ExecutionExplanation } from '../types/index.js'
 
 export interface DEXTradeRequest {
@@ -256,6 +257,32 @@ export class StellarDEXService {
             rollback.success = rollbackResult.success
             rollback.rolledBackTrades = rollbackResult.rolledBackTrades
             rollback.failures = rollbackResult.failures
+        }
+
+        // A mid-sequence leg failed (or filled only partially) after other
+        // legs already succeeded: flag this for reconciliation with a
+        // structured log capturing exactly which legs succeeded vs failed,
+        // and whether rollback/compensation ran and how it went.
+        if (executedTrades.length > 0 && (failedTrades.length > 0 || partialFills.length > 0)) {
+            logger.warn('[DEX] rebalance_partial_failure', {
+                userAddress,
+                succeededLegs: executedTrades.map(t => ({
+                    tradeId: t.tradeId,
+                    fromAsset: t.fromAsset,
+                    toAsset: t.toAsset,
+                    executedAmount: t.executedAmount,
+                    status: t.status,
+                    txHash: t.txHash,
+                    rolledBack: t.rolledBack ?? false
+                })),
+                failedLegs: failedTrades.map(t => ({
+                    tradeId: t.tradeId,
+                    fromAsset: t.fromAsset,
+                    toAsset: t.toAsset,
+                    failureReason: t.failureReason
+                })),
+                rollback
+            })
         }
 
         const totalSlippageBps = slippageWeight > 0 ? (slippageWeightedSum / slippageWeight) : 0

--- a/backend/src/services/portfolioImportService.ts
+++ b/backend/src/services/portfolioImportService.ts
@@ -58,54 +58,192 @@ export function parseJsonPayload(payload: unknown): { rows: AllocationInputRow[]
   return { rows: [], formatError: 'JSON payload must be an array of {asset, allocation_pct} or an object with allocations: [...]' }
 }
 
-export function parseCsvText(csvText: string): { rows: AllocationInputRow[]; errors: BulkImportRowError[] } {
-  // Minimal CSV parser: supports commas and newlines, with optional double-quoted fields.
-  // No external deps.
+export type CsvParseOptions = {
+  /** Field delimiter. Defaults to ','. */
+  delimiter?: string
+  /**
+   * Maps a raw (lowercased, trimmed) header cell to a canonical field name
+   * ('asset' | 'allocation_pct'), so CSVs don't have to use those exact
+   * header names. Example: { symbol: 'asset', 'weight_pct': 'allocation_pct' }
+   */
+  headerMap?: Record<string, string>
+}
 
+/**
+ * Single-pass, dependency-free CSV state machine.
+ *
+ * Processes input one character at a time and emits a complete row as soon
+ * as its terminator is seen, so callers never have to materialize the whole
+ * file as an array of lines before parsing can begin. `push()` accepts
+ * successive chunks (e.g. from a file/network stream) and correctly resumes
+ * state across chunk boundaries, including a quote or CRLF pair split
+ * across two chunks.
+ */
+class IncrementalCsvParser {
+  private readonly delimiter: string
+  private field = ''
+  private row: string[] = []
+  private rowHasContent = false
+  private inQuotes = false
+  private pendingCr = false
+  private pendingQuoteBoundary = false
+
+  constructor(delimiter: string) {
+    this.delimiter = delimiter
+  }
+
+  *push(chunk: string): Generator<string[]> {
+    let i = 0
+
+    if (this.pendingCr) {
+      this.pendingCr = false
+      if (chunk[0] === '\n') i = 1
+    }
+
+    if (this.pendingQuoteBoundary) {
+      this.pendingQuoteBoundary = false
+      if (chunk[0] === '"') {
+        this.field += '"'
+        i = 1
+      } else {
+        this.inQuotes = false
+      }
+    }
+
+    for (; i < chunk.length; i++) {
+      const ch = chunk[i]
+
+      if (this.inQuotes) {
+        if (ch === '"') {
+          if (i + 1 < chunk.length) {
+            if (chunk[i + 1] === '"') {
+              this.field += '"'
+              i++
+              continue
+            }
+            this.inQuotes = false
+            continue
+          }
+          // Quote is the last char of this chunk: whether it closes the
+          // field or starts an escaped "" pair depends on the next chunk.
+          this.pendingQuoteBoundary = true
+          return
+        }
+        this.field += ch
+        this.rowHasContent = true
+        continue
+      }
+
+      if (ch === '"') {
+        this.inQuotes = true
+        this.rowHasContent = true
+        continue
+      }
+      if (ch === this.delimiter) {
+        this.row.push(this.field.trim())
+        this.field = ''
+        this.rowHasContent = true
+        continue
+      }
+      if (ch === '\r') {
+        if (i + 1 < chunk.length) {
+          if (chunk[i + 1] === '\n') i++
+          yield* this.endRow()
+          continue
+        }
+        this.pendingCr = true
+        yield* this.endRow()
+        return
+      }
+      if (ch === '\n') {
+        yield* this.endRow()
+        continue
+      }
+
+      this.field += ch
+      this.rowHasContent = true
+    }
+  }
+
+  /** Flush any trailing partial row once the input is exhausted. */
+  *end(): Generator<string[]> {
+    if (this.rowHasContent || this.field.length > 0 || this.row.length > 0) {
+      yield* this.endRow()
+    }
+  }
+
+  private *endRow(): Generator<string[]> {
+    // A genuinely blank line (no delimiters, no content) is skipped rather
+    // than emitted as a row -- matches CRLF/LF and trailing-empty-line handling.
+    if (!this.rowHasContent && this.field === '' && this.row.length === 0) {
+      return
+    }
+    this.row.push(this.field.trim())
+    const result = this.row
+    this.row = []
+    this.field = ''
+    this.rowHasContent = false
+    yield result
+  }
+}
+
+function resolveHeaderIndex(header: string[], canonicalField: string, headerMap?: Record<string, string>): number {
+  const direct = header.findIndex(h => h === canonicalField)
+  if (direct !== -1) return direct
+
+  if (headerMap) {
+    for (const [raw, mapped] of Object.entries(headerMap)) {
+      if (mapped !== canonicalField) continue
+      const idx = header.findIndex(h => h === raw.toLowerCase().trim())
+      if (idx !== -1) return idx
+    }
+  }
+
+  return -1
+}
+
+function toAllocationRow(
+  cols: string[],
+  assetIdx: number,
+  pctIdx: number,
+  rowNum: number,
+): { row: AllocationInputRow; errors: BulkImportRowError[] } {
   const errors: BulkImportRowError[] = []
+  const assetRaw = cols[assetIdx]
+  const pctRaw = cols[pctIdx]
 
-  const trimmed = csvText.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-  const lines = trimmed
-    .split('\n')
-    .map(l => l.trim())
-    .filter(l => l.length > 0)
+  const asset = typeof assetRaw === 'string' ? normalizeAssetCode(assetRaw) : ''
+  const pctStr = typeof pctRaw === 'string' ? pctRaw : ''
+  const pctNum = pctStr === '' ? NaN : Number(pctStr)
 
-  if (lines.length === 0) {
+  if (!asset) {
+    errors.push({ row: rowNum, field: 'asset', message: 'Asset is required' })
+  }
+  if (!Number.isFinite(pctNum)) {
+    errors.push({ row: rowNum, field: 'allocation_pct', message: 'allocation_pct must be a number' })
+  }
+
+  return { row: { asset, allocation_pct: pctNum }, errors }
+}
+
+export function parseCsvText(
+  csvText: string,
+  options: CsvParseOptions = {},
+): { rows: AllocationInputRow[]; errors: BulkImportRowError[] } {
+  const delimiter = options.delimiter ?? ','
+  const parser = new IncrementalCsvParser(delimiter)
+
+  const allRows: string[][] = []
+  for (const cols of parser.push(csvText)) allRows.push(cols)
+  for (const cols of parser.end()) allRows.push(cols)
+
+  if (allRows.length === 0) {
     return { rows: [], errors: [{ row: 1, field: 'csv', message: 'CSV is empty' }] }
   }
 
-  const parseLine = (line: string): string[] => {
-    const out: string[] = []
-    let cur = ''
-    let inQuotes = false
-
-    for (let i = 0; i < line.length; i++) {
-      const ch = line[i]
-      if (ch === '"') {
-        const next = line[i + 1]
-        // Handle escaped quote "" inside quotes
-        if (inQuotes && next === '"') {
-          cur += '"'
-          i++
-          continue
-        }
-        inQuotes = !inQuotes
-        continue
-      }
-      if (ch === ',' && !inQuotes) {
-        out.push(cur.trim())
-        cur = ''
-        continue
-      }
-      cur += ch
-    }
-    out.push(cur.trim())
-    return out
-  }
-
-  const header = parseLine(lines[0]).map(h => h.replace(/^\uFEFF/, '').trim().toLowerCase())
-  const assetIdx = header.findIndex(h => h === 'asset')
-  const pctIdx = header.findIndex(h => h === 'allocation_pct')
+  const header = allRows[0].map(h => h.replace(/^\uFEFF/, '').trim().toLowerCase())
+  const assetIdx = resolveHeaderIndex(header, 'asset', options.headerMap)
+  const pctIdx = resolveHeaderIndex(header, 'allocation_pct', options.headerMap)
 
   if (assetIdx === -1 || pctIdx === -1) {
     return {
@@ -121,29 +259,73 @@ export function parseCsvText(csvText: string): { rows: AllocationInputRow[]; err
   }
 
   const rows: AllocationInputRow[] = []
+  const errors: BulkImportRowError[] = []
 
-  for (let i = 1; i < lines.length; i++) {
-    const cols = parseLine(lines[i])
+  for (let i = 1; i < allRows.length; i++) {
     const rowNum = i + 1 // 1-based data row (including header row at 1)
-    const assetRaw = cols[assetIdx]
-    const pctRaw = cols[pctIdx]
-
-    const asset = typeof assetRaw === 'string' ? normalizeAssetCode(assetRaw) : ''
-    const pctStr = typeof pctRaw === 'string' ? pctRaw : ''
-
-    const pctNum = pctStr === '' ? NaN : Number(pctStr)
-
-    rows.push({ asset, allocation_pct: pctNum })
-
-    if (!asset) {
-      errors.push({ row: rowNum, field: 'asset', message: 'Asset is required' })
-    }
-    if (!Number.isFinite(pctNum)) {
-      errors.push({ row: rowNum, field: 'allocation_pct', message: 'allocation_pct must be a number' })
-    }
+    const { row, errors: rowErrors } = toAllocationRow(allRows[i], assetIdx, pctIdx, rowNum)
+    rows.push(row)
+    errors.push(...rowErrors)
   }
 
   return { rows, errors }
+}
+
+export type CsvStreamRowResult =
+  | { row: AllocationInputRow; error?: undefined }
+  | { row?: undefined; error: BulkImportRowError }
+
+/**
+ * Streaming counterpart to {@link parseCsvText}: consumes an (async) iterable
+ * of string chunks -- e.g. a large file/upload stream -- and yields each
+ * parsed row (or header error) as soon as it's available, so a caller never
+ * has to hold the whole CSV in memory at once.
+ */
+export async function* parseCsvStream(
+  source: AsyncIterable<string> | Iterable<string>,
+  options: CsvParseOptions = {},
+): AsyncGenerator<CsvStreamRowResult> {
+  const delimiter = options.delimiter ?? ','
+  const parser = new IncrementalCsvParser(delimiter)
+
+  let header: string[] | null = null
+  let assetIdx = -1
+  let pctIdx = -1
+  let dataRowCount = 0
+  let headerErrored = false
+
+  function* handleRow(cols: string[]): Generator<CsvStreamRowResult> {
+    if (!header) {
+      header = cols.map(h => h.replace(/^\uFEFF/, '').trim().toLowerCase())
+      assetIdx = resolveHeaderIndex(header, 'asset', options.headerMap)
+      pctIdx = resolveHeaderIndex(header, 'allocation_pct', options.headerMap)
+      if (assetIdx === -1 || pctIdx === -1) {
+        headerErrored = true
+        yield { error: { row: 1, field: 'header', message: 'CSV header must include columns: asset, allocation_pct' } }
+      }
+      return
+    }
+    if (headerErrored) return
+
+    dataRowCount++
+    const rowNum = dataRowCount + 1
+    const { row, errors } = toAllocationRow(cols, assetIdx, pctIdx, rowNum)
+    for (const error of errors) yield { error }
+    yield { row }
+  }
+
+  for await (const chunk of source) {
+    for (const cols of parser.push(chunk)) {
+      yield* handleRow(cols)
+    }
+  }
+  for (const cols of parser.end()) {
+    yield* handleRow(cols)
+  }
+
+  if (!header) {
+    yield { error: { row: 1, field: 'csv', message: 'CSV is empty' } }
+  }
 }
 
 async function validateAssetCodes(assets: string[]): Promise<{ valid: Set<string>; errors: BulkImportRowError[] }> {
@@ -321,8 +503,9 @@ export function coerceJsonRows(jsonRows: any[]): { rows: AllocationInputRow[]; e
 export async function buildAllocationsFromAnyPayload(params: {
   body: any
   contentType?: string
+  csvOptions?: CsvParseOptions
 }): Promise<{ format: 'csv' | 'json'; allocations?: Record<string, number>; validationError?: BulkImportValidationError }> {
-  const { body, contentType } = params
+  const { body, contentType, csvOptions } = params
   const format = guessFormat(body, contentType)
 
   if (format === 'json') {
@@ -348,9 +531,32 @@ export async function buildAllocationsFromAnyPayload(params: {
 
   // CSV
   const csvText = typeof body === 'string' ? body : (body?.csvText ?? '')
-  const parsed = parseCsvText(csvText)
+  const parsed = parseCsvText(csvText, csvOptions)
   const validated = await validateAndBuildAllocations({ rows: parsed.rows, initialRowErrors: parsed.errors })
   if ('errors' in validated) return { format, validationError: validated }
   return { format, allocations: validated.allocations }
+}
+
+/**
+ * Streaming counterpart to {@link buildAllocationsFromAnyPayload} for CSV
+ * sources too large to buffer as a single string (e.g. a large file/upload
+ * stream). Rows are validated as they're parsed; only the accumulated
+ * allocation map and any errors are held in memory, not the raw file.
+ */
+export async function buildAllocationsFromCsvStream(
+  source: AsyncIterable<string> | Iterable<string>,
+  options: CsvParseOptions = {},
+): Promise<{ allocations?: Record<string, number>; validationError?: BulkImportValidationError }> {
+  const rows: AllocationInputRow[] = []
+  const initialRowErrors: BulkImportRowError[] = []
+
+  for await (const result of parseCsvStream(source, options)) {
+    if (result.error) initialRowErrors.push(result.error)
+    if (result.row) rows.push(result.row)
+  }
+
+  const validated = await validateAndBuildAllocations({ rows, initialRowErrors })
+  if ('errors' in validated) return { validationError: validated }
+  return { allocations: validated.allocations }
 }
 

--- a/backend/src/test/dex.service.test.ts
+++ b/backend/src/test/dex.service.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { Horizon, Asset, Networks, Keypair } from "@stellar/stellar-sdk";
+import { Horizon, Asset, Account, Networks, Keypair } from "@stellar/stellar-sdk";
+
+vi.mock("../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
 import {
   StellarDEXService,
   DEXTradeRequest,
   DEXTradeExecutionResult,
 } from "../services/dex.js";
 import { Dec } from "../utils/decimal.js";
+import { logger } from "../utils/logger.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mock types and helpers
@@ -596,6 +602,142 @@ describe("StellarDEXService", () => {
       expect(result.explanation.failureReason).toBeDefined();
       expect(result.explanation.failureReason).toContain("bps");
       expect(result.explanation.rationale).toBeTruthy();
+    });
+  });
+
+  // ── Rollback on partial multi-leg failure (#1380) ────────────────────────
+
+  describe("Rollback on partial multi-leg failure", () => {
+    const MOCK_KEYPAIR = Keypair.random();
+
+    function tightOrderbook() {
+      return createOrderbook(
+        [{ price: 0.185, amount: 5000 }],
+        [{ price: 0.1855, amount: 5000 }],
+      );
+    }
+
+    function wideOrderbook() {
+      return createOrderbook(
+        [{ price: 0.00002, amount: 1000 }],
+        [{ price: 0.00005, amount: 1000 }],
+      );
+    }
+
+    function setupCommonMocks() {
+      vi.spyOn(service["server"], "fetchBaseFee").mockResolvedValue(100);
+      vi.spyOn(service as any, "resolveSigner").mockReturnValue(MOCK_KEYPAIR);
+      vi.spyOn(service["server"], "loadAccount").mockImplementation(
+        async () => new Account(MOCK_KEYPAIR.publicKey(), "1") as any,
+      );
+      vi.spyOn(service["server"], "submitTransaction").mockResolvedValue({
+        hash: "tx-hash",
+      } as any);
+      vi.spyOn(service["server"], "offers").mockReturnValue({
+        forAccount: () => ({
+          limit: () => ({ call: vi.fn().mockResolvedValue({ records: [] }) }),
+        }),
+      } as any);
+      vi.spyOn(service as any, "tryGetAverageTradePrice").mockResolvedValue(
+        undefined,
+      );
+    }
+
+    // Every pair resolves to a healthy orderbook, except USDC->BTC which is
+    // deliberately too wide to clear `maxSpreadBps` -- simulating the second
+    // leg of a three-leg rebalance failing after the first already executed.
+    function mockPerPairOrderbook() {
+      vi.spyOn(service["server"], "orderbook").mockImplementation(((
+        selling: Asset,
+        buying: Asset,
+      ) => {
+        const sellCode = selling.isNative() ? "XLM" : selling.getCode();
+        const buyCode = buying.isNative() ? "XLM" : buying.getCode();
+        const isWideLeg = sellCode === "USDC" && buyCode === "BTC";
+        return {
+          call: vi
+            .fn()
+            .mockResolvedValue(isWideLeg ? wideOrderbook() : tightOrderbook()),
+        } as any;
+      }) as any);
+    }
+
+    it("rolls back the successfully executed first leg when the second of three legs fails", async () => {
+      setupCommonMocks();
+      mockPerPairOrderbook();
+
+      const trades: DEXTradeRequest[] = [
+        { tradeId: "leg-1", fromAsset: "XLM", toAsset: "USDC", amount: 100 },
+        { tradeId: "leg-2", fromAsset: "USDC", toAsset: "BTC", amount: 50 },
+        { tradeId: "leg-3", fromAsset: "BTC", toAsset: "XLM", amount: 1 },
+      ];
+
+      const result = await service.executeRebalanceTrades(
+        MOCK_KEYPAIR.publicKey(),
+        trades,
+        { maxSpreadBps: 200 },
+      );
+
+      expect(result.status).toBe("failed");
+      // The loop stops at the first failure, so the third leg is never attempted.
+      expect(result.executedTrades.map((t) => t.tradeId)).toEqual(["leg-1"]);
+      expect(result.failedTrades.map((t) => t.tradeId)).toEqual(["leg-2"]);
+
+      // Compensation ran for the leg that had already succeeded, rather than
+      // leaving the portfolio silently partially rebalanced.
+      expect(result.rollback.attempted).toBe(true);
+      expect(result.rollback.success).toBe(true);
+      expect(result.rollback.rolledBackTrades).toBe(1);
+      expect(result.executedTrades[0].rolledBack).toBe(true);
+      expect(result.executedTrades[0].rollbackTxHash).toBeDefined();
+    });
+
+    it("logs rebalance_partial_failure capturing which legs succeeded and which failed", async () => {
+      setupCommonMocks();
+      mockPerPairOrderbook();
+
+      const trades: DEXTradeRequest[] = [
+        { tradeId: "leg-1", fromAsset: "XLM", toAsset: "USDC", amount: 100 },
+        { tradeId: "leg-2", fromAsset: "USDC", toAsset: "BTC", amount: 50 },
+      ];
+
+      await service.executeRebalanceTrades(MOCK_KEYPAIR.publicKey(), trades, {
+        maxSpreadBps: 200,
+      });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        "[DEX] rebalance_partial_failure",
+        expect.objectContaining({
+          succeededLegs: expect.arrayContaining([
+            expect.objectContaining({ tradeId: "leg-1" }),
+          ]),
+          failedLegs: expect.arrayContaining([
+            expect.objectContaining({ tradeId: "leg-2" }),
+          ]),
+        }),
+      );
+    });
+
+    it("does not attempt rollback or log a partial failure when the single leg that fails never executed anything", async () => {
+      setupCommonMocks();
+      vi.spyOn(service["server"], "orderbook").mockReturnValue({
+        call: vi.fn().mockResolvedValue(wideOrderbook()),
+      } as any);
+      (logger.warn as any).mockClear();
+
+      const result = await service.executeRebalanceTrades(
+        MOCK_KEYPAIR.publicKey(),
+        [{ tradeId: "leg-1", fromAsset: "XLM", toAsset: "USDC", amount: 100 }],
+        { maxSpreadBps: 200 },
+      );
+
+      expect(result.status).toBe("failed");
+      expect(result.executedTrades).toEqual([]);
+      expect(result.rollback.attempted).toBe(false);
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        "[DEX] rebalance_partial_failure",
+        expect.anything(),
+      );
     });
   });
 

--- a/backend/src/test/portfolioImportService.test.ts
+++ b/backend/src/test/portfolioImportService.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
   parseCsvText,
+  parseCsvStream,
   validateAndBuildAllocations,
   coerceJsonRows,
 } from '../services/portfolioImportService.js'
@@ -120,5 +121,139 @@ describe('portfolioImportService - structured error array', () => {
 
     const { errors } = coerceJsonRows(jsonRows)
     expect(errors.length).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe('parseCsvText - dependency-free parser edge cases', () => {
+  it('parses quoted fields containing embedded commas', () => {
+    const csv = 'asset,allocation_pct\n"XLM, primary",60\nUSDC,40'
+    const { rows, errors } = parseCsvText(csv)
+    expect(errors.length).toBe(0)
+    expect(rows[0].asset).toBe('XLM, PRIMARY')
+    expect(rows[1].asset).toBe('USDC')
+  })
+
+  it('handles escaped double-quotes ("") inside quoted fields', () => {
+    const csv = 'asset,allocation_pct\n"XL""M",60\nUSDC,40'
+    const { rows, errors } = parseCsvText(csv)
+    expect(errors.length).toBe(0)
+    expect(rows[0].asset).toBe('XL"M')
+  })
+
+  it('handles CRLF line endings identically to LF', () => {
+    const csv = 'asset,allocation_pct\r\nXLM,60\r\nUSDC,40\r\n'
+    const { rows, errors } = parseCsvText(csv)
+    expect(errors.length).toBe(0)
+    expect(rows).toEqual([
+      { asset: 'XLM', allocation_pct: 60 },
+      { asset: 'USDC', allocation_pct: 40 },
+    ])
+  })
+
+  it('skips trailing and embedded blank lines without producing phantom rows', () => {
+    const csv = 'asset,allocation_pct\n\nXLM,60\n\nUSDC,40\n\n\n'
+    const { rows, errors } = parseCsvText(csv)
+    expect(errors.length).toBe(0)
+    expect(rows).toEqual([
+      { asset: 'XLM', allocation_pct: 60 },
+      { asset: 'USDC', allocation_pct: 40 },
+    ])
+  })
+
+  it('reports a row-level error for a malformed (non-numeric) allocation_pct', () => {
+    const csv = 'asset,allocation_pct\nXLM,sixty\nUSDC,40'
+    const { rows, errors } = parseCsvText(csv)
+    expect(rows[0].allocation_pct).toBeNaN()
+    expect(errors.some(e => e.field === 'allocation_pct' && e.row === 2)).toBe(true)
+  })
+
+  it('reports a row-level error for a missing asset column value', () => {
+    const csv = 'asset,allocation_pct\n,60\nUSDC,40'
+    const { errors } = parseCsvText(csv)
+    expect(errors.some(e => e.field === 'asset' && e.row === 2)).toBe(true)
+  })
+
+  it('supports a configurable delimiter', () => {
+    const csv = 'asset;allocation_pct\nXLM;60\nUSDC;40'
+    const { rows, errors } = parseCsvText(csv, { delimiter: ';' })
+    expect(errors.length).toBe(0)
+    expect(rows).toEqual([
+      { asset: 'XLM', allocation_pct: 60 },
+      { asset: 'USDC', allocation_pct: 40 },
+    ])
+  })
+
+  it('supports header-row mapping to canonical field names', () => {
+    const csv = 'symbol,weight_pct\nXLM,60\nUSDC,40'
+    const { rows, errors } = parseCsvText(csv, {
+      headerMap: { symbol: 'asset', weight_pct: 'allocation_pct' },
+    })
+    expect(errors.length).toBe(0)
+    expect(rows).toEqual([
+      { asset: 'XLM', allocation_pct: 60 },
+      { asset: 'USDC', allocation_pct: 40 },
+    ])
+  })
+
+  it('rejects a header missing required columns', () => {
+    const csv = 'foo,bar\nXLM,60'
+    const { rows, errors } = parseCsvText(csv)
+    expect(rows).toEqual([])
+    expect(errors[0].field).toBe('header')
+  })
+
+  it('treats an empty CSV as an error', () => {
+    const { rows, errors } = parseCsvText('')
+    expect(rows).toEqual([])
+    expect(errors[0].field).toBe('csv')
+  })
+})
+
+describe('parseCsvStream - chunked streaming parser', () => {
+  async function collect(chunks: string[], options?: Parameters<typeof parseCsvStream>[1]) {
+    const rows: { asset: string; allocation_pct: number }[] = []
+    const errors: string[] = []
+    async function* gen() {
+      for (const c of chunks) yield c
+    }
+    for await (const result of parseCsvStream(gen(), options)) {
+      if (result.row) rows.push(result.row)
+      if (result.error) errors.push(result.error.field)
+    }
+    return { rows, errors }
+  }
+
+  it('parses a CSV delivered as many small chunks, split mid-field', async () => {
+    const chunks = ['as', 'set,all', 'ocation_pct\nXL', 'M,6', '0\nUSD', 'C,40']
+    const { rows, errors } = await collect(chunks)
+    expect(errors.length).toBe(0)
+    expect(rows).toEqual([
+      { asset: 'XLM', allocation_pct: 60 },
+      { asset: 'USDC', allocation_pct: 40 },
+    ])
+  })
+
+  it('correctly resolves an escaped quote pair split across a chunk boundary', async () => {
+    // "XL""M" split right between the two quote characters of the pair
+    const chunks = ['asset,allocation_pct\n"XL"', '"M",60']
+    const { rows, errors } = await collect(chunks)
+    expect(errors.length).toBe(0)
+    expect(rows[0].asset).toBe('XL"M')
+  })
+
+  it('correctly resolves a CRLF terminator split across a chunk boundary', async () => {
+    const chunks = ['asset,allocation_pct\r', '\nXLM,60\r', '\nUSDC,40']
+    const { rows, errors } = await collect(chunks)
+    expect(errors.length).toBe(0)
+    expect(rows).toEqual([
+      { asset: 'XLM', allocation_pct: 60 },
+      { asset: 'USDC', allocation_pct: 40 },
+    ])
+  })
+
+  it('yields a header error for a stream missing required columns', async () => {
+    const { rows, errors } = await collect(['foo,bar\n', 'XLM,60'])
+    expect(rows.length).toBe(0)
+    expect(errors).toContain('header')
   })
 })

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -17,6 +17,7 @@ mod slippage;
 mod stop_loss;
 mod strategies;
 mod templates;
+mod upgrade;
 #[cfg(all(test, feature = "testutils"))]
 mod test;
 #[cfg(all(test, feature = "testutils"))]
@@ -90,7 +91,19 @@ impl PortfolioRebalancer {
             .instance()
             .set(&DataKey::EmergencyStop, &false);
         env.storage().instance().set(&DataKey::Initialized, &true);
+        // A freshly initialized contract has no legacy storage to migrate,
+        // so it starts on the current schema directly.
+        env.storage()
+            .instance()
+            .set(&DataKey::SchemaVersion, &CURRENT_STORAGE_SCHEMA_VERSION);
         Ok(())
+    }
+
+    /// Currently persisted storage schema version (see
+    /// `CURRENT_STORAGE_SCHEMA_VERSION`), advanced automatically by
+    /// `execute_upgrade` via `migrate_storage`.
+    pub fn storage_schema_version(env: Env) -> u32 {
+        upgrade::current_schema_version(&env)
     }
 
     pub fn get_admin(env: Env) -> Address {
@@ -468,14 +481,57 @@ impl PortfolioRebalancer {
         Ok(results)
     }
 
+    /// Force-rebalance a portfolio, bypassing the cooldown. Callable by the
+    /// contract Admin or by any registered Operator (see `add_operator`) --
+    /// `caller` must be one of the two, and must authorize the call itself.
     pub fn admin_force_rebalance(
         env: Env,
+        caller: Address,
         portfolio_id: u64,
         actual_balances: Map<Address, i128>,
     ) -> Result<(), Error> {
+        caller.require_auth();
+
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        admin.require_auth();
-        Self::execute_rebalance_internal(&env, portfolio_id, actual_balances, true, Some(admin))
+        if caller != admin && !Self::is_operator(env.clone(), caller.clone()) {
+            return Err(Error::Unauthorized);
+        }
+
+        Self::execute_rebalance_internal(&env, portfolio_id, actual_balances, true, Some(caller))
+    }
+
+    /// Admin-only: register `operator` as a scoped operator, allowed to call
+    /// `admin_force_rebalance` but nothing else that's admin-only (e.g.
+    /// `upgrade`, `set_fee_config` remain Admin-only).
+    pub fn add_operator(env: Env, operator: Address) {
+        require_admin(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Operator(operator.clone()), &true);
+        env.events().publish(
+            (Symbol::new(&env, "operator_added"),),
+            operator,
+        );
+    }
+
+    /// Admin-only: revoke a previously registered operator.
+    pub fn remove_operator(env: Env, operator: Address) {
+        require_admin(&env);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Operator(operator.clone()));
+        env.events().publish(
+            (Symbol::new(&env, "operator_removed"),),
+            operator,
+        );
+    }
+
+    /// Whether `address` is currently a registered operator.
+    pub fn is_operator(env: Env, address: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Operator(address))
+            .unwrap_or(false)
     }
 
     pub fn set_emergency_stop(env: Env, stop: bool) {
@@ -769,7 +825,11 @@ impl PortfolioRebalancer {
             .instance()
             .set(&DataKey::WasmHash, &queued.new_wasm_hash);
         env.storage().instance().remove(&DataKey::QueuedUpgrade);
-        
+
+        // Bring storage up to the current schema before any new
+        // functionality introduced by this upgrade is exposed.
+        upgrade::migrate_storage(&env);
+
         env.events().publish(
             ("portfolio", "upgraded"),
             UpgradeEvent {

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -2176,7 +2176,7 @@ fn test_admin_force_rebalance_bypasses_cooldown() {
     });
 
     let actual_balances = Map::new(&env);
-    client.admin_force_rebalance(&pid, &actual_balances);
+    client.admin_force_rebalance(&admin, &pid, &actual_balances);
 
     let portfolio = client.get_portfolio(&pid);
     assert_eq!(portfolio.last_rebalance, 10010);
@@ -2207,11 +2207,11 @@ fn test_admin_force_rebalance_non_admin_rejected() {
             invoke: &MockAuthInvoke {
                 contract: &contract_id,
                 fn_name: "admin_force_rebalance",
-                args: (pid, actual_balances.clone()).into_val(&env),
+                args: (unauthorized.clone(), pid, actual_balances.clone()).into_val(&env),
                 sub_invokes: &[],
             },
         }])
-        .admin_force_rebalance(&pid, &actual_balances);
+        .admin_force_rebalance(&unauthorized, &pid, &actual_balances);
 }
 
 #[test]
@@ -2234,7 +2234,162 @@ fn test_admin_force_rebalance_admin_success() {
     // `admin_force_rebalance` and the portfolio user auth required by the
     // inner `execute_rebalance_internal`.
     let actual_balances = Map::new(&env);
-    client.admin_force_rebalance(&pid, &actual_balances);
+    client.admin_force_rebalance(&admin, &pid, &actual_balances);
+}
+
+// ── Issue #1377: operator role, scoped to admin_force_rebalance ─────────
+
+#[test]
+fn test_operator_can_force_rebalance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 10000;
+    });
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    assert!(!client.is_operator(&operator));
+    client.add_operator(&operator);
+    assert!(client.is_operator(&operator));
+
+    let mut allocations = Map::new(&env);
+    let asset = create_token_and_mint(&env, &admin, &user, 100);
+    allocations.set(asset.clone(), 10000);
+    let pid = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
+    client.deposit(&pid, &asset, &100, &String::from_str(&env, ""));
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 10010;
+    });
+
+    // Operator can force-rebalance without holding admin rights.
+    let actual_balances = Map::new(&env);
+    client.admin_force_rebalance(&operator, &pid, &actual_balances);
+
+    let portfolio = client.get_portfolio(&pid);
+    assert_eq!(portfolio.last_rebalance, 10010);
+}
+
+#[test]
+fn test_revoked_operator_rejected_from_force_rebalance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    let mut allocations = Map::new(&env);
+    let asset = Address::generate(&env);
+    allocations.set(asset, 10000);
+    let pid = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
+
+    client.add_operator(&operator);
+    client.remove_operator(&operator);
+    assert!(!client.is_operator(&operator));
+
+    let actual_balances = Map::new(&env);
+    let result = client.try_admin_force_rebalance(&operator, &pid, &actual_balances);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_non_operator_rejected_from_force_rebalance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    let mut allocations = Map::new(&env);
+    let asset = Address::generate(&env);
+    allocations.set(asset, 10000);
+    let pid = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
+
+    let actual_balances = Map::new(&env);
+    let result = client.try_admin_force_rebalance(&stranger, &pid, &actual_balances);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+#[should_panic]
+fn test_operator_rejected_from_admin_only_upgrade() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    let operator = Address::generate(&env);
+    client.add_operator(&operator);
+
+    let new_wasm_hash = env.deployer().upload_contract_wasm(&[0u8; 0] as &[u8]);
+
+    // Operators are scoped to `admin_force_rebalance` only: `queue_upgrade`
+    // still fetches the real Admin from storage and requires auth from
+    // exactly that address, so an operator-only auth mock fails here.
+    client
+        .mock_auths(&[MockAuth {
+            address: &operator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "queue_upgrade",
+                args: (new_wasm_hash.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .queue_upgrade(&new_wasm_hash);
+}
+
+#[test]
+#[should_panic]
+fn test_operator_rejected_from_admin_only_set_fee_config() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    let operator = Address::generate(&env);
+    client.add_operator(&operator);
+
+    let config = FeeConfig {
+        platform_name: String::from_str(&env, "test"),
+        fee_bps: 25,
+        fee_recipient: Address::generate(&env),
+        enabled: true,
+    };
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &operator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "set_fee_config",
+                args: (config.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .set_fee_config(&config);
 }
 
 #[test]
@@ -3586,6 +3741,102 @@ fn test_timelock_upgrade_post_delay_success() {
         })
         .collect();
     assert!(!upgrade_events.is_empty(), "upgraded event should be emitted");
+}
+
+// ── Issue #1378: schema-version-aware migrate_storage() in upgrade() ────
+
+#[test]
+fn test_fresh_initialize_starts_at_current_schema_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &reflector_id);
+
+    assert_eq!(client.storage_schema_version(), CURRENT_STORAGE_SCHEMA_VERSION);
+}
+
+#[test]
+fn test_execute_upgrade_migrates_legacy_portfolio_storage() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    let mut allocations = Map::new(&env);
+    let asset = Address::generate(&env);
+    allocations.set(asset, 10000);
+    let pid = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
+
+    // Simulate a contract that predates both the strategy-aware portfolio
+    // schema and storage-schema versioning: downgrade the just-created
+    // PortfolioV2 entry to the old LegacyPortfolio shape under the old key,
+    // and reset SchemaVersion to "never migrated".
+    env.as_contract(&contract_id, || {
+        let current: Portfolio = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PortfolioV2(pid))
+            .unwrap();
+        let legacy = LegacyPortfolio {
+            user: current.user,
+            target_allocations: current.target_allocations,
+            current_balances: current.current_balances,
+            asset_decimals: current.asset_decimals,
+            rebalance_threshold: current.rebalance_threshold,
+            slippage_tolerance: current.slippage_tolerance,
+            slippage_policy_version: current.slippage_policy_version,
+            last_rebalance: current.last_rebalance,
+            total_value: current.total_value,
+            is_active: current.is_active,
+            pause_reason: current.pause_reason,
+            circuit_breaker_config: current.circuit_breaker_config,
+            global_max_slippage_bps: current.global_max_slippage_bps,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Portfolio(pid), &legacy);
+        env.storage().persistent().remove(&DataKey::PortfolioV2(pid));
+        env.storage().instance().remove(&DataKey::SchemaVersion);
+    });
+
+    assert_eq!(client.storage_schema_version(), 0);
+
+    // Queue + execute an upgrade -- migrate_storage() should run as part of
+    // execute_upgrade, before any new functionality is exposed.
+    let new_wasm_hash = env.deployer().upload_contract_wasm(&[0u8; 0] as &[u8]);
+    client.queue_upgrade(&new_wasm_hash);
+    env.ledger().with_mut(|li| {
+        li.timestamp = TIMELOCK_DELAY_SECONDS + 1;
+    });
+    client.execute_upgrade();
+
+    // schema_version is incremented and persisted post-migration.
+    assert_eq!(client.storage_schema_version(), CURRENT_STORAGE_SCHEMA_VERSION);
+
+    // Old-format data was migrated and is readable post-upgrade -- checked
+    // directly against storage (not via a getter that itself lazily
+    // migrates on read) to prove migrate_storage() did the work eagerly.
+    env.as_contract(&contract_id, || {
+        assert!(
+            !env.storage().persistent().has(&DataKey::Portfolio(pid)),
+            "legacy key should have been removed by migration"
+        );
+        let migrated: Portfolio = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PortfolioV2(pid))
+            .expect("PortfolioV2 should exist after migration");
+        assert_eq!(migrated.user, user);
+        assert_eq!(migrated.strategy, StrategyType::Threshold);
+    });
 }
 
 #[test]

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -15,6 +15,13 @@ pub const CURRENT_SLIPPAGE_POLICY_VERSION: u32 = SLIPPAGE_POLICY_VERSION_V1;
 pub const CONTRACT_VERSION: u32 = 2;
 /// Contract event schema version matching backend expected schema version.
 pub const CONTRACT_EVENT_SCHEMA_VERSION: u32 = 1;
+/// Persistent storage schema version. Tracked separately from
+/// `CONTRACT_EVENT_SCHEMA_VERSION` (which only versions emitted event
+/// shapes): this one versions the on-chain storage layout itself and is
+/// advanced by `upgrade::migrate_storage`, which runs automatically as part
+/// of `execute_upgrade`. A contract with no stored value is treated as
+/// version 0 (pre-versioning / legacy storage).
+pub const CURRENT_STORAGE_SCHEMA_VERSION: u32 = 1;
 /// Maximum number of assets allowed in a single portfolio (#296).
 ///
 /// Soroban persistent storage entries are bounded by ledger entry size limits.
@@ -274,6 +281,11 @@ pub enum DataKey {
     AssetSlippage(Address),
     Template(String),
     TemplateNames,
+    /// Persisted storage schema version; see `CURRENT_STORAGE_SCHEMA_VERSION`.
+    SchemaVersion,
+    /// Marks `Address` as a registered operator (scoped permission distinct
+    /// from full Admin rights) when present and `true`.
+    Operator(Address),
 }
 
 #[contracttype]
@@ -326,6 +338,9 @@ pub enum Error {
     TemplateNotFound = 34,
     TemplateAlreadyExists = 35,
     TooManyTemplates = 36,
+    /// Caller authenticated successfully but is neither the contract admin
+    /// nor a registered operator for an operator-eligible entrypoint.
+    Unauthorized = 37,
 }
 
 #[contracttype]

--- a/contracts/src/upgrade.rs
+++ b/contracts/src/upgrade.rs
@@ -1,19 +1,71 @@
-use soroban_sdk::{Env, BytesN, Address};
-use crate::types::DataKey;
+use soroban_sdk::Env;
 
-pub fn upgrade(env: &Env, new_wasm_hash: BytesN<32>) {
-    let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-    admin.require_auth();
-    
-    // Migration guard: Validate existing storage schema before activating new WASM
-    if !env.storage().instance().has(&DataKey::Admin) {
-        panic!("Migration guard failed: invalid schema");
+use crate::types::{DataKey, LegacyPortfolio, Portfolio, CURRENT_STORAGE_SCHEMA_VERSION};
+
+/// Returns the currently persisted storage schema version, or 0 if the
+/// contract predates schema versioning (never migrated / freshly initialized
+/// before this feature existed).
+pub fn current_schema_version(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::SchemaVersion)
+        .unwrap_or(0)
+}
+
+/// Schema-version-aware migration hook, dispatched by the stored
+/// `schema_version`. Each branch below brings storage from one version to
+/// the next; run them in order so a contract several versions behind catches
+/// up in a single call. Idempotent — calling this when storage is already at
+/// `CURRENT_STORAGE_SCHEMA_VERSION` is a no-op.
+///
+/// Called automatically from `execute_upgrade`, after the new WASM is
+/// activated and before the upgrade is considered complete, so storage is
+/// never left readable-but-stale by new contract logic.
+pub fn migrate_storage(env: &Env) {
+    let mut version = current_schema_version(env);
+    if version >= CURRENT_STORAGE_SCHEMA_VERSION {
+        return;
     }
-    
-    env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
-    
-    env.events().publish(
-        ("upgrade", "executed"),
-        new_wasm_hash
-    );
+
+    if version < 1 {
+        migrate_v0_to_v1(env);
+        version = 1;
+    }
+
+    env.storage().instance().set(&DataKey::SchemaVersion, &version);
+}
+
+/// v0 -> v1: portfolios used to be stored as `LegacyPortfolio` (no strategy
+/// fields) under `DataKey::Portfolio(id)`. Reads already migrate a portfolio
+/// on access (see `get_config_view`), but this sweeps any that haven't been
+/// touched yet so storage is fully current right after an upgrade rather
+/// than depending on incidental future reads.
+fn migrate_v0_to_v1(env: &Env) {
+    let next_id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::NextPortfolioId)
+        .unwrap_or(1);
+
+    for portfolio_id in 0..next_id {
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::PortfolioV2(portfolio_id))
+        {
+            continue;
+        }
+
+        if let Some(legacy) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, LegacyPortfolio>(&DataKey::Portfolio(portfolio_id))
+        {
+            let migrated: Portfolio = legacy.into();
+            env.storage()
+                .persistent()
+                .set(&DataKey::PortfolioV2(portfolio_id), &migrated);
+            env.storage().persistent().remove(&DataKey::Portfolio(portfolio_id));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- **Operator role (#1377)**: `add_operator` / `remove_operator` / `is_operator` register a scoped Operator role, stored separately from Admin. `admin_force_rebalance` now accepts a `caller` and authorizes either the Admin or a registered Operator; `operator_added` / `operator_removed` events are emitted on grant/revoke. Every other admin-only entrypoint (`queue_upgrade`, `set_fee_config`, ...) is untouched and still fetches the real Admin address from storage, so operators remain rejected from those by construction. Tests cover operator grant, revoke, the scoped force-rebalance success path, and rejection from admin-only entrypoints.

- **Schema-versioned storage migration (#1378)**: a new `upgrade` module tracks a persisted `SchemaVersion` and exposes `migrate_storage()`, dispatched by version. It's called automatically from `execute_upgrade` right after the new WASM is activated, and sweeps any remaining `LegacyPortfolio` entries to `PortfolioV2`. A fresh `initialize()` starts directly on the current schema (nothing to migrate). Added `storage_schema_version()` view fn. Test simulates an old-schema portfolio and confirms `execute_upgrade` migrates it and persists the bumped version.

- **Dependency-free CSV parser (#1379)**: rewrote `parseCsvText` around a single-pass character state machine (`IncrementalCsvParser`) instead of eagerly splitting the whole file into a line array. Added a configurable `delimiter` option, `headerMap` for non-default header names, and a true streaming counterpart `parseCsvStream` that consumes chunks incrementally (correctly resuming state across a chunk boundary that splits a `\r\n` or an escaped `""` pair) for large-file ingestion without buffering the whole CSV. Also registered `express.text()` for `text/csv`/`application/csv` in `index.ts` — without it CSV bodies never reached `req.body` in production (only the test harness had this middleware). New tests cover quoted/escaped fields, embedded commas, CRLF vs LF, blank-line handling, malformed rows, delimiter/header-mapping, and streaming across chunk boundaries.

- **DEX rollback on partial failure (#1380)**: the existing rollback/compensation path in `dex.ts` is now paired with a `rebalance_partial_failure` structured log emitted whenever some legs already executed and a later leg failed or only partially filled, capturing which legs succeeded, which failed, and the rollback outcome — so a partially-rebalanced portfolio is never left un-flagged. New tests simulate a failure on the second of three legs and assert the first leg's compensating trade runs, and that a single leg failing with nothing yet executed does not spuriously trigger rollback/logging.

## Test plan
- [x] `cargo test --features testutils` (contracts) — 152 passed
- [x] `npx vitest run src/test/dex.service.test.ts` — 29 passed
- [x] `npx vitest run src/test/portfolioImportService.test.ts src/test/portfolioImport.routes.integration.test.ts` — 23 passed
- [x] `npx tsc --noEmit` — no new errors introduced

Closes #1377
Closes #1378
Closes #1379
Closes #1380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CSV imports now support large files, custom delimiters, header mapping, quoted fields, and streamed processing.
  - Added operator access controls for authorized portfolio rebalancing.
  - Added operator management and storage schema version visibility.
  - Contract upgrades now automatically migrate stored portfolio data.

- **Bug Fixes**
  - Improved CSV parsing across chunk boundaries, quoted values, escaped quotes, and line endings.
  - Partial rebalance failures now roll back completed trades when possible and provide clearer warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->