### PR TITLE
Feat/batch rebalance rpc failover indexer gap metadata ttl

### DIFF
--- a/backend/src/api/admin.routes.ts
+++ b/backend/src/api/admin.routes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express'
 import { requireAdmin } from '../middleware/auth.js'
 import { databaseService } from '../services/databaseService.js'
+import { issuerMetadataService } from '../services/issuerMetadataService.js'
 import { logger } from '../utils/logger.js'
 import { ok, fail } from '../utils/apiResponse.js'
 import { getErrorMessage } from '../utils/helpers.js'
@@ -122,5 +123,61 @@ adminRouter.get('/audit-log', requireAdmin, async (req: Request, res: Response) 
   } catch (error) {
     logger.error('[ADMIN] Failed to query audit log', { error: getErrorMessage(error) })
     return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+  }
+})
+
+// ── Issuer metadata cache (TTL + stale-serve + manual refresh) ───────────────
+
+adminRouter.get('/issuer-metadata/:issuer', requireAdmin, async (req: Request, res: Response) => {
+  try {
+    const issuer = req.params.issuer
+    if (!issuer) {
+      return fail(res, 400, 'VALIDATION_ERROR', 'issuer account is required')
+    }
+    const result = await issuerMetadataService.getMetadataWithStatus(issuer)
+    if (!result) {
+      return fail(res, 404, 'NOT_FOUND', 'No metadata available for this issuer account')
+    }
+    return ok(res, {
+      issuer,
+      fetchedAtMs: result.fetchedAtMs,
+      expiresAtMs: result.expiresAtMs,
+      stale: result.stale,
+      source: result.source,
+      data: result.data
+    })
+  } catch (error) {
+    logger.error('[ADMIN] Failed to read issuer metadata', { error: getErrorMessage(error), issuer: req.params.issuer })
+    return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+  }
+})
+
+adminRouter.post('/issuer-metadata/:issuer/refresh', requireAdmin, async (req: Request, res: Response) => {
+  try {
+    const issuer = req.params.issuer
+    if (!issuer) {
+      return fail(res, 400, 'VALIDATION_ERROR', 'issuer account is required')
+    }
+    const actor = req.adminPublicKey ?? 'unknown'
+    logger.info('[ADMIN] Issuer metadata refresh requested', { issuer, adminPublicKey: actor })
+
+    const result = await issuerMetadataService.forceRefreshMetadata(issuer)
+    logAdminAction(actor, 'issuer_metadata_refresh', issuer, null, {
+      stale: result.stale,
+      source: result.source,
+      fetchedAtMs: result.fetchedAtMs
+    })
+
+    return ok(res, {
+      issuer,
+      stale: result.stale,
+      source: result.source,
+      fetchedAtMs: result.fetchedAtMs,
+      expiresAtMs: result.expiresAtMs,
+      data: result.data
+    })
+  } catch (error) {
+    logger.warn('[ADMIN] Issuer metadata refresh failed', { error: getErrorMessage(error), issuer: req.params.issuer })
+    return fail(res, 502, 'UPSTREAM_ERROR', `Failed to refresh issuer metadata: ${getErrorMessage(error)}`)
   }
 })

--- a/backend/src/api/portfolios.routes.ts
+++ b/backend/src/api/portfolios.routes.ts
@@ -16,12 +16,13 @@ import { createPortfolioSchema, clonePortfolioSchema, portfolioExportQuerySchema
 import { getAuthConfig } from '../services/authService.js'
 import { getFeatureFlags } from '../config/featureFlags.js'
 import { getPortfolioExport, getRebalanceHistoryExport, setExportSchedule, getExportSchedule, deleteExportSchedule } from '../services/portfolioExportService.js'
+import { buildRebalancePlan, buildBatchRebalancePlan } from '../services/rebalancePlan.js'
 
 import { logger } from '../utils/logger.js'
 import { getErrorObject, getErrorMessage } from '../utils/helpers.js'
 import { ok, fail } from '../utils/apiResponse.js'
 import { ConflictError } from '../types/index.js'
-import { createPortfolioSchema, updatePortfolioSchema, portfolioExportQuerySchema, rebalancePortfolioSchema, portfolioHistoryQuerySchema, portfolioRebalanceHistoryQuerySchema, rebalanceHistoryExportQuerySchema, exportScheduleSchema, createDraftSchema, updateDraftSchema, portfolioSummaryQuerySchema } from './validation.js'
+import { createPortfolioSchema, updatePortfolioSchema, portfolioExportQuerySchema, rebalancePortfolioSchema, portfolioHistoryQuerySchema, portfolioRebalanceHistoryQuerySchema, rebalanceHistoryExportQuerySchema, exportScheduleSchema, createDraftSchema, updateDraftSchema, portfolioSummaryQuerySchema, batchRebalancePlansSchema } from './validation.js'
 import { buildPortfolioSummaries } from '../services/portfolioSummary.js'
 import type { Portfolio } from '../types/index.js'
 
@@ -776,6 +777,47 @@ portfoliosRouter.get('/portfolio/:id/rebalance-plan', async (req: Request, res: 
         return ok(res, buildRebalancePlan(portfolio, prices, feedMeta))
     } catch (error) {
         logger.error('[ERROR] Rebalance plan failed', { error: getErrorObject(error) })
+        return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
+    }
+})
+
+// Batch rebalance planning: compute plans for many portfolios in one call
+// without executing any trades. Each portfolio is planned in isolation; a
+// failure for one portfolio does not block the others, and the response
+// carries a combined summary (total trades / estimated fees).
+portfoliosRouter.post('/portfolios/rebalance-plans', validateRequest(batchRebalancePlansSchema), async (req: Request, res: Response) => {
+    try {
+        const portfolioIds = req.body.portfolioIds as string[]
+        const uniqueIds = [...new Set(portfolioIds)]
+
+        // Per-portfolio load isolation: a missing/unreadable portfolio is
+        // reported in `failed` instead of aborting the whole batch.
+        const portfolios: Portfolio[] = []
+        const failed: { portfolioId: string; error: string }[] = []
+        for (const portfolioId of uniqueIds) {
+            try {
+                const portfolio = await portfolioStorage.getPortfolio(portfolioId) as Portfolio | undefined
+                if (!portfolio) {
+                    failed.push({ portfolioId, error: 'Portfolio not found' })
+                    continue
+                }
+                portfolios.push(portfolio)
+            } catch (error) {
+                failed.push({ portfolioId, error: getErrorMessage(error) })
+            }
+        }
+
+        const { prices, feedMeta } = await reflectorService.getCurrentPricesWithMeta()
+        const result = buildBatchRebalancePlan(portfolios, prices, feedMeta)
+        // Merge load-phase failures into the planning-phase failure list.
+        result.failed.push(...failed)
+        result.summary.failedCount = result.failed.length
+        result.summary.totalPortfolios = uniqueIds.length
+        result.summary.plansGenerated = result.plans.length
+
+        return ok(res, result)
+    } catch (error) {
+        logger.error('[ERROR] Batch rebalance plans failed', { error: getErrorObject(error) })
         return fail(res, 500, 'INTERNAL_ERROR', getErrorMessage(error))
     }
 })

--- a/backend/src/api/validation.ts
+++ b/backend/src/api/validation.ts
@@ -66,6 +66,13 @@ export const portfolioSummaryQuerySchema = z.object({
     userAddress: z.string().min(1, "userAddress is required"),
 });
 
+// Schema for POST /portfolios/rebalance-plans (batch planning, no trading).
+export const batchRebalancePlansSchema = z.object({
+    portfolioIds: z.array(z.string().min(1, "portfolioId must be a non-empty string"))
+        .min(1, "At least one portfolioId is required")
+        .max(50, "Cannot plan more than 50 portfolios in a single batch")
+}).strict();
+
 // Schema for POST /portfolio/:id/rebalance
 export const rebalancePortfolioSchema = z.object({
     options: z.object({

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import cors from 'cors'
 import swaggerUi from 'swagger-ui-express'
 import { WebSocketServer } from 'ws'
 import { validateStartupConfigOrThrow, buildStartupSummary, logStartupSubsystems } from './config/startupConfig.js'
+import { getFeatureFlags } from './config/featureFlags.js'
 import { logger } from './utils/logger.js'
 import { apiErrorHandler } from './middleware/apiErrorHandler.js'
 import { requestContextMiddleware } from './middleware/requestContext.js'
@@ -91,6 +92,22 @@ export async function main(argv: string[] = process.argv): Promise<void> {
 
     mountApiRoutes(app)
     mountLegacyNonApiRedirects(app)
+
+    // Stage-warm the issuer metadata cache so deployments don't serve stale or
+    // missing metadata immediately after rollout. Fire-and-forget: failures are
+    // logged and skipped without delaying startup.
+    const flags = getFeatureFlags()
+    const warmAccounts = (process.env.ISSUER_METADATA_WARM_ACCOUNTS || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    if (flags.enableIssuerMetadata && warmAccounts.length > 0) {
+        import('./services/issuerMetadataService.js').then(({ warmIssuerMetadataCache }) =>
+            warmIssuerMetadataCache(warmAccounts).then((warmed) => {
+                logger.info('[ISSUER-METADATA] Cache warm-up complete', { requested: warmAccounts.length, warmed })
+            })
+        )
+    }
 
     app.get('/health', (_req: Request, res: Response) => {
         res.status(200).type('text/plain').send('ok')

--- a/backend/src/services/contractEventIndexer.ts
+++ b/backend/src/services/contractEventIndexer.ts
@@ -1,10 +1,15 @@
+import { createHash } from "node:crypto";
 import { Address, SorobanRpc, scValToNative } from "@stellar/stellar-sdk";
-import { databaseService, type IndexerCursorState } from "./databaseService.js";
+import { databaseService } from "./databaseService.js";
+import { sorobanRpcEndpointPool } from "./stellar.js";
 import { logger } from "../utils/logger.js";
 import {
   BACKEND_CONTRACT_EVENT_SCHEMA_VERSION,
   checkContractEventSchemaVersion,
 } from "../config/contractEventSchema.js";
+
+const INDEXER_CURSOR_KEY = "soroban_event_indexer.cursor";
+const INDEXER_LATEST_LEDGER_KEY = "soroban_event_indexer.latest_ledger";
 
 type IndexedEventKind = "portfolio_created" | "deposit" | "rebalance_executed";
 
@@ -44,6 +49,25 @@ interface ContractEventIndexerStatus {
         eventCount: number
         integrityHash: string | undefined
     }
+    gapReplay?: {
+        detected: boolean
+        gapSize: number
+        fromLedger: number | undefined
+        toLedger: number | undefined
+        ingested: number
+        batches: number
+        lastDetectedAt?: string
+    }
+}
+
+interface GapReplayResult {
+    detected: boolean
+    replayed: boolean
+    gapSize: number
+    fromLedger: number | undefined
+    toLedger: number | undefined
+    ingested: number
+    batches: number
 }
 
 interface ReplayValidationResult {
@@ -54,8 +78,6 @@ interface ReplayValidationResult {
     integrityHash: string
     errors: string[]
 }
-
-const INDEXER_STATE_NAME = "soroban_event_indexer";
 
 const MAX_RECENT_ERRORS = 10;
 const MAX_RPC_RETRIES = 3;
@@ -105,9 +127,26 @@ export class ContractEventIndexerService {
     1,
     100,
   );
-  private readonly rpcServer = new SorobanRpc.Server(this.rpcUrl, {
-    allowHttp: this.rpcUrl.startsWith("http://"),
-  });
+  private readonly gapReplayThreshold = this.readNumberEnv(
+    "SOROBAN_EVENT_INDEXER_GAP_REPLAY_THRESHOLD_LEDGERS",
+    100,
+    1,
+    10_000_000,
+  );
+  private readonly maxGapReplaySyncs = this.readNumberEnv(
+    "SOROBAN_EVENT_INDEXER_GAP_REPLAY_MAX_SYNCS",
+    10,
+    1,
+    1000,
+  );
+  private readonly gapReplayBatchDelayMs = this.readNumberEnv(
+    "SOROBAN_EVENT_INDEXER_GAP_REPLAY_BATCH_DELAY_MS",
+    100,
+    0,
+    300000,
+  );
+  /** Test seam: when set, RPC calls use this server instead of the endpoint pool. */
+  private readonly rpcServer: SorobanRpc.Server | null = null;
 
   private pollingTimer: NodeJS.Timeout | null = null;
   private isSyncing = false;
@@ -142,16 +181,11 @@ export class ContractEventIndexerService {
   }
 
   getStatus(): ContractEventIndexerStatus {
-    const storedState = this.loadPersistedState();
     return {
       ...this.status,
       running: this.pollingTimer !== null,
-      cursor: storedState.cursor ?? this.status.cursor,
-      latestLedger: storedState.latestLedger ?? this.status.latestLedger,
-      lastSuccessfulRunAt:
-        storedState.lastSuccessfulSyncAt ?? this.status.lastSuccessfulRunAt,
-      lastFailedRunAt: storedState.lastFailedSyncAt ?? this.status.lastFailedRunAt,
-      lastError: storedState.lastError ?? this.status.lastError,
+      cursor: databaseService.getIndexerState(INDEXER_CURSOR_KEY) ?? this.status.cursor,
+      latestLedger: Number(databaseService.getIndexerState(INDEXER_LATEST_LEDGER_KEY) || 0) || this.status.latestLedger,
       consecutiveFailures: this.consecutiveFailures,
       recentErrors: [...this.recentErrors],
     };
@@ -168,16 +202,12 @@ export class ContractEventIndexerService {
     consecutiveFailures: number;
     recentErrors: string[];
   } {
-    const storedState = this.loadPersistedState();
-
     return {
-      cursor: storedState.cursor,
-      latestLedger: storedState.latestLedger,
-      lastSuccessfulSyncAt:
-        storedState.lastSuccessfulSyncAt ?? this.status.lastSuccessfulRunAt,
-      lastFailedSyncAt:
-        storedState.lastFailedSyncAt ?? this.status.lastFailedRunAt,
-      lastError: storedState.lastError ?? this.status.lastError,
+      cursor: databaseService.getIndexerState(INDEXER_CURSOR_KEY) ?? this.status.cursor,
+      latestLedger: Number(databaseService.getIndexerState(INDEXER_LATEST_LEDGER_KEY) || 0) || this.status.latestLedger,
+      lastSuccessfulSyncAt: this.status.lastSuccessfulRunAt,
+      lastFailedSyncAt: this.status.lastFailedRunAt,
+      lastError: this.status.lastError,
       pollIntervalMs: this.pollIntervalMs,
       bootstrapWindowLedgers: this.bootstrapWindowLedgers,
       consecutiveFailures: this.consecutiveFailures,
@@ -186,16 +216,117 @@ export class ContractEventIndexerService {
   }
 
   resetCursor(fromLedger?: number): void {
-    const resetState = databaseService.resetContractEventIndexerState(
-      fromLedger,
-      INDEXER_STATE_NAME,
-    );
-    this.status.cursor = resetState.cursor;
-    this.status.latestLedger = resetState.latestLedger;
-    this.status.lastSuccessfulRunAt = resetState.lastSuccessfulSyncAt;
-    this.status.lastFailedRunAt = resetState.lastFailedSyncAt;
-    this.status.lastError = resetState.lastError;
+    if (fromLedger !== undefined) {
+      databaseService.setIndexerState(INDEXER_CURSOR_KEY, "");
+      databaseService.setIndexerState(INDEXER_LATEST_LEDGER_KEY, String(fromLedger));
+    } else {
+      databaseService.setIndexerState(INDEXER_CURSOR_KEY, "");
+      databaseService.setIndexerState(INDEXER_LATEST_LEDGER_KEY, "0");
+    }
+    this.status.cursor = undefined;
+    this.status.latestLedger = fromLedger;
+    this.status.lastSuccessfulRunAt = undefined;
+    this.status.lastFailedRunAt = undefined;
+    this.status.lastError = undefined;
     logger.info("[CHAIN-INDEXER] Cursor reset", { fromLedger });
+  }
+
+  /**
+   * Last ledger sequence the indexer successfully observed, if any.
+   */
+  private getLastIndexedLedger(): number | undefined {
+    const raw = databaseService.getIndexerState(INDEXER_LATEST_LEDGER_KEY);
+    const parsed = Number(raw || 0);
+    return parsed > 0 ? parsed : undefined;
+  }
+
+  /**
+   * Detect a downtime gap between the last indexed ledger and the current chain
+   * tip. Returns `null` when there is no prior state or the gap is within the
+   * configured threshold (normal lag that the regular polling catches up on).
+   */
+  async detectGap(): Promise<{
+    fromLedger: number | undefined;
+    toLedger: number;
+    gapSize: number;
+  } | null> {
+    if (!this.isEnabled()) return null;
+    const latest = await this.rpcExecute((server) => server.getLatestLedger());
+    const toLedger = latest.sequence;
+    const fromLedger = this.getLastIndexedLedger();
+    if (fromLedger === undefined) return null;
+    const gapSize = toLedger - fromLedger;
+    if (gapSize <= this.gapReplayThreshold) return null;
+    return { fromLedger, toLedger, gapSize };
+  }
+
+  /**
+   * Replay events missed during downtime, in bounded batches.
+   *
+   * After a long downtime the gap between the last indexed ledger and the chain
+   * tip can be very large. Instead of replaying it in one unbounded sweep, this
+   * rewinds the cursor to the last indexed ledger and runs a series of
+   * `syncOnce()` passes — each pass ingests at most
+   * `maxPagesPerSync × pageLimit` events — so a huge gap cannot overwhelm the
+   * indexer on startup. The remaining range (if the batch cap is hit) is picked
+   * up by the regular polling cycle.
+   */
+  async runStartupGapReplay(): Promise<GapReplayResult> {
+    if (!this.isEnabled() || this.isSyncing) {
+      return { detected: false, replayed: false, gapSize: 0, fromLedger: undefined, toLedger: undefined, ingested: 0, batches: 0 };
+    }
+
+    const gap = await this.detectGap();
+    if (!gap) {
+      return { detected: false, replayed: false, gapSize: 0, fromLedger: this.getLastIndexedLedger(), toLedger: undefined, ingested: 0, batches: 0 };
+    }
+
+    logger.info("[CHAIN-INDEXER] Downtime gap detected, replaying missed events", {
+      fromLedger: gap.fromLedger,
+      toLedger: gap.toLedger,
+      gapSize: gap.gapSize,
+      threshold: this.gapReplayThreshold,
+    });
+
+    this.resetCursor(gap.fromLedger);
+
+    let ingested = 0;
+    let batches = 0;
+    for (let i = 0; i < this.maxGapReplaySyncs; i++) {
+      const result = await this.syncOnce();
+      ingested += result.ingested;
+      batches += 1;
+      if (result.ingested === 0) break;
+      if (this.gapReplayBatchDelayMs > 0 && i < this.maxGapReplaySyncs - 1) {
+        await this.sleep(this.gapReplayBatchDelayMs);
+      }
+    }
+
+    this.status.gapReplay = {
+      detected: true,
+      gapSize: gap.gapSize,
+      fromLedger: gap.fromLedger,
+      toLedger: gap.toLedger,
+      ingested,
+      batches,
+      lastDetectedAt: new Date().toISOString(),
+    };
+
+    logger.info("[CHAIN-INDEXER] Gap replay finished", {
+      ingested,
+      batches,
+      bound: this.maxGapReplaySyncs,
+    });
+
+    return {
+      detected: true,
+      replayed: true,
+      gapSize: gap.gapSize,
+      fromLedger: gap.fromLedger,
+      toLedger: gap.toLedger,
+      ingested,
+      batches,
+    };
   }
 
   async start(): Promise<void> {
@@ -209,9 +340,16 @@ export class ContractEventIndexerService {
     logger.info("[CHAIN-INDEXER] Starting contract event indexer", {
       contractAddress: this.contractAddress,
       pollIntervalMs: this.pollIntervalMs,
+      lastIndexedLedger: this.getLastIndexedLedger(),
     });
 
-    await this.syncOnce();
+    // Catch up on events emitted while the indexer was down, then run a normal
+    // sync only when there was no gap to replay (the replay already advances
+    // the cursor through the missed range in bounded batches).
+    const gapReplay = await this.runStartupGapReplay();
+    if (!gapReplay.detected) {
+      await this.syncOnce();
+    }
     this.pollingTimer = setInterval(() => {
       void this.syncWithBackoff();
     }, this.pollIntervalMs);
@@ -243,202 +381,11 @@ export class ContractEventIndexerService {
     await this.syncOnce();
   }
 
-  async syncOnce(): Promise<{ ingested: number; latestLedger?: number }> {
-    if (!this.isEnabled()) return { ingested: 0 };
-    if (this.isSyncing)
-      return { ingested: 0, latestLedger: this.status.latestLedger };
-
-    const schemaCheck = checkContractEventSchemaVersion();
-    if (!schemaCheck.ok) {
-      this.status.lastRunAt = new Date().toISOString();
-      this.status.lastError = schemaCheck.message;
-      this.status.contractEventSchemaOk = false;
-      logger.error("[CHAIN-INDEXER] Contract event schema mismatch", {
-        message: schemaCheck.message,
-      });
-      return { ingested: 0, latestLedger: this.status.latestLedger };
+  private async rpcExecute<T>(fn: (server: SorobanRpc.Server) => Promise<T>): Promise<T> {
+    if (this.rpcServer) {
+      return this.rpcCallWithRetry(() => fn(this.rpcServer));
     }
-    this.status.contractEventSchemaOk = true;
-
-    this.isSyncing = true;
-    try {
-      const storedState = this.loadPersistedState();
-      const storedCursor = storedState.cursor;
-      const storedLatestLedger = storedState.latestLedger;
-
-      let cursor = storedCursor;
-      let startLedger: number | undefined;
-      if (!cursor) {
-        const latest = await this.rpcCallWithRetry(() =>
-          this.rpcServer.getLatestLedger(),
-        );
-        const floorLedger = Math.max(
-          1,
-          latest.sequence - this.bootstrapWindowLedgers,
-        );
-        startLedger = storedLatestLedger
-          ? Math.max(1, storedLatestLedger - 1)
-          : floorLedger;
-      }
-
-      let ingested = 0;
-      let latestLedger = storedLatestLedger;
-      let pagesRead = 0;
-
-      while (pagesRead < this.maxPagesPerSync) {
-        const response = await this.rpcCallWithRetry(() =>
-          this.rpcServer.getEvents({
-            cursor,
-            startLedger,
-            limit: this.pageLimit,
-            filters: [{ type: "contract" }],
-          }),
-        );
-        pagesRead++;
-        latestLedger = response.latestLedger;
-
-        if (!response.events.length) {
-          if (latestLedger) this.persistCursorState({ latestLedger });
-          break;
-        }
-
-        for (const event of response.events) {
-          let indexed: ReturnType<typeof this.toIndexedOnChainEvent>;
-          try {
-            indexed = this.toIndexedOnChainEvent(event);
-          } catch (err) {
-            logger.warn("[CHAIN-INDEXER] Skipping malformed event", {
-              error: String(err),
-              txHash: event.txHash,
-            });
-            continue;
-          }
-          if (!indexed) continue;
-
-          const dedupKey = `${indexed.ledger}:${indexed.txHash}:${indexed.kind}:${indexed.portfolioId}`;
-          if (this.seenEventKeys.has(dedupKey)) {
-            continue;
-          }
-          this.seenEventKeys.add(dedupKey);
-
-          // Prevent unbounded memory growth
-          if (this.seenEventKeys.size > 10000) {
-            const iterator = this.seenEventKeys.values();
-            for (let i = 0; i < 1000; i++) {
-              const val = iterator.next().value;
-              if (val !== undefined) {
-                this.seenEventKeys.delete(val);
-              }
-            }
-          }
-
-          databaseService.ensurePortfolioExists(
-            indexed.portfolioId,
-            indexed.userAddress || "ONCHAIN-INDEXER",
-          );
-          databaseService.recordRebalanceEvent({
-            portfolioId: indexed.portfolioId,
-            timestamp: indexed.timestamp,
-            trigger: indexed.trigger,
-            trades: indexed.trades,
-            gasUsed: "on-chain",
-            status: "completed",
-            isAutomatic: false,
-            eventSource: "onchain",
-            onChainConfirmed: true,
-            onChainEventType: indexed.kind,
-            onChainTxHash: indexed.txHash,
-            onChainLedger: indexed.ledger,
-            onChainContractId: indexed.contractId,
-            onChainPagingToken: indexed.pagingToken,
-            isSimulated: false,
-          });
-          ingested++;
-        }
-
-        const previousCursor = cursor;
-        const nextCursor =
-          response.events[response.events.length - 1]?.pagingToken;
-        if (nextCursor) {
-          cursor = nextCursor;
-          this.persistCursorState({ cursor, latestLedger });
-          logger.debug("[CHAIN-INDEXER] Persisted page cursor", {
-            cursor,
-            latestLedger,
-            pagesRead,
-          });
-        } else if (latestLedger) {
-          this.persistCursorState({ latestLedger });
-        }
-
-        if (!nextCursor || nextCursor === previousCursor) break;
-        startLedger = undefined;
-      }
-
-      this.status.lastRunAt = new Date().toISOString();
-      this.status.lastSuccessfulRunAt = this.status.lastRunAt;
-      this.persistCursorState({
-        cursor,
-        latestLedger,
-        lastSuccessfulSyncAt: this.status.lastSuccessfulRunAt,
-        lastError: undefined,
-      });
-      this.status.lastError = undefined;
-      this.status.lastIngestedCount = ingested;
-      this.status.cursor = cursor;
-      this.status.latestLedger = latestLedger;
-      this.status.enabled = true;
-      this.consecutiveFailures = 0;
-
-      return { ingested, latestLedger };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      const now = new Date().toISOString();
-      this.status.lastRunAt = now;
-      this.status.lastFailedRunAt = now;
-      this.status.lastError = message;
-      this.consecutiveFailures++;
-      this.pushRecentError(`[${now}] ${message}`);
-      this.persistCursorState({
-        lastFailedSyncAt: now,
-        lastError: message,
-      });
-      logger.error("[CHAIN-INDEXER] Sync failed", {
-        error: message,
-        consecutiveFailures: this.consecutiveFailures,
-        cursor: this.status.cursor,
-        latestLedger: this.status.latestLedger,
-      });
-      return { ingested: 0, latestLedger: this.status.latestLedger };
-    } finally {
-      this.isSyncing = false;
-    }
-  }
-
-  private loadPersistedState(): IndexerCursorState {
-    try {
-      return databaseService.getContractEventIndexerState(INDEXER_STATE_NAME);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error("[CHAIN-INDEXER] Failed to read persisted cursor state", {
-        error: message,
-      });
-      return { name: INDEXER_STATE_NAME };
-    }
-  }
-
-  private persistCursorState(
-    state: Partial<Omit<IndexerCursorState, "name">>,
-  ): void {
-    const persisted = databaseService.saveContractEventIndexerState(
-      state,
-      INDEXER_STATE_NAME,
-    );
-    this.status.cursor = persisted.cursor;
-    this.status.latestLedger = persisted.latestLedger;
-    this.status.lastSuccessfulRunAt = persisted.lastSuccessfulSyncAt;
-    this.status.lastFailedRunAt = persisted.lastFailedSyncAt;
-    this.status.lastError = persisted.lastError;
+    return sorobanRpcEndpointPool.call(fn);
   }
 
   private async rpcCallWithRetry<T>(fn: () => Promise<T>): Promise<T> {
@@ -536,7 +483,7 @@ export class ContractEventIndexerService {
         }
 
         if (!ledgerRange) {
-            const latest = await this.rpcCallWithRetry(() => this.rpcServer.getLatestLedger())
+            const latest = await this.rpcExecute((s) => s.getLatestLedger())
             ledgerRange = {
                 start: Math.max(1, latest.sequence - this.bootstrapWindowLedgers),
                 end: latest.sequence,
@@ -593,7 +540,7 @@ export class ContractEventIndexerService {
             let cursor = storedCursor
             let startLedger: number | undefined
             if (!cursor) {
-                const latest = await this.rpcCallWithRetry(() => this.rpcServer.getLatestLedger())
+                const latest = await this.rpcExecute((s) => s.getLatestLedger())
                 const floorLedger = Math.max(1, latest.sequence - this.bootstrapWindowLedgers)
                 startLedger = storedLatestLedger ? Math.max(1, storedLatestLedger - 1) : floorLedger
             }
@@ -603,8 +550,8 @@ export class ContractEventIndexerService {
             let pagesRead = 0
 
             while (pagesRead < this.maxPagesPerSync) {
-                const response = await this.rpcCallWithRetry(() =>
-                    this.rpcServer.getEvents({
+                const response = await this.rpcExecute((s) =>
+                    s.getEvents({
                         cursor,
                         startLedger,
                         limit: this.pageLimit,
@@ -704,6 +651,13 @@ export class ContractEventIndexerService {
 
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private pushRecentError(message: string): void {
+    this.recentErrors.push(message);
+    if (this.recentErrors.length > MAX_RECENT_ERRORS) {
+      this.recentErrors.splice(0, this.recentErrors.length - MAX_RECENT_ERRORS);
+    }
   }
 
   private toIndexedOnChainEvent(

--- a/backend/src/services/issuerMetadataService.ts
+++ b/backend/src/services/issuerMetadataService.ts
@@ -13,6 +13,7 @@ const CACHE_TTL_MS = Number(process.env.ISSUER_METADATA_TTL_MS) || 6 * 60 * 60 *
 
 type CacheEntry = {
   data: IssuerMetadata;
+  fetchedAt: number;
   expires: number;
 };
 
@@ -24,31 +25,106 @@ const horizonUrl = process.env.STELLAR_HORIZON_URL ||
 const server = new Horizon.Server(horizonUrl);
 
 /**
- * Resolve the home domain from the issuer account and fetch its stellar.toml.
- * Returns parsed metadata or throws an error if fetching/parsing fails.
+ * Result of a metadata fetch that conveys cache provenance, so callers can tell
+ * a live response from stale (expired) data that was only served because the
+ * network refetch failed.
  */
-export async function fetchIssuerMetadata(domain: string): Promise<IssuerMetadata> {
-  const now = Date.now();
-  const cached = cache.get(domain);
-  if (cached && cached.expires > now) {
-    logger.debug('[IssuerMetadata] Cache hit', { domain });
-    return cached.data;
-  }
+export interface IssuerMetadataResult {
+  data: IssuerMetadata;
+  stale: boolean;
+  fetchedAtMs: number;
+  expiresAtMs: number;
+  source: 'cache' | 'network' | 'stale';
+}
 
-  logger.debug('[IssuerMetadata] Fetching from network', { domain });
-  const toml = await StellarToml.Resolver.resolve(domain);
-  // Select fields we care about – extend as needed.
-  const metadata: IssuerMetadata = {
+function toMetadata(toml: Awaited<ReturnType<typeof StellarToml.Resolver.resolve>>): IssuerMetadata {
+  return {
     org_name: toml?.ORG_NAME,
     org_url: toml?.ORG_URL,
     org_logo: toml?.ORG_LOGO,
     org_description: toml?.ORG_DESCRIPTION,
     version: toml?.VERSION,
-    // Additional optional fields can be added here.
   };
+}
 
-  cache.set(domain, { data: metadata, expires: now + CACHE_TTL_MS });
-  return metadata;
+/**
+ * Resolve metadata for a domain with cache semantics.
+ *
+ * - A fresh cache entry is returned immediately (source: 'cache').
+ * - A miss (or forced refresh) fetches from the network and repopulates the cache.
+ * - If the network fetch fails and a (possibly expired) entry exists, the stale
+ *   entry is served with `stale: true` (source: 'stale') instead of erroring.
+ * - If the fetch fails and there is nothing cached, the error propagates.
+ */
+async function loadIssuerMetadataWithStatus(
+  domain: string,
+  options?: { forceRefresh?: boolean }
+): Promise<IssuerMetadataResult> {
+  const now = Date.now();
+  const cached = cache.get(domain);
+  const forceRefresh = !!options?.forceRefresh;
+
+  if (cached && cached.expires > now && !forceRefresh) {
+    logger.debug('[IssuerMetadata] Cache hit', { domain });
+    return {
+      data: cached.data,
+      stale: false,
+      fetchedAtMs: cached.fetchedAt,
+      expiresAtMs: cached.expires,
+      source: 'cache',
+    };
+  }
+
+  logger.debug('[IssuerMetadata] Fetching from network', { domain, forceRefresh });
+  try {
+    const toml = await StellarToml.Resolver.resolve(domain);
+    const data = toMetadata(toml);
+    const fetchedAt = Date.now();
+    const expires = fetchedAt + CACHE_TTL_MS;
+    cache.set(domain, { data, fetchedAt, expires });
+    return { data, stale: false, fetchedAtMs: fetchedAt, expiresAtMs: expires, source: 'network' };
+  } catch (error) {
+    if (cached) {
+      logger.warn('[IssuerMetadata] Network fetch failed; serving stale cached metadata', {
+        domain,
+        error: String(error),
+      });
+      return {
+        data: cached.data,
+        stale: true,
+        fetchedAtMs: cached.fetchedAt,
+        expiresAtMs: cached.expires,
+        source: 'stale',
+      };
+    }
+    logger.warn('[IssuerMetadata] Network fetch failed (nothing cached to serve)', {
+      domain,
+      error: String(error),
+    });
+    throw error;
+  }
+}
+
+/**
+ * Resolve the home domain from the issuer account and fetch its stellar.toml.
+ * Returns parsed metadata or throws an error if fetching/parsing fails.
+ */
+export async function fetchIssuerMetadata(
+  domain: string,
+  options?: { forceRefresh?: boolean }
+): Promise<IssuerMetadata> {
+  const result = await fetchIssuerMetadataWithStatus(domain, options);
+  return result.data;
+}
+
+/**
+ * Domain-level variant that surfaces cache provenance / staleness.
+ */
+export async function fetchIssuerMetadataWithStatus(
+  domain: string,
+  options?: { forceRefresh?: boolean }
+): Promise<IssuerMetadataResult> {
+  return loadIssuerMetadataWithStatus(domain, options);
 }
 
 /**
@@ -64,6 +140,7 @@ export function getCachedMetadata(domain: string): IssuerMetadata | undefined {
 
 /**
  * Main entry point: Get metadata for an issuer account by resolving its home domain.
+ * Kept backward compatible — failures resolve to `undefined`.
  */
 export async function getMetadata(issuerAccount: string): Promise<IssuerMetadata | undefined> {
   try {
@@ -81,8 +158,76 @@ export async function getMetadata(issuerAccount: string): Promise<IssuerMetadata
   }
 }
 
+/**
+ * Account-level variant that surfaces cache provenance / staleness.
+ */
+export async function getMetadataWithStatus(issuerAccount: string): Promise<IssuerMetadataResult | undefined> {
+  try {
+    logger.debug('[IssuerMetadata] Loading account from Horizon', { issuerAccount });
+    const account = await server.loadAccount(issuerAccount);
+    const homeDomain = account.home_domain;
+    if (!homeDomain) {
+      logger.debug('[IssuerMetadata] Account has no home domain', { issuerAccount });
+      return undefined;
+    }
+    return await loadIssuerMetadataWithStatus(homeDomain);
+  } catch (error) {
+    logger.warn('[IssuerMetadata] Failed to load account/metadata', { issuerAccount, error: String(error) });
+    return undefined;
+  }
+}
+
+/**
+ * Force a manual refresh of the metadata for an issuer account, bypassing a
+ * fresh cache entry. If the network fetch fails, an existing cached entry is
+ * served flagged as stale (the caller decides how to surface that).
+ */
+export async function forceRefreshMetadata(issuerAccount: string): Promise<IssuerMetadataResult> {
+  const account = await server.loadAccount(issuerAccount);
+  const homeDomain = account.home_domain;
+  if (!homeDomain) {
+    throw new Error(`Issuer account ${issuerAccount} has no home domain to refresh`);
+  }
+  logger.info('[IssuerMetadata] Force-refreshing issuer metadata', { issuerAccount, homeDomain });
+  return loadIssuerMetadataWithStatus(homeDomain, { forceRefresh: true });
+}
+
+/**
+ * Stage-warming: prefetch metadata for the given issuer accounts so the cache is
+ * hot before real traffic arrives (avoids serving stale/missing metadata right
+ * after a deployment). Failures are logged and skipped without aborting the
+ * startup sequence.
+ */
+export async function warmIssuerMetadataCache(issuerAccounts: string[]): Promise<number> {
+  let warmed = 0;
+  for (const issuerAccount of issuerAccounts) {
+    try {
+      const account = await server.loadAccount(issuerAccount);
+      const homeDomain = account.home_domain;
+      if (homeDomain) {
+        const result = await loadIssuerMetadataWithStatus(homeDomain);
+        if (result.source === 'network' || result.source === 'cache') {
+          warmed += 1;
+        }
+        logger.debug('[IssuerMetadata] Cache warmed', { issuerAccount, homeDomain, source: result.source });
+      }
+    } catch (error) {
+      logger.warn('[IssuerMetadata] Cache warm-up failed for issuer', { issuerAccount, error: String(error) });
+    }
+  }
+  return warmed;
+}
+
 export const issuerMetadataService = {
   fetchIssuerMetadata,
+  fetchIssuerMetadataWithStatus,
   getCachedMetadata,
-  getMetadata
+  getMetadata,
+  getMetadataWithStatus,
+  forceRefreshMetadata,
+  warmIssuerMetadataCache,
+  getCacheStats: () => ({
+    entries: cache.size,
+    ttlMs: CACHE_TTL_MS,
+  }),
 };

--- a/backend/src/services/rebalancePlan.ts
+++ b/backend/src/services/rebalancePlan.ts
@@ -46,6 +46,74 @@ function readBaseFeeXlm(): number {
     return Dec.roundStellar(stroops / STROOPS_PER_XLM)
 }
 
+export interface BatchRebalancePlanResult {
+    plans: RebalancePlan[]
+    failed: { portfolioId: string; error: string }[]
+    summary: {
+        totalPortfolios: number
+        plansGenerated: number
+        failedCount: number
+        totalTrades: number
+        totalEstimatedFeesXlm: number
+        totalEstimatedFeesUsd: number
+        maxSlippageBps: number
+    }
+}
+
+/**
+ * Compute rebalance plans for several portfolios in a single batch.
+ *
+ * Each portfolio is planned in isolation: a failure for one portfolio is
+ * captured in `failed` and never prevents the remaining portfolios from
+ * being planned. A combined summary (total trades and estimated fees) is
+ * aggregated from the successful plans.
+ */
+export function buildBatchRebalancePlan(
+    portfolios: Portfolio[],
+    prices: PricesMap,
+    priceFeedMeta: PriceFeedMeta
+): BatchRebalancePlanResult {
+    const plans: RebalancePlan[] = []
+    const failed: { portfolioId: string; error: string }[] = []
+
+    for (const portfolio of portfolios) {
+        try {
+            plans.push(buildRebalancePlan(portfolio, prices, priceFeedMeta))
+        } catch (error) {
+            failed.push({
+                portfolioId: portfolio.id,
+                error: error instanceof Error ? error.message : String(error),
+            })
+        }
+    }
+
+    const totalTrades = plans.reduce((sum, plan) => sum + plan.estimatedFees.tradeCount, 0)
+    const totalEstimatedFeesXlm = Dec.roundStellar(
+        plans.reduce((sum, plan) => Dec.add(sum, plan.estimatedFees.xlm), 0),
+    )
+    const totalEstimatedFeesUsd = Dec.roundStellar(
+        plans.reduce((sum, plan) => Dec.add(sum, plan.estimatedFees.usd), 0),
+    )
+    const maxSlippageBps = plans.reduce(
+        (max, plan) => Math.max(max, plan.estimatedSlippageBps),
+        0,
+    )
+
+    return {
+        plans,
+        failed,
+        summary: {
+            totalPortfolios: portfolios.length,
+            plansGenerated: plans.length,
+            failedCount: failed.length,
+            totalTrades,
+            totalEstimatedFeesXlm,
+            totalEstimatedFeesUsd,
+            maxSlippageBps,
+        },
+    }
+}
+
 export function buildRebalancePlan(
     portfolio: Portfolio,
     prices: PricesMap,

--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3'
 import { randomUUID } from 'node:crypto'
 import { trace } from '@opentelemetry/api'
-import { Horizon } from '@stellar/stellar-sdk'
+import { Horizon, SorobanRpc } from '@stellar/stellar-sdk'
 
 function getTracer() {
   return trace.getTracer('stellar-service', '1.0.0')
@@ -13,6 +13,221 @@ function getHorizonServer(): Horizon.Server {
     (network === 'mainnet' ? 'https://horizon.stellar.org' : 'https://horizon-testnet.stellar.org')
   return new Horizon.Server(horizonUrl)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Soroban RPC endpoint pool with failover and health-based steering
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface SorobanRpcEndpointHealth {
+  url: string
+  healthy: boolean
+  consecutiveFailures: number
+  /** EWMA of the last successful call latency (ms). `null` = no sample yet. */
+  averageLatencyMs: number | null
+  lastUsedAt: number | null
+  lastError?: string
+  /** Timestamp before which the endpoint is not retried after a failure. */
+  nextRetryAt: number | null
+}
+
+export interface SorobanRpcPoolOptions {
+  /** Per-call timeout in ms. Calls that exceed it count as a failure. */
+  timeoutMs?: number
+  /** Cooldown (ms) after a failure before an endpoint is probed again. */
+  cooldownMs?: number
+  /** Optional factory so tests can inject mocked RPC servers. */
+  serverFactory?: (url: string) => SorobanRpc.Server
+}
+
+const RPC_TIMEOUT_MS_DEFAULT = 10_000
+const RPC_COOLDOWN_MS_DEFAULT = 5_000
+const LATENCY_EWMA_ALPHA = 0.3
+
+function sorobanRpcTimeoutMs(): number {
+  const parsed = Number(process.env.SOROBAN_RPC_TIMEOUT_MS)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : RPC_TIMEOUT_MS_DEFAULT
+}
+
+function defaultSorobanRpcUrl(): string {
+  const network = (process.env.STELLAR_NETWORK || 'testnet').trim().toLowerCase()
+  return network === 'mainnet'
+    ? 'https://soroban-rpc.mainnet.stellar.gateway.fm'
+    : 'https://soroban-testnet.stellar.org'
+}
+
+/**
+ * Resolve the list of configured Soroban RPC endpoints.
+ *
+ * `SOROBAN_RPC_URLS` (comma-separated) is preferred when present; falls back
+ * to the legacy single `SOROBAN_RPC_URL`, then to a network default. Duplicate
+ * URLs are collapsed.
+ */
+export function resolveSorobanRpcUrls(): string[] {
+  const multi = process.env.SOROBAN_RPC_URLS
+  const single = process.env.SOROBAN_RPC_URL
+  const raw = multi && multi.trim() ? multi : (single ? single : '')
+  const urls = raw
+    .split(',')
+    .map((u) => u.trim())
+    .filter(Boolean)
+  return urls.length > 0 ? [...new Set(urls)] : [defaultSorobanRpcUrl()]
+}
+
+export interface SorobanRpcPoolStatus {
+  endpoints: SorobanRpcEndpointHealth[]
+  preferredUrl: string | undefined
+  timeoutMs: number
+  cooldownMs: number
+}
+
+/**
+ * Failover-aware pool over a list of Soroban RPC endpoints.
+ *
+ * `call()` attempts the healthiest endpoint first and transparently falls back
+ * to the next endpoint on connection failure or timeout. Per-endpoint
+ * health and smoothed latency are tracked so subsequent calls steer toward
+ * the most responsive endpoint.
+ */
+export class SorobanRpcEndpointPool {
+  private readonly endpoints: SorobanRpcEndpointHealth[]
+  private readonly servers: Map<string, SorobanRpc.Server>
+  private readonly serverFactory: (url: string) => SorobanRpc.Server
+  private readonly timeoutMs: number
+  private readonly cooldownMs: number
+
+  constructor(endpoints: string[], options: SorobanRpcPoolOptions = {}) {
+    this.timeoutMs = options.timeoutMs ?? sorobanRpcTimeoutMs()
+    this.cooldownMs = options.cooldownMs ?? RPC_COOLDOWN_MS_DEFAULT
+    this.serverFactory = options.serverFactory ?? ((url: string) =>
+      new SorobanRpc.Server(url, { allowHttp: url.startsWith('http://') }))
+    this.servers = new Map()
+    this.endpoints = [...new Set(endpoints)].map((url) => ({
+      url,
+      healthy: true,
+      consecutiveFailures: 0,
+      averageLatencyMs: null,
+      lastUsedAt: null,
+      nextRetryAt: null,
+    }))
+  }
+
+  getEndpointHealths(): SorobanRpcEndpointHealth[] {
+    return this.endpoints
+  }
+
+  getStatus(): SorobanRpcPoolStatus {
+    return {
+      endpoints: this.endpoints.map((e) => ({ ...e })),
+      preferredUrl: this.candidateOrder()[0]?.url,
+      timeoutMs: this.timeoutMs,
+      cooldownMs: this.cooldownMs,
+    }
+  }
+
+  /**
+   * The single most responsive (healthy) endpoint, for callers that hold a
+   * `SorobanRpc.Server` rather than going through `call()`.
+   */
+  getServer(): SorobanRpc.Server {
+    const preferred = this.candidateOrder()[0]
+    const url = preferred?.url ?? this.endpoints[0]?.url ?? ''
+    return this.getServerForUrl(url)
+  }
+
+  private getServerForUrl(url: string): SorobanRpc.Server {
+    let server = this.servers.get(url)
+    if (!server) {
+      server = this.serverFactory(url)
+      this.servers.set(url, server)
+    }
+    return server
+  }
+
+  /**
+   * Run an RPC invocation against the pool. The healthiest endpoint is tried
+   * first; on connection failure or timeout the next endpoint is attempted
+   * until one succeeds. Throws the last error when every endpoint fails.
+   */
+  async call<T>(fn: (server: SorobanRpc.Server) => Promise<T>): Promise<T> {
+    let lastError: Error | undefined
+    for (const endpoint of this.candidateOrder()) {
+      const server = this.getServerForUrl(endpoint.url)
+      const startedAt = Date.now()
+      try {
+        const result = await this.withTimeout(fn(server), this.timeoutMs)
+        this.recordSuccess(endpoint, Date.now() - startedAt)
+        return result
+      } catch (err) {
+        this.recordFailure(endpoint, err)
+        lastError = err instanceof Error ? err : new Error(String(err))
+      }
+    }
+    throw lastError ?? new Error('No Soroban RPC endpoints configured')
+  }
+
+  /**
+   * Order endpoints by preference:
+   *   1. healthy endpoints, fastest EWMA latency first (unknown latency last)
+   *   2. unhealthy endpoints whose cooldown has elapsed (re-probe candidates)
+   *   3. unhealthy endpoints still cooling down (avoid hammering them)
+   */
+  private candidateOrder(): SorobanRpcEndpointHealth[] {
+    const now = Date.now()
+    const healthy = this.endpoints
+      .filter((e) => e.healthy)
+      .sort((a, b) => {
+        const latA = a.averageLatencyMs ?? Number.POSITIVE_INFINITY
+        const latB = b.averageLatencyMs ?? Number.POSITIVE_INFINITY
+        if (latA !== latB) return latA - latB
+        return this.endpoints.indexOf(a) - this.endpoints.indexOf(b)
+      })
+    const probing = this.endpoints
+      .filter((e) => !e.healthy && (e.nextRetryAt ?? 0) <= now)
+      .sort((a, b) => this.endpoints.indexOf(a) - this.endpoints.indexOf(b))
+    const coolingDown = this.endpoints
+      .filter((e) => !e.healthy && (e.nextRetryAt ?? 0) > now)
+      .sort((a, b) => this.endpoints.indexOf(a) - this.endpoints.indexOf(b))
+    return [...healthy, ...probing, ...coolingDown]
+  }
+
+  private recordSuccess(endpoint: SorobanRpcEndpointHealth, latencyMs: number): void {
+    endpoint.healthy = true
+    endpoint.consecutiveFailures = 0
+    endpoint.averageLatencyMs =
+      endpoint.averageLatencyMs === null
+        ? latencyMs
+        : endpoint.averageLatencyMs * (1 - LATENCY_EWMA_ALPHA) + latencyMs * LATENCY_EWMA_ALPHA
+    endpoint.lastUsedAt = Date.now()
+    endpoint.lastError = undefined
+  }
+
+  private recordFailure(endpoint: SorobanRpcEndpointHealth, err: unknown): void {
+    endpoint.consecutiveFailures += 1
+    endpoint.healthy = false
+    endpoint.nextRetryAt = Date.now() + this.cooldownMs
+    endpoint.lastUsedAt = Date.now()
+    endpoint.lastError = err instanceof Error ? err.message : String(err)
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+    if (!ms || ms <= 0) return promise
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      return await Promise.race<T>([
+        promise,
+        new Promise<T>((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error('Soroban RPC call timed out')), ms)
+        }),
+      ])
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
+}
+
+const sorobanRpcUrls = resolveSorobanRpcUrls()
+/** Shared pool for the process; used by the contract event indexer etc. */
+export const sorobanRpcEndpointPool = new SorobanRpcEndpointPool(sorobanRpcUrls)
 
 export interface ExecuteRebalanceOptions {
     simulateOnly?: boolean

--- a/backend/src/test/adminRoutes.test.ts
+++ b/backend/src/test/adminRoutes.test.ts
@@ -315,4 +315,123 @@ describe('Admin routes – unauthenticated, non-admin, and admin access', () => 
             expect(res.body.data.queries[0]).toHaveProperty('query')
         })
     })
+
+    // ── Issuer metadata cache endpoints (TTL + stale-serve + refresh) ─────────
+
+    const META_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5'
+
+    describe('GET /api/admin/issuer-metadata/:issuer', () => {
+        afterEach(() => { vi.restoreAllMocks() })
+
+        it('returns 401 without admin headers', async () => {
+            const res = await request(app).get(`/api/admin/issuer-metadata/${META_ISSUER}`)
+            expect(res.status).toBe(401)
+        })
+
+        it('returns 403 for a key not in ADMIN_PUBLIC_KEYS', async () => {
+            const res = await request(app)
+                .get(`/api/admin/issuer-metadata/${META_ISSUER}`)
+                .set(makeAdminHeaders(nonAdminKp))
+            expect(res.status).toBe(403)
+        })
+
+        it('returns 404 when no metadata is available for the account', async () => {
+            const routesSvc = (await import('../services/issuerMetadataService.js')).issuerMetadataService
+            vi.spyOn(routesSvc, 'getMetadataWithStatus')
+                .mockResolvedValue(undefined as never)
+            const res = await request(app)
+                .get(`/api/admin/issuer-metadata/${META_ISSUER}`)
+                .set(makeAdminHeaders(adminKp))
+            expect(res.status).toBe(404)
+            expect(res.body.error.code).toBe('NOT_FOUND')
+        })
+
+        it('returns 200 with metadata and staleness flags', async () => {
+            const routesSvc = (await import('../services/issuerMetadataService.js')).issuerMetadataService
+            vi.spyOn(routesSvc, 'getMetadataWithStatus')
+                .mockResolvedValue({
+                    data: { org_name: 'Stellar Foundation' } as any,
+                    stale: false,
+                    fetchedAtMs: 1234,
+                    expiresAtMs: 7654321,
+                    source: 'network',
+                })
+            const res = await request(app)
+                .get(`/api/admin/issuer-metadata/${META_ISSUER}`)
+                .set(makeAdminHeaders(adminKp))
+            expect(res.status).toBe(200)
+            expect(res.body.success).toBe(true)
+            expect(res.body.data.issuer).toBe(META_ISSUER)
+            expect(res.body.data.stale).toBe(false)
+            expect(res.body.data.source).toBe('network')
+            expect(res.body.data.data.org_name).toBe('Stellar Foundation')
+        })
+    })
+
+    describe('POST /api/admin/issuer-metadata/:issuer/refresh', () => {
+        afterEach(() => { vi.restoreAllMocks() })
+
+        it('returns 401 without admin headers', async () => {
+            const res = await request(app).post(`/api/admin/issuer-metadata/${META_ISSUER}/refresh`)
+            expect(res.status).toBe(401)
+        })
+
+        it('returns 403 for a key not in ADMIN_PUBLIC_KEYS', async () => {
+            const res = await request(app)
+                .post(`/api/admin/issuer-metadata/${META_ISSUER}/refresh`)
+                .set(makeAdminHeaders(nonAdminKp))
+            expect(res.status).toBe(403)
+        })
+
+        it('returns 200 with refreshed metadata for a valid admin', async () => {
+            const routesSvc = (await import('../services/issuerMetadataService.js')).issuerMetadataService
+            const forceRefreshSpy = vi.spyOn(routesSvc, 'forceRefreshMetadata')
+                .mockResolvedValue({
+                    data: { org_name: 'Refreshed Org' } as any,
+                    stale: false,
+                    fetchedAtMs: 99,
+                    expiresAtMs: 123456,
+                    source: 'network',
+                })
+            const res = await request(app)
+                .post(`/api/admin/issuer-metadata/${META_ISSUER}/refresh`)
+                .set(makeAdminHeaders(adminKp))
+            expect(res.status).toBe(200)
+            expect(forceRefreshSpy).toHaveBeenCalledWith(META_ISSUER)
+            expect(res.body.success).toBe(true)
+            expect(res.body.data.stale).toBe(false)
+            expect(res.body.data.source).toBe('network')
+            expect(res.body.data.data.org_name).toBe('Refreshed Org')
+        })
+
+        it('signals stale data in the response when the upstream refetch fails', async () => {
+            const routesSvc = (await import('../services/issuerMetadataService.js')).issuerMetadataService
+            vi.spyOn(routesSvc, 'forceRefreshMetadata')
+                .mockResolvedValue({
+                    data: { org_name: 'Stale Org' } as any,
+                    stale: true,
+                    fetchedAtMs: 1,
+                    expiresAtMs: 2,
+                    source: 'stale',
+                })
+            const res = await request(app)
+                .post(`/api/admin/issuer-metadata/${META_ISSUER}/refresh`)
+                .set(makeAdminHeaders(adminKp))
+            expect(res.status).toBe(200)
+            expect(res.body.data.stale).toBe(true)
+            expect(res.body.data.source).toBe('stale')
+            expect(res.body.data.data.org_name).toBe('Stale Org')
+        })
+
+        it('returns 502 when the refresh fails with nothing cached to serve', async () => {
+            const routesSvc = (await import('../services/issuerMetadataService.js')).issuerMetadataService
+            vi.spyOn(routesSvc, 'forceRefreshMetadata')
+                .mockRejectedValue(new Error('TOML host unreachable'))
+            const res = await request(app)
+                .post(`/api/admin/issuer-metadata/${META_ISSUER}/refresh`)
+                .set(makeAdminHeaders(adminKp))
+            expect(res.status).toBe(502)
+            expect(res.body.error.code).toBe('UPSTREAM_ERROR')
+        })
+    })
 })

--- a/backend/src/test/contractEventIndexer.test.ts
+++ b/backend/src/test/contractEventIndexer.test.ts
@@ -313,7 +313,7 @@ describe('contractEventIndexer', () => {
     it('indexer:reindex script re-processes events idempotently', async () => {
         // Arrange
         const safeScValToNativeSpy = vi.spyOn(contractEventIndexerService as any, 'safeScValToNative')
-        
+
         const mockEvent = {
             contractId: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEWCEUNYQZ2QZ2QZ2QZ2QZ2QZ2QZ2Q',
             topic: ['topic1', 'topic2'],
@@ -349,6 +349,135 @@ describe('contractEventIndexer', () => {
         expect(result1.ingested).toBe(1)
         expect(result2.ingested).toBe(0) // Idempotent output
         expect(databaseService.recordRebalanceEvent).toHaveBeenCalledTimes(1) // Only called once total
+
+        safeScValToNativeSpy.mockRestore()
+    })
+
+    // ── Downtime gap detection and replay (#3) ──────────────────────────────
+
+    const LATEST_LEDGER_KEY = 'soroban_event_indexer.latest_ledger'
+    const CURSOR_KEY = 'soroban_event_indexer.cursor'
+
+    function mockEventsFrom(startLedger: number, count = 2000) {
+        let call = 0
+        return vi.fn().mockImplementation(async () => {
+            call += 1
+            const events = []
+            // Two pages worth of distinct events per sync pass so the page loop has
+            // something to iterate over.
+            for (let i = 0; i < 2; i++) {
+                const ledger = startLedger + call * 2 - 2 + i
+                if (ledger >= 1000) break
+                events.push({
+                    contractId: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEWCEUNYQZ2QZ2QZ2QZ2QZ2QZ2QZ2Q',
+                    topic: ['topic1', 'topic2'],
+                    value: 'gap-value',
+                    ledgerClosedAt: '2023-01-01T00:00:00Z',
+                    txHash: `gap-tx-${ledger}`,
+                    ledger,
+                    pagingToken: `gap-tok-${ledger}`
+                } as unknown as SorobanRpc.Api.EventResponse)
+            }
+            return { events, latestLedger: 1000 }
+        })
+    }
+
+    it('detectGap returns null when there is no prior indexed ledger', async () => {
+        const dbMock = (await import('../services/databaseService.js')).databaseService as any
+        dbMock.getIndexerState.mockReturnValue(undefined)
+
+        const gap = await contractEventIndexerService.detectGap()
+        expect(gap).toBeNull()
+        expect(rpcServerMock.getLatestLedger).toHaveBeenCalled()
+    })
+
+    it('detectGap returns null when the gap is within the threshold', async () => {
+        const dbMock = (await import('../services/databaseService.js')).databaseService as any
+        dbMock.getIndexerState.mockImplementation((key: string) =>
+            key === LATEST_LEDGER_KEY ? String(950) : undefined
+        )
+        ;(contractEventIndexerService as any).gapReplayThreshold = 100
+
+        const gap = await contractEventIndexerService.detectGap()
+        expect(gap).toBeNull()
+    })
+
+    it('detectGap reports a downtime gap against the chain tip', async () => {
+        const dbMock = (await import('../services/databaseService.js')).databaseService as any
+        dbMock.getIndexerState.mockImplementation((key: string) =>
+            key === LATEST_LEDGER_KEY ? String(500) : undefined
+        )
+        ;(contractEventIndexerService as any).gapReplayThreshold = 100
+
+        const gap = await contractEventIndexerService.detectGap()
+        expect(gap).toEqual({ fromLedger: 500, toLedger: 1000, gapSize: 500 })
+    })
+
+    it('replays missed events across a downtime gap on startup', async () => {
+        const safeScValToNativeSpy = vi.spyOn(contractEventIndexerService as any, 'safeScValToNative')
+        safeScValToNativeSpy.mockImplementation((val) => {
+            if (val === 'topic1') return 'portfolio'
+            if (val === 'topic2') return 'rebalance_executed'
+            if (val === 'gap-value') return ['portfolio-gap', 'user-abc']
+            return undefined
+        })
+
+        const dbMock = (await import('../services/databaseService.js')).databaseService as any
+        dbMock.getIndexerState.mockImplementation((key: string) =>
+            key === LATEST_LEDGER_KEY ? String(950) : undefined
+        )
+        ;(contractEventIndexerService as any).gapReplayThreshold = 10
+        ;(contractEventIndexerService as any).maxGapReplaySyncs = 5
+        ;(contractEventIndexerService as any).gapReplayBatchDelayMs = 0
+
+        rpcServerMock.getEvents.mockImplementation(mockEventsFrom(950))
+
+        const result = await contractEventIndexerService.runStartupGapReplay()
+
+        expect(result.detected).toBe(true)
+        expect(result.replayed).toBe(true)
+        expect(result.gapSize).toBe(50)
+        expect(result.fromLedger).toBe(950)
+        expect(result.toLedger).toBe(1000)
+        expect(result.ingested).toBeGreaterThanOrEqual(1)
+        expect(databaseService.recordRebalanceEvent).toHaveBeenCalled()
+        const latestLedgerCall = dbMock.setIndexerState.mock.calls.find(
+            (c: [string, string]) => c[0] === LATEST_LEDGER_KEY
+        )
+        expect(latestLedgerCall).toBeDefined()
+        expect(contractEventIndexerService.getStatus().gapReplay?.detected).toBe(true)
+
+        safeScValToNativeSpy.mockRestore()
+    })
+
+    it('bounds replay batches to avoid overwhelming the indexer on a large gap', async () => {
+        const safeScValToNativeSpy = vi.spyOn(contractEventIndexerService as any, 'safeScValToNative')
+        safeScValToNativeSpy.mockImplementation((val) => {
+            if (val === 'topic1') return 'portfolio'
+            if (val === 'topic2') return 'rebalance_executed'
+            if (val === 'gap-value') return ['portfolio-gap', 'user-abc']
+            return undefined
+        })
+
+        const dbMock = (await import('../services/databaseService.js')).databaseService as any
+        dbMock.getIndexerState.mockImplementation((key: string) =>
+            key === LATEST_LEDGER_KEY ? String(500) : undefined
+        )
+        ;(contractEventIndexerService as any).gapReplayThreshold = 10
+        ;(contractEventIndexerService as any).maxGapReplaySyncs = 2
+        ;(contractEventIndexerService as any).maxPagesPerSync = 1
+        ;(contractEventIndexerService as any).gapReplayBatchDelayMs = 0
+
+        rpcServerMock.getEvents.mockImplementation(mockEventsFrom(500))
+
+        const result = await contractEventIndexerService.runStartupGapReplay()
+
+        // The gap is 500 ledgers, but only `maxGapReplaySyncs` bounded sync
+        // passes run at startup; the rest is picked up by regular polling.
+        expect(result.replayed).toBe(true)
+        expect(result.batches).toBe(2)
+        expect(result.ingested).toBe(4) // 2 events per page × 1 page × 2 syncs
+        ;(contractEventIndexerService as any).maxPagesPerSync = 10
 
         safeScValToNativeSpy.mockRestore()
     })

--- a/backend/src/test/issuerMetadataService.test.ts
+++ b/backend/src/test/issuerMetadataService.test.ts
@@ -3,7 +3,11 @@ import { StellarToml, Horizon } from '@stellar/stellar-sdk'
 import {
   fetchIssuerMetadata,
   getCachedMetadata,
-  getMetadata
+  getMetadata,
+  fetchIssuerMetadataWithStatus,
+  getMetadataWithStatus,
+  forceRefreshMetadata,
+  warmIssuerMetadataCache
 } from '../services/issuerMetadataService.js'
 
 describe('IssuerMetadataService', () => {
@@ -123,5 +127,116 @@ describe('IssuerMetadataService', () => {
 
     expect(loadAccountSpy).toHaveBeenCalledWith(issuerAccount)
     expect(result).toBeUndefined()
+  })
+
+  it('serves stale cached metadata with a staleness flag when a refetch fails', async () => {
+    const mockToml = { ORG_NAME: 'Stale Org', VERSION: '1.0.0' }
+    const resolveSpy = vi
+      .spyOn(StellarToml.Resolver, 'resolve')
+      .mockResolvedValue(mockToml)
+
+    const domain = 'stale.org'
+    // Populate the cache, then let the entry expire so the next read refetches.
+    await fetchIssuerMetadata(domain)
+    vi.advanceTimersByTime(6 * 60 * 60 * 1000 + 1)
+
+    // The network refetch fails, so the expired entry is served flagged stale.
+    resolveSpy.mockRejectedValue(new Error('TOML host unreachable'))
+    const status = await fetchIssuerMetadataWithStatus(domain)
+
+    expect(resolveSpy).toHaveBeenCalledTimes(2)
+    expect(status.stale).toBe(true)
+    expect(status.source).toBe('stale')
+    expect(status.data.org_name).toBe('Stale Org')
+    expect(status.fetchedAtMs).toBeGreaterThan(0)
+    expect(status.expiresAtMs).toBeLessThanOrEqual(status.fetchedAtMs + 6 * 60 * 60 * 1000)
+  })
+
+  it('still propagates a fetch failure when nothing is cached to serve', async () => {
+    const resolveSpy = vi
+      .spyOn(StellarToml.Resolver, 'resolve')
+      .mockRejectedValue(new Error('TOML host unreachable'))
+
+    await expect(fetchIssuerMetadata('missing.org')).rejects.toThrow('TOML host unreachable')
+    expect(resolveSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('force refresh bypasses a fresh cache entry', async () => {
+    const resolveSpy = vi
+      .spyOn(StellarToml.Resolver, 'resolve')
+      .mockResolvedValueOnce({ ORG_NAME: 'Cached Org' })
+      .mockResolvedValueOnce({ ORG_NAME: 'Refreshed Org' })
+
+    const domain = 'refresh.org'
+    await fetchIssuerMetadata(domain)
+    expect(resolveSpy).toHaveBeenCalledTimes(1)
+
+    const status = await fetchIssuerMetadataWithStatus(domain, { forceRefresh: true })
+
+    expect(resolveSpy).toHaveBeenCalledTimes(2)
+    expect(status.source).toBe('network')
+    expect(status.stale).toBe(false)
+    expect(status.data.org_name).toBe('Refreshed Org')
+  })
+
+  it('forceRefreshMetadata refetches for an issuer account', async () => {
+    const loadAccountSpy = vi
+      .spyOn(Horizon.Server.prototype, 'loadAccount')
+      .mockResolvedValue({ home_domain: 'issuer-refresh.com' } as any)
+
+    const resolveSpy = vi
+      .spyOn(StellarToml.Resolver, 'resolve')
+      .mockResolvedValueOnce({ ORG_NAME: 'First Org' })
+      .mockResolvedValueOnce({ ORG_NAME: 'Second Org' })
+
+    const issuerAccount = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5'
+    const first = await forceRefreshMetadata(issuerAccount)
+    expect(loadAccountSpy).toHaveBeenCalledWith(issuerAccount)
+    expect(first.data.org_name).toBe('First Org')
+    expect(resolveSpy).toHaveBeenCalledTimes(1)
+
+    // Forced refresh bypasses the now-hot cache.
+    const second = await forceRefreshMetadata(issuerAccount)
+    expect(resolveSpy).toHaveBeenCalledTimes(2)
+    expect(second.data.org_name).toBe('Second Org')
+    expect(second.stale).toBe(false)
+  })
+
+  it('getMetadataWithStatus reports cache provenance for an account', async () => {
+    const mockAccount = { home_domain: 'status-domain.com' }
+    vi.spyOn(Horizon.Server.prototype, 'loadAccount').mockResolvedValue(mockAccount as any)
+
+    const resolveSpy = vi
+      .spyOn(StellarToml.Resolver, 'resolve')
+      .mockResolvedValue({ ORG_NAME: 'Status Org' })
+
+    const issuerAccount = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5'
+    const cold = await getMetadataWithStatus(issuerAccount)
+    expect(cold?.source).toBe('network')
+    expect(cold?.data.org_name).toBe('Status Org')
+    expect(resolveSpy).toHaveBeenCalledTimes(1)
+
+    const hot = await getMetadataWithStatus(issuerAccount)
+    expect(hot?.source).toBe('cache')
+    expect(resolveSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('warmIssuerMetadataCache prefetches metadata for the configured issuers', async () => {
+    const mockAccount = { home_domain: 'warm-domain.com' }
+    vi.spyOn(Horizon.Server.prototype, 'loadAccount').mockResolvedValue(mockAccount as any)
+
+    const resolveSpy = vi
+      .spyOn(StellarToml.Resolver, 'resolve')
+      .mockResolvedValue({ ORG_NAME: 'Warm Org' })
+
+    const issuerAccount = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5'
+    const warmed = await warmIssuerMetadataCache([issuerAccount])
+    expect(warmed).toBe(1)
+    expect(resolveSpy).toHaveBeenCalledTimes(1)
+
+    // Cache is hot for the warm-up domain now.
+    const status = await getMetadataWithStatus(issuerAccount)
+    expect(status?.source).toBe('cache')
+    expect(resolveSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/backend/src/test/rebalanceBatchPlans.routes.test.ts
+++ b/backend/src/test/rebalanceBatchPlans.routes.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
+import express, { type Express } from 'express'
+import cors from 'cors'
+import request from 'supertest'
+import { mkdirSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { Portfolio } from '../types/index.js'
+
+const PRICES = {
+  XLM: { price: 0.35, change: 0, timestamp: Date.now() },
+  USDC: { price: 1, change: 0, timestamp: Date.now() },
+}
+
+const FEED_META = {
+  provider: 'backend' as const,
+  resolvedAtMs: Date.now(),
+  degraded: false,
+  staleOrLimited: false,
+  resolutionHint: 'fresh_primary' as const,
+  assetsCount: 2,
+}
+
+const { mockGetPortfolio } = vi.hoisted(() => ({
+  mockGetPortfolio: vi.fn(),
+}))
+
+const { mockGetCurrentPricesWithMeta } = vi.hoisted(() => ({
+  mockGetCurrentPricesWithMeta: vi.fn(),
+}))
+
+const { mockExecuteRebalance } = vi.hoisted(() => ({
+  mockExecuteRebalance: vi.fn(),
+}))
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../services/reflector.js', () => {
+  function ReflectorService(this: unknown) {
+    ;(this as { getCurrentPricesWithMeta: typeof mockGetCurrentPricesWithMeta }).getCurrentPricesWithMeta = mockGetCurrentPricesWithMeta
+  }
+  return { ReflectorService }
+})
+
+vi.mock('../services/stellar.js', () => {
+  function StellarService(this: unknown) {
+    const self = this as Record<string, unknown>
+    self.createPortfolio = vi.fn()
+    self.getPortfolio = vi.fn()
+    self.executeRebalance = mockExecuteRebalance
+  }
+  return { StellarService }
+})
+
+vi.mock('../services/portfolioStorage.js', () => ({
+  portfolioStorage: {
+    getPortfolio: mockGetPortfolio,
+    getUserPortfolios: vi.fn().mockResolvedValue([]),
+    getAllPortfolios: vi.fn().mockResolvedValue([]),
+  },
+}))
+
+vi.mock('../services/databaseService.js', () => ({
+  databaseService: {
+    getPublicShareByPortfolioId: vi.fn(),
+    createPublicShare: vi.fn(),
+    revokePublicShare: vi.fn(),
+    getPublicShareByHash: vi.fn(),
+    createDraft: vi.fn(),
+    getDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    publishDraft: vi.fn(),
+    deleteDraft: vi.fn(),
+    listDrafts: vi.fn(),
+    hasFullConsent: vi.fn().mockReturnValue(true),
+  },
+}))
+
+vi.mock('../services/serviceContainer.js', () => ({
+  rebalanceHistoryService: { recordRebalanceEvent: vi.fn() },
+  riskManagementService: { shouldAllowRebalance: vi.fn().mockReturnValue({ allowed: true, reason: 'OK', alerts: [] }) },
+}))
+
+function makePortfolio(id: string, allocations: Record<string, number>, balances: Record<string, number>): Portfolio {
+  return {
+    id,
+    userAddress: 'GABC',
+    allocations,
+    threshold: 5,
+    balances,
+    totalValue: 0,
+    createdAt: new Date().toISOString(),
+    lastRebalance: new Date().toISOString(),
+    version: 1,
+  }
+}
+
+describe('POST /api/portfolios/rebalance-plans (batch, no trades)', () => {
+  let app: Express
+  let testDbPath: string
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test'
+    const testDir = join(tmpdir(), `rebalance-batch-plans-${Date.now()}`)
+    mkdirSync(testDir, { recursive: true })
+    testDbPath = join(testDir, 'test.db')
+    process.env.DB_PATH = testDbPath
+
+    const appInstance = express()
+    appInstance.use(cors({ origin: true, credentials: true }))
+    appInstance.use(express.json())
+    const { portfoliosRouter } = await import('../api/portfolios.routes.js')
+    appInstance.use('/api', portfoliosRouter)
+    app = appInstance
+  })
+
+  afterAll(() => {
+    if (existsSync(testDbPath)) {
+      try { rmSync(testDbPath, { force: true }) } catch { /* ignore */ }
+    }
+    delete process.env.DB_PATH
+    delete process.env.NODE_ENV
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetCurrentPricesWithMeta.mockResolvedValue({ prices: PRICES, feedMeta: FEED_META })
+    mockGetPortfolio.mockImplementation((id: string) => {
+      if (id === 'batch-a') {
+        return Promise.resolve(makePortfolio('batch-a', { XLM: 60, USDC: 40 }, { XLM: 1000, USDC: 100 }))
+      }
+      if (id === 'batch-b') {
+        return Promise.resolve(makePortfolio('batch-b', {}, {}))
+      }
+      return Promise.resolve(undefined)
+    })
+  })
+
+  it('computes plans for multiple portfolios and returns a combined summary', async () => {
+    const res = await request(app)
+      .post('/api/portfolios/rebalance-plans')
+      .send({ portfolioIds: ['batch-a', 'batch-b'] })
+      .expect(200)
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.plans.map((p: { portfolioId: string }) => p.portfolioId)).toEqual(['batch-a', 'batch-b'])
+    expect(res.body.data.failed).toEqual([])
+    expect(res.body.data.summary.totalPortfolios).toBe(2)
+    expect(res.body.data.summary.plansGenerated).toBe(2)
+    expect(res.body.data.summary.failedCount).toBe(0)
+    expect(res.body.data.summary.totalTrades).toBe(res.body.data.plans[0].estimatedFees.tradeCount)
+    // Batch-b is empty (zero trades), so the summary only reflects batch-a fees.
+    expect(res.body.data.summary.totalEstimatedFeesXlm).toBe(res.body.data.plans[0].estimatedFees.xlm)
+  })
+
+  it('isolates missing portfolios without blocking plans for the others', async () => {
+    const res = await request(app)
+      .post('/api/portfolios/rebalance-plans')
+      .send({ portfolioIds: ['batch-a', 'does-not-exist', 'batch-b'] })
+      .expect(200)
+
+    expect(res.body.data.plans.map((p: { portfolioId: string }) => p.portfolioId)).toEqual(['batch-a', 'batch-b'])
+    expect(res.body.data.failed).toEqual([{ portfolioId: 'does-not-exist', error: 'Portfolio not found' }])
+    expect(res.body.data.summary.plansGenerated).toBe(2)
+    expect(res.body.data.summary.failedCount).toBe(1)
+    expect(res.body.data.summary.totalPortfolios).toBe(3)
+  })
+
+  it('validates the request body', async () => {
+    const res = await request(app)
+      .post('/api/portfolios/rebalance-plans')
+      .send({ portfolioIds: [] })
+      .expect(422)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('does not execute any trades', async () => {
+    await request(app)
+      .post('/api/portfolios/rebalance-plans')
+      .send({ portfolioIds: ['batch-a'] })
+      .expect(200)
+
+    expect(mockExecuteRebalance).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/test/rebalancePlan.test.ts
+++ b/backend/src/test/rebalancePlan.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { buildRebalancePlan, buildBatchRebalancePlan } from '../services/rebalancePlan.js'
+import type { Portfolio, PricesMap, PriceFeedMeta } from '../types/index.js'
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const prices: PricesMap = {
+  XLM: { price: 0.35, change: 0, timestamp: Date.now() },
+  USDC: { price: 1, change: 0, timestamp: Date.now() },
+}
+
+const feedMeta: PriceFeedMeta = {
+  provider: 'backend',
+  resolvedAtMs: Date.now(),
+  degraded: false,
+  staleOrLimited: false,
+  resolutionHint: 'fresh_primary',
+  assetsCount: 2,
+}
+
+function makePortfolio(id: string, allocations: Record<string, number>, balances: Record<string, number>): Portfolio {
+  return {
+    id,
+    userAddress: 'GABC',
+    allocations,
+    threshold: 5,
+    balances,
+    totalValue: 0,
+    createdAt: new Date().toISOString(),
+    lastRebalance: new Date().toISOString(),
+    version: 1,
+  }
+}
+
+describe('buildRebalancePlan', () => {
+  beforeEach(() => {
+    delete process.env.REBALANCE_DRY_RUN_BASE_FEE_STROOPS
+  })
+
+  afterEach(() => {
+    delete process.env.REBALANCE_DRY_RUN_BASE_FEE_STROOPS
+  })
+
+  it('computes buy/sell/hold actions and fee estimate for a single portfolio', () => {
+    const portfolio = makePortfolio(
+      'p-1',
+      { XLM: 60, USDC: 40 },
+      { XLM: 1000, USDC: 100 },
+    )
+
+    const plan = buildRebalancePlan(portfolio, prices, feedMeta)
+
+    expect(plan.portfolioId).toBe('p-1')
+    expect(plan.assets.length).toBe(2)
+    const trades = plan.assets.filter((a) => a.action !== 'hold')
+    expect(trades.length).toBeGreaterThan(0)
+    expect(plan.estimatedFees.tradeCount).toBe(trades.length)
+    expect(plan.estimatedFees.xlm).toBeGreaterThan(0)
+    expect(plan.totalValue).toBeCloseTo(1000 * 0.35 + 100)
+  })
+
+  it('produces a zero-trade zero-fee plan for an empty portfolio', () => {
+    const portfolio = makePortfolio('p-empty', {}, {})
+    const plan = buildRebalancePlan(portfolio, prices, feedMeta)
+    expect(plan.assets).toEqual([])
+    expect(plan.estimatedFees.tradeCount).toBe(0)
+    expect(plan.estimatedFees.xlm).toBe(0)
+  })
+})
+
+describe('buildBatchRebalancePlan', () => {
+  it('plans a batch and aggregates total trades / fees', () => {
+    const portfolioA = makePortfolio(
+      'batch-a',
+      { XLM: 60, USDC: 40 },
+      { XLM: 1000, USDC: 100 },
+    )
+    const portfolioB = makePortfolio('batch-b', {}, {})
+
+    const result = buildBatchRebalancePlan([portfolioA, portfolioB], prices, feedMeta)
+
+    expect(result.plans.length).toBe(2)
+    expect(result.failed.length).toBe(0)
+    expect(result.summary.totalPortfolios).toBe(2)
+    expect(result.summary.plansGenerated).toBe(2)
+    expect(result.summary.failedCount).toBe(0)
+    expect(result.summary.totalTrades).toBe(result.plans[0].estimatedFees.tradeCount)
+    expect(result.summary.totalEstimatedFeesXlm).toBeCloseTo(result.plans[0].estimatedFees.xlm)
+    expect(result.summary.totalEstimatedFeesUsd).toBeCloseTo(result.plans[0].estimatedFees.usd)
+  })
+
+  it('isolates per-portfolio planning failures without blocking the rest', () => {
+    const goodPortfolio = makePortfolio(
+      'batch-good',
+      { XLM: 60, USDC: 40 },
+      { XLM: 1000, USDC: 100 },
+    )
+
+    // A portfolio whose allocations getter throws while being read.
+    const badPortfolio = makePortfolio('batch-bad', {}, {})
+    Object.defineProperty(badPortfolio, 'allocations', {
+      get() {
+        throw new Error('corrupt allocation data')
+      },
+    })
+
+    const result = buildBatchRebalancePlan([goodPortfolio, badPortfolio], prices, feedMeta)
+
+    expect(result.plans.map((p) => p.portfolioId)).toEqual(['batch-good'])
+    expect(result.failed).toEqual([
+      { portfolioId: 'batch-bad', error: 'corrupt allocation data' },
+    ])
+    expect(result.summary.plansGenerated).toBe(1)
+    expect(result.summary.failedCount).toBe(1)
+    expect(result.summary.totalPortfolios).toBe(2)
+    expect(result.summary.totalTrades).toBe(result.plans[0].estimatedFees.tradeCount)
+  })
+})

--- a/backend/src/test/stellarRpcFailover.test.ts
+++ b/backend/src/test/stellarRpcFailover.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// stellar.ts imports better-sqlite3 at module scope; the native binding is not
+// available in this environment, so stub it. The RPC pool does not touch the DB.
+vi.mock('better-sqlite3', () => {
+  const StubDatabase = vi.fn()
+  return { default: StubDatabase }
+})
+
+import {
+  SorobanRpcEndpointPool,
+  resolveSorobanRpcUrls,
+} from '../services/stellar.js'
+
+function makeServer(impl: Record<string, unknown> = {}) {
+  return {
+    getLatestLedger: vi.fn().mockResolvedValue({ sequence: 42 }),
+    getEvents: vi.fn().mockResolvedValue({ events: [], latestLedger: 42 }),
+    ...impl,
+  }
+}
+
+describe('SorobanRpcEndpointPool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fails over to the secondary endpoint when the primary is down', async () => {
+    const primary = makeServer({
+      getLatestLedger: vi.fn().mockRejectedValue(new Error('connection refused')),
+    })
+    const secondary = makeServer()
+
+    const factory = vi.fn((url: string) => (url.includes('primary') ? primary : secondary))
+    const pool = new SorobanRpcEndpointPool(['http://primary:8000', 'http://secondary:8000'], {
+      serverFactory: factory,
+    })
+
+    const result = await pool.call((s) => s.getLatestLedger())
+
+    expect(result.sequence).toBe(42)
+    expect(primary.getLatestLedger).toHaveBeenCalledTimes(1)
+    expect(secondary.getLatestLedger).toHaveBeenCalledTimes(1)
+    expect(primary.getLatestLedger).toHaveBeenCalled()
+    expect(secondary.getLatestLedger).toHaveBeenCalled()
+  })
+
+  it('prefers the responsive secondary on subsequent calls after a primary outage', async () => {
+    const primary = makeServer({
+      getLatestLedger: vi.fn().mockRejectedValue(new Error('timeout')),
+    })
+    const secondary = makeServer()
+
+    const factory = vi.fn((url: string) => (url.includes('primary') ? primary : secondary))
+    const pool = new SorobanRpcEndpointPool(['http://primary:8000', 'http://secondary:8000'], {
+      serverFactory: factory,
+    })
+
+    await pool.call((s) => s.getLatestLedger())
+    await pool.call((s) => s.getLatestLedger())
+    await pool.call((s) => s.getLatestLedger())
+
+    // Primary is cooling down after the failure, so the secondary serves every call.
+    expect(primary.getLatestLedger).toHaveBeenCalledTimes(1)
+    expect(secondary.getLatestLedger).toHaveBeenCalledTimes(3)
+    expect(pool.getStatus().preferredUrl).toBe('http://secondary:8000')
+  })
+
+  it('treats a call that exceeds the timeout as a failure and uses the next endpoint', async () => {
+    vi.useFakeTimers()
+    const primary = makeServer({
+      getLatestLedger: vi.fn(() => new Promise(() => { /* never resolves */ })),
+    })
+    const secondary = makeServer()
+
+    const factory = vi.fn((url: string) => (url.includes('primary') ? primary : secondary))
+    const pool = new SorobanRpcEndpointPool(['http://primary:8000', 'http://secondary:8000'], {
+      serverFactory: factory,
+      timeoutMs: 1000,
+    })
+
+    const pending = pool.call((s) => s.getLatestLedger())
+    await vi.advanceTimersByTimeAsync(1000)
+    const result = await pending
+
+    expect(result.sequence).toBe(42)
+    expect(primary.getLatestLedger).toHaveBeenCalledTimes(1)
+    expect(secondary.getLatestLedger).toHaveBeenCalledTimes(1)
+  })
+
+  it('steers toward the endpoint with the lowest latency once both have samples', async () => {
+    const slowPrimary = makeServer()
+    const fastSecondary = makeServer()
+
+    const factory = vi.fn((url: string) => (url.includes('primary') ? slowPrimary : fastSecondary))
+    const pool = new SorobanRpcEndpointPool(['http://primary:8000', 'http://secondary:8000'], {
+      serverFactory: factory,
+    })
+
+    // Primary has an accepted latency sample; secondary is faster.
+    pool.getEndpointHealths()[0].averageLatencyMs = 200
+    pool.getEndpointHealths()[1].averageLatencyMs = 15
+
+    await pool.call((s) => s.getLatestLedger())
+
+    expect(fastSecondary.getLatestLedger).toHaveBeenCalledTimes(1)
+    expect(slowPrimary.getLatestLedger).not.toHaveBeenCalled()
+  })
+
+  it('re-probes a cooled-down endpoint when no healthy endpoint remains', async () => {
+    vi.useFakeTimers()
+    const primary = makeServer()
+    primary.getLatestLedger.mockRejectedValueOnce(new Error('transient failure'))
+
+    const secondary = makeServer()
+    const factory = vi.fn((url: string) => (url.includes('primary') ? primary : secondary))
+    const pool = new SorobanRpcEndpointPool(['http://primary:8000', 'http://secondary:8000'], {
+      serverFactory: factory,
+      cooldownMs: 1000,
+    })
+
+    // Initial outage: primary fails, secondary serves the call.
+    await pool.call((s) => s.getLatestLedger())
+    expect(secondary.getLatestLedger).toHaveBeenCalledTimes(1)
+
+    // Now secondary goes down too. Once primary's cooldown elapses the pool
+    // probes it again and restores its health on success.
+    await vi.advanceTimersByTimeAsync(1000)
+    secondary.getLatestLedger.mockRejectedValue(new Error('secondary down'))
+    await pool.call((s) => s.getLatestLedger())
+
+    expect(primary.getLatestLedger).toHaveBeenCalledTimes(2)
+    expect(pool.getEndpointHealths()[0].healthy).toBe(true)
+    expect(pool.getEndpointHealths()[0].consecutiveFailures).toBe(0)
+  })
+
+  it('throws the last error when every endpoint fails', async () => {
+    const primary = makeServer({
+      getLatestLedger: vi.fn().mockRejectedValue(new Error('boom-a')),
+    })
+    const secondary = makeServer({
+      getLatestLedger: vi.fn().mockRejectedValue(new Error('boom-b')),
+    })
+    const factory = vi.fn((url: string) => (url.includes('primary') ? primary : secondary))
+    const pool = new SorobanRpcEndpointPool(['http://primary:8000', 'http://secondary:8000'], {
+      serverFactory: factory,
+    })
+
+    await expect(pool.call((s) => s.getLatestLedger())).rejects.toThrow('boom-b')
+  })
+
+  it('resolves configured URLs with multiple endpoints preferred over a single one', () => {
+    vi.stubEnv('SOROBAN_RPC_URLS', 'http://a, http://b ,http://a')
+    vi.stubEnv('SOROBAN_RPC_URL', 'http://legacy')
+    try {
+      expect(resolveSorobanRpcUrls()).toEqual(['http://a', 'http://b'])
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+})


### PR DESCRIPTION
closes #1414 
closes #1417 
closes #1420
closes #1421 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can view issuer metadata status, refresh metadata on demand, and use stale cached data when available.
  * Added batch rebalance planning for up to 50 portfolios, with combined summaries and per-portfolio failure details.
  * Batch planning remains preview-only and does not execute trades.
  * Issuer metadata can be preloaded during startup when enabled.

* **Reliability**
  * Improved network failover and recovery for Stellar data access.
  * Added automatic replay of missed contract events after extended downtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->