### PR TITLE
fix: guard against zero-record TWAP window in circuit breaker

### DIFF
--- a/contracts/src/circuit_breaker.rs
+++ b/contracts/src/circuit_breaker.rs
@@ -15,6 +15,13 @@ pub fn check_volatility(
         
         let records = (config.window_seconds / 60) as u32;
         
+        // An empty price history (records == 0) would otherwise lead to a
+        // divide-by-zero when averaging TWAP samples. Guard explicitly so we
+        // fail safely instead of panicking/returning an invalid ratio.
+        if records == 0 {
+            return Err(Error::InvalidThreshold);
+        }
+        
         if let Some(historical_price) = client.twap(&crate::reflector::Asset::Stellar(asset.clone()), &records) {
             if historical_price > 0 {
                 let diff = current_price - historical_price;


### PR DESCRIPTION
closes #1360 
closes #1361 
closes #1362 
closes #1363 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volatility evaluation by safely handling empty TWAP windows.
  * Prevented invalid calculations when no historical price records are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->