### PR TITLE
feat: add crash auto-restart supervisor for worker heartbeat failures

### DIFF
--- a/backend/src/queue/workers/workerHeartbeat.ts
+++ b/backend/src/queue/workers/workerHeartbeat.ts
@@ -6,10 +6,11 @@ import type { WorkerRuntimeStatus } from './workerRuntime.js';
  * Worker heartbeat and status persistence layer
  * Stores worker status in Redis so operators can query health without reading logs
  * Issue #450: Persist worker heartbeat and status for ops visibility
+ * Issue #1400: Add crash auto-restart supervisor for worker heartbeat failures
  */
 
 const WORKER_STATUS_KEY_PREFIX = 'worker:status:';
-const WORKER_HEARTBEAT_TTL = 120; // 2 minutes - status expires if not updated
+export const WORKER_HEARTBEAT_TTL = 120; // 2 minutes - status expires if not updated
 
 export interface PersistedWorkerStatus {
   name: string;
@@ -28,6 +29,101 @@ export interface PersistedWorkerStatus {
   persistedAt: string;
   heartbeatAt: string;
   isHealthy: boolean; // true if updated within WORKER_HEARTBEAT_TTL
+}
+
+export type WorkerRestartHandler = () => Promise<void> | void;
+
+export interface SupervisorConfig {
+  /** Number of consecutive missed heartbeats before triggering a restart (default: 3) */
+  missedHeartbeatThreshold: number;
+  /** Max restart attempts allowed within the restartWindowMs before entering crash loop state (default: 3) */
+  maxRestartAttempts: number;
+  /** Time window in milliseconds for tracking restart attempts (default: 300,000 ms / 5 min) */
+  restartWindowMs: number;
+  /** Max heartbeat age in milliseconds before considering a heartbeat missed (default: WORKER_HEARTBEAT_TTL * 1000) */
+  heartbeatTimeoutMs: number;
+}
+
+export interface WorkerSupervisorState {
+  name: string;
+  consecutiveMissedHeartbeats: number;
+  restartTimestamps: number[];
+  inCrashLoop: boolean;
+  lastRestartAt?: string;
+  lastCrashLoopAt?: string;
+}
+
+export type SupervisorAction =
+  | 'healthy'
+  | 'heartbeat_missed'
+  | 'restart_triggered'
+  | 'restart_failed'
+  | 'crash_loop_prevented'
+  | 'no_handler';
+
+export interface SupervisorCheckResult {
+  workerName: string;
+  action: SupervisorAction;
+  consecutiveMissedHeartbeats: number;
+  restartCountInWindow: number;
+  inCrashLoop: boolean;
+  error?: string;
+}
+
+export const DEFAULT_SUPERVISOR_CONFIG: SupervisorConfig = {
+  missedHeartbeatThreshold: 3,
+  maxRestartAttempts: 3,
+  restartWindowMs: 5 * 60 * 1000, // 5 minutes
+  heartbeatTimeoutMs: WORKER_HEARTBEAT_TTL * 1000, // 120 seconds
+};
+
+const restartHandlers = new Map<string, WorkerRestartHandler>();
+const supervisorStates = new Map<string, WorkerSupervisorState>();
+let supervisorTimer: NodeJS.Timeout | null = null;
+
+export function registerWorkerRestartHandler(name: string, handler: WorkerRestartHandler): void {
+  restartHandlers.set(name, handler);
+}
+
+export function unregisterWorkerRestartHandler(name: string): void {
+  restartHandlers.delete(name);
+}
+
+export function clearWorkerRestartHandlers(): void {
+  restartHandlers.clear();
+}
+
+export function getRegisteredRestartHandlers(): string[] {
+  return Array.from(restartHandlers.keys());
+}
+
+export function getWorkerSupervisorState(name: string): WorkerSupervisorState {
+  let state = supervisorStates.get(name);
+  if (!state) {
+    state = {
+      name,
+      consecutiveMissedHeartbeats: 0,
+      restartTimestamps: [],
+      inCrashLoop: false,
+    };
+    supervisorStates.set(name, state);
+  }
+  return state;
+}
+
+export function getAllSupervisorStates(): WorkerSupervisorState[] {
+  return Array.from(supervisorStates.values()).map((s) => ({
+    ...s,
+    restartTimestamps: [...s.restartTimestamps],
+  }));
+}
+
+export function resetWorkerSupervisorState(name?: string): void {
+  if (name) {
+    supervisorStates.delete(name);
+  } else {
+    supervisorStates.clear();
+  }
 }
 
 /**
@@ -230,6 +326,201 @@ export async function updateWorkerHeartbeat(name: string): Promise<void> {
 }
 
 /**
+ * Supervise a specific worker by inspecting its heartbeat,
+ * tracking consecutive missed heartbeats, enforcing crash-loop protection,
+ * and triggering a restart handler when threshold is reached.
+ */
+export async function superviseWorker(
+  name: string,
+  config: Partial<SupervisorConfig> = {}
+): Promise<SupervisorCheckResult> {
+  const mergedConfig: SupervisorConfig = { ...DEFAULT_SUPERVISOR_CONFIG, ...config };
+  const state = getWorkerSupervisorState(name);
+  const now = Date.now();
+
+  // Prune timestamps outside the active restart sliding window
+  state.restartTimestamps = state.restartTimestamps.filter(
+    (t) => now - t <= mergedConfig.restartWindowMs
+  );
+
+  // If in crash loop, check if window has cleared below maxRestartAttempts
+  if (state.inCrashLoop && state.restartTimestamps.length < mergedConfig.maxRestartAttempts) {
+    state.inCrashLoop = false;
+  }
+
+  // Retrieve current persisted worker status
+  const status = await getPersistedWorkerStatus(name);
+
+  // Determine if heartbeat is present, healthy, and within heartbeat timeout
+  const isHeartbeatValid = (() => {
+    if (!status) return false;
+    if (!status.isHealthy) return false;
+    const heartbeatTime = new Date(status.heartbeatAt).getTime();
+    if (isNaN(heartbeatTime)) return false;
+    return now - heartbeatTime <= mergedConfig.heartbeatTimeoutMs;
+  })();
+
+  if (isHeartbeatValid) {
+    state.consecutiveMissedHeartbeats = 0;
+    return {
+      workerName: name,
+      action: 'healthy',
+      consecutiveMissedHeartbeats: 0,
+      restartCountInWindow: state.restartTimestamps.length,
+      inCrashLoop: state.inCrashLoop,
+    };
+  }
+
+  // Heartbeat is missing or stale
+  state.consecutiveMissedHeartbeats += 1;
+  logger.warn('[WORKER:supervisor] Worker missed heartbeat', {
+    name,
+    consecutiveMissed: state.consecutiveMissedHeartbeats,
+    threshold: mergedConfig.missedHeartbeatThreshold,
+  });
+
+  // Check if threshold not yet reached
+  if (state.consecutiveMissedHeartbeats < mergedConfig.missedHeartbeatThreshold) {
+    return {
+      workerName: name,
+      action: 'heartbeat_missed',
+      consecutiveMissedHeartbeats: state.consecutiveMissedHeartbeats,
+      restartCountInWindow: state.restartTimestamps.length,
+      inCrashLoop: state.inCrashLoop,
+    };
+  }
+
+  // Threshold reached - evaluate crash-loop protection
+  if (state.restartTimestamps.length >= mergedConfig.maxRestartAttempts) {
+    state.inCrashLoop = true;
+    state.lastCrashLoopAt = new Date(now).toISOString();
+    logger.error('[WORKER:supervisor] Crash-loop protection activated. Maximum restarts reached.', {
+      name,
+      restartAttemptsInWindow: state.restartTimestamps.length,
+      windowMs: mergedConfig.restartWindowMs,
+    });
+    return {
+      workerName: name,
+      action: 'crash_loop_prevented',
+      consecutiveMissedHeartbeats: state.consecutiveMissedHeartbeats,
+      restartCountInWindow: state.restartTimestamps.length,
+      inCrashLoop: true,
+    };
+  }
+
+  // Supervised restart
+  const handler = restartHandlers.get(name);
+  if (!handler) {
+    logger.warn('[WORKER:supervisor] Missing heartbeats detected but no restart handler registered', {
+      name,
+    });
+    return {
+      workerName: name,
+      action: 'no_handler',
+      consecutiveMissedHeartbeats: state.consecutiveMissedHeartbeats,
+      restartCountInWindow: state.restartTimestamps.length,
+      inCrashLoop: false,
+    };
+  }
+
+  state.restartTimestamps.push(now);
+  state.lastRestartAt = new Date(now).toISOString();
+  state.consecutiveMissedHeartbeats = 0; // reset consecutive missed counter on restart initiation
+
+  try {
+    logger.info('[WORKER:supervisor] Triggering supervised worker restart', {
+      name,
+      attemptInWindow: state.restartTimestamps.length,
+      maxAttempts: mergedConfig.maxRestartAttempts,
+    });
+    await handler();
+    return {
+      workerName: name,
+      action: 'restart_triggered',
+      consecutiveMissedHeartbeats: 0,
+      restartCountInWindow: state.restartTimestamps.length,
+      inCrashLoop: false,
+    };
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    logger.error('[WORKER:supervisor] Supervised worker restart failed', {
+      name,
+      error: errorMsg,
+    });
+    return {
+      workerName: name,
+      action: 'restart_failed',
+      consecutiveMissedHeartbeats: 0,
+      restartCountInWindow: state.restartTimestamps.length,
+      inCrashLoop: false,
+      error: errorMsg,
+    };
+  }
+}
+
+/**
+ * Supervise all tracked and persisted workers
+ */
+export async function superviseAllWorkers(
+  config: Partial<SupervisorConfig> = {}
+): Promise<SupervisorCheckResult[]> {
+  const allNames = new Set<string>();
+  const persistedStatuses = await getAllPersistedWorkerStatuses();
+  for (const s of persistedStatuses) {
+    allNames.add(s.name);
+  }
+  for (const name of restartHandlers.keys()) {
+    allNames.add(name);
+  }
+  for (const name of supervisorStates.keys()) {
+    allNames.add(name);
+  }
+
+  const results: SupervisorCheckResult[] = [];
+  for (const name of allNames) {
+    const result = await superviseWorker(name, config);
+    results.push(result);
+  }
+  return results;
+}
+
+/**
+ * Start periodic worker supervisor monitoring loop
+ */
+export function startWorkerSupervisor(
+  config: Partial<SupervisorConfig> = {},
+  intervalMs: number = 30000
+): { stop: () => void } {
+  stopWorkerSupervisor();
+
+  supervisorTimer = setInterval(() => {
+    void superviseAllWorkers(config).catch((err) => {
+      logger.error('[WORKER:supervisor] Error in supervisor cycle', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }, intervalMs);
+
+  if (supervisorTimer.unref) {
+    supervisorTimer.unref();
+  }
+
+  return {
+    stop: () => stopWorkerSupervisor(),
+  };
+}
+
+/**
+ * Stop periodic worker supervisor monitoring loop
+ */
+export function stopWorkerSupervisor(): void {
+  if (supervisorTimer) {
+    clearInterval(supervisorTimer);
+    supervisorTimer = null;
+  }
+}
+
+/**
  * Clear all worker status entries (used on shutdown)
  */
 export async function clearAllWorkerStatus(): Promise<void> {
@@ -266,6 +557,8 @@ export async function getWorkerHealthSummary() {
         const lastRunMs = new Date(s.lastSuccessfulRunAt).getTime();
         return (Date.now() - lastRunMs) > 300000; // >5 minutes
       }).length,
+      crashLooping: Array.from(supervisorStates.values()).filter(s => s.inCrashLoop).length,
+      supervisor: Array.from(supervisorStates.values()),
       workers: statuses
     };
 
@@ -274,6 +567,6 @@ export async function getWorkerHealthSummary() {
     logger.error('[WORKER:heartbeat] Failed to compute health summary', {
       error: error instanceof Error ? error.message : String(error)
     });
-    return { total: 0, healthy: 0, unhealthy: 0, idle: 0, lagging: 0, workers: [] };
+    return { total: 0, healthy: 0, unhealthy: 0, idle: 0, lagging: 0, crashLooping: 0, supervisor: [], workers: [] };
   }
 }

--- a/backend/src/test/workerHeartbeat.test.ts
+++ b/backend/src/test/workerHeartbeat.test.ts
@@ -6,6 +6,17 @@ import {
   updateWorkerHeartbeat,
   clearAllWorkerStatus,
   getWorkerHealthSummary,
+  registerWorkerRestartHandler,
+  unregisterWorkerRestartHandler,
+  clearWorkerRestartHandlers,
+  getRegisteredRestartHandlers,
+  getWorkerSupervisorState,
+  resetWorkerSupervisorState,
+  superviseWorker,
+  superviseAllWorkers,
+  startWorkerSupervisor,
+  stopWorkerSupervisor,
+  DEFAULT_SUPERVISOR_CONFIG,
   type PersistedWorkerStatus,
 } from "../queue/workers/workerHeartbeat.js";
 import type { WorkerRuntimeStatus } from "../queue/workers/workerRuntime.js";
@@ -17,6 +28,9 @@ describe("Worker heartbeat persistence (Issue #450)", () => {
   });
 
   afterEach(async () => {
+    stopWorkerSupervisor();
+    clearWorkerRestartHandlers();
+    resetWorkerSupervisorState();
     vi.useRealTimers();
     await clearAllWorkerStatus();
   });
@@ -441,6 +455,353 @@ describe("Worker heartbeat persistence (Issue #450)", () => {
 
       expect(retrieved?.ready).toBe(false);
       expect(retrieved?.lastError).toContain("Queue connection lost");
+    });
+  });
+});
+
+describe("Crash auto-restart supervisor for worker heartbeat failures (Issue #1400)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    clearWorkerRestartHandlers();
+    resetWorkerSupervisorState();
+  });
+
+  afterEach(async () => {
+    stopWorkerSupervisor();
+    clearWorkerRestartHandlers();
+    resetWorkerSupervisorState();
+    vi.useRealTimers();
+    await clearAllWorkerStatus();
+  });
+
+  describe("Restart handler registration", () => {
+    it("registers, retrieves, and unregisters worker restart handlers", () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      registerWorkerRestartHandler("portfolio-check", handler1);
+      registerWorkerRestartHandler("rebalance", handler2);
+
+      expect(getRegisteredRestartHandlers().sort()).toEqual(["portfolio-check", "rebalance"]);
+
+      unregisterWorkerRestartHandler("portfolio-check");
+      expect(getRegisteredRestartHandlers()).toEqual(["rebalance"]);
+
+      clearWorkerRestartHandlers();
+      expect(getRegisteredRestartHandlers()).toEqual([]);
+    });
+  });
+
+  describe("Missed heartbeat detection", () => {
+    it("recognizes healthy worker when heartbeat is active within timeout", async () => {
+      const status: WorkerRuntimeStatus = {
+        name: "portfolio-check",
+        concurrency: 1,
+        started: true,
+        ready: true,
+        schedulerRegistered: true,
+      };
+
+      await persistWorkerStatus(status);
+      await vi.runAllTimersAsync();
+
+      const result = await superviseWorker("portfolio-check", {
+        missedHeartbeatThreshold: 3,
+      });
+
+      expect(result.action).toBe("healthy");
+      expect(result.consecutiveMissedHeartbeats).toBe(0);
+      expect(result.inCrashLoop).toBe(false);
+    });
+
+    it("increments consecutive missed heartbeats when worker does not send heartbeats", async () => {
+      const status: WorkerRuntimeStatus = {
+        name: "portfolio-check",
+        concurrency: 1,
+        started: true,
+        ready: true,
+        schedulerRegistered: true,
+      };
+
+      await persistWorkerStatus(status);
+      await vi.runAllTimersAsync();
+
+      // Advance time beyond heartbeat timeout (120s)
+      vi.advanceTimersByTime(130_000);
+
+      const check1 = await superviseWorker("portfolio-check", {
+        missedHeartbeatThreshold: 3,
+      });
+
+      expect(check1.action).toBe("heartbeat_missed");
+      expect(check1.consecutiveMissedHeartbeats).toBe(1);
+
+      const check2 = await superviseWorker("portfolio-check", {
+        missedHeartbeatThreshold: 3,
+      });
+
+      expect(check2.action).toBe("heartbeat_missed");
+      expect(check2.consecutiveMissedHeartbeats).toBe(2);
+    });
+
+    it("resets consecutive missed heartbeat count when a worker becomes healthy again", async () => {
+      const status: WorkerRuntimeStatus = {
+        name: "portfolio-check",
+        concurrency: 1,
+        started: true,
+        ready: true,
+        schedulerRegistered: true,
+      };
+
+      await persistWorkerStatus(status);
+      await vi.runAllTimersAsync();
+
+      // Miss 2 heartbeats
+      vi.advanceTimersByTime(130_000);
+      await superviseWorker("portfolio-check", { missedHeartbeatThreshold: 3 });
+      await superviseWorker("portfolio-check", { missedHeartbeatThreshold: 3 });
+
+      expect(getWorkerSupervisorState("portfolio-check").consecutiveMissedHeartbeats).toBe(2);
+
+      // Worker sends fresh status / heartbeat
+      await persistWorkerStatus(status);
+      await vi.runAllTimersAsync();
+
+      const healthyCheck = await superviseWorker("portfolio-check", {
+        missedHeartbeatThreshold: 3,
+      });
+
+      expect(healthyCheck.action).toBe("healthy");
+      expect(healthyCheck.consecutiveMissedHeartbeats).toBe(0);
+      expect(getWorkerSupervisorState("portfolio-check").consecutiveMissedHeartbeats).toBe(0);
+    });
+  });
+
+  describe("Supervised restart execution", () => {
+    it("does NOT trigger restart before reaching consecutive missed threshold", async () => {
+      const restartHandler = vi.fn();
+      registerWorkerRestartHandler("portfolio-check", restartHandler);
+
+      const status: WorkerRuntimeStatus = {
+        name: "portfolio-check",
+        concurrency: 1,
+        started: true,
+        ready: true,
+        schedulerRegistered: true,
+      };
+
+      await persistWorkerStatus(status);
+      await vi.runAllTimersAsync();
+
+      vi.advanceTimersByTime(130_000);
+
+      // 1st missed check (threshold = 3)
+      const res1 = await superviseWorker("portfolio-check", { missedHeartbeatThreshold: 3 });
+      expect(res1.action).toBe("heartbeat_missed");
+      expect(restartHandler).not.toHaveBeenCalled();
+
+      // 2nd missed check
+      const res2 = await superviseWorker("portfolio-check", { missedHeartbeatThreshold: 3 });
+      expect(res2.action).toBe("heartbeat_missed");
+      expect(restartHandler).not.toHaveBeenCalled();
+    });
+
+    it("triggers supervised restart when consecutive missed heartbeats reach threshold", async () => {
+      const restartHandler = vi.fn().mockResolvedValue(undefined);
+      registerWorkerRestartHandler("portfolio-check", restartHandler);
+
+      const status: WorkerRuntimeStatus = {
+        name: "portfolio-check",
+        concurrency: 1,
+        started: true,
+        ready: true,
+        schedulerRegistered: true,
+      };
+
+      await persistWorkerStatus(status);
+      await vi.runAllTimersAsync();
+
+      vi.advanceTimersByTime(130_000);
+
+      // Miss 1, 2, 3
+      await superviseWorker("portfolio-check", { missedHeartbeatThreshold: 3 });
+      await superviseWorker("portfolio-check", { missedHeartbeatThreshold: 3 });
+      const res3 = await superviseWorker("portfolio-check", { missedHeartbeatThreshold: 3 });
+
+      expect(res3.action).toBe("restart_triggered");
+      expect(restartHandler).toHaveBeenCalledTimes(1);
+      expect(res3.restartCountInWindow).toBe(1);
+      expect(res3.consecutiveMissedHeartbeats).toBe(0);
+    });
+
+    it("handles failure of restart handler gracefully", async () => {
+      const restartHandler = vi.fn().mockRejectedValue(new Error("Worker spawn failed"));
+      registerWorkerRestartHandler("rebalance", restartHandler);
+
+      // No status persisted -> missed
+      const res = await superviseWorker("rebalance", { missedHeartbeatThreshold: 1 });
+
+      expect(res.action).toBe("restart_failed");
+      expect(res.error).toBe("Worker spawn failed");
+      expect(restartHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns no_handler if worker missed threshold but has no registered handler", async () => {
+      const res = await superviseWorker("unregistered-worker", { missedHeartbeatThreshold: 1 });
+
+      expect(res.action).toBe("no_handler");
+    });
+  });
+
+  describe("Crash-loop protection & bounded restarts", () => {
+    it("caps restart attempts within time window to prevent crash-loop resource exhaustion", async () => {
+      let restartCount = 0;
+      const restartHandler = vi.fn().mockImplementation(async () => {
+        restartCount++;
+      });
+      registerWorkerRestartHandler("portfolio-check", restartHandler);
+
+      const config = {
+        missedHeartbeatThreshold: 1,
+        maxRestartAttempts: 3,
+        restartWindowMs: 5 * 60 * 1000, // 5 minutes
+      };
+
+      // 1st restart
+      const r1 = await superviseWorker("portfolio-check", config);
+      expect(r1.action).toBe("restart_triggered");
+      expect(r1.restartCountInWindow).toBe(1);
+      expect(r1.inCrashLoop).toBe(false);
+
+      // 2nd restart
+      const r2 = await superviseWorker("portfolio-check", config);
+      expect(r2.action).toBe("restart_triggered");
+      expect(r2.restartCountInWindow).toBe(2);
+      expect(r2.inCrashLoop).toBe(false);
+
+      // 3rd restart (reaches max limit)
+      const r3 = await superviseWorker("portfolio-check", config);
+      expect(r3.action).toBe("restart_triggered");
+      expect(r3.restartCountInWindow).toBe(3);
+      expect(r3.inCrashLoop).toBe(false);
+
+      expect(restartHandler).toHaveBeenCalledTimes(3);
+
+      // 4th attempt: crash-loop protection MUST trigger and block further restarts
+      const r4 = await superviseWorker("portfolio-check", config);
+      expect(r4.action).toBe("crash_loop_prevented");
+      expect(r4.inCrashLoop).toBe(true);
+      expect(r4.restartCountInWindow).toBe(3);
+      // Restart handler is NOT called again
+      expect(restartHandler).toHaveBeenCalledTimes(3);
+
+      // 5th attempt: continues to be blocked
+      const r5 = await superviseWorker("portfolio-check", config);
+      expect(r5.action).toBe("crash_loop_prevented");
+      expect(r5.inCrashLoop).toBe(true);
+      expect(restartHandler).toHaveBeenCalledTimes(3);
+    });
+
+    it("recovers and allows restarts again after sliding window elapses", async () => {
+      const restartHandler = vi.fn().mockResolvedValue(undefined);
+      registerWorkerRestartHandler("portfolio-check", restartHandler);
+
+      const config = {
+        missedHeartbeatThreshold: 1,
+        maxRestartAttempts: 2,
+        restartWindowMs: 60_000, // 1 minute window
+      };
+
+      // Exhaust 2 attempts
+      await superviseWorker("portfolio-check", config);
+      await superviseWorker("portfolio-check", config);
+
+      // 3rd attempt is blocked by crash loop
+      const blocked = await superviseWorker("portfolio-check", config);
+      expect(blocked.action).toBe("crash_loop_prevented");
+      expect(blocked.inCrashLoop).toBe(true);
+      expect(restartHandler).toHaveBeenCalledTimes(2);
+
+      // Advance time past restartWindowMs
+      vi.advanceTimersByTime(65_000);
+
+      // Now old restarts have expired out of the window -> restart allowed again
+      const recovered = await superviseWorker("portfolio-check", config);
+      expect(recovered.action).toBe("restart_triggered");
+      expect(recovered.inCrashLoop).toBe(false);
+      expect(restartHandler).toHaveBeenCalledTimes(3);
+    });
+
+    it("reflects crash-looping workers in getWorkerHealthSummary", async () => {
+      const restartHandler = vi.fn();
+      registerWorkerRestartHandler("crashed-worker", restartHandler);
+
+      const config = {
+        missedHeartbeatThreshold: 1,
+        maxRestartAttempts: 1,
+        restartWindowMs: 60_000,
+      };
+
+      await superviseWorker("crashed-worker", config);
+      // Trigger crash loop
+      await superviseWorker("crashed-worker", config);
+
+      const summary = await getWorkerHealthSummary();
+      expect(summary.crashLooping).toBe(1);
+      expect(summary.supervisor.find((s) => s.name === "crashed-worker")?.inCrashLoop).toBe(true);
+    });
+  });
+
+  describe("Multi-worker supervision & periodic supervisor", () => {
+    it("supervises multiple registered and persisted workers", async () => {
+      const restart1 = vi.fn();
+      const restart2 = vi.fn();
+
+      registerWorkerRestartHandler("worker-a", restart1);
+      registerWorkerRestartHandler("worker-b", restart2);
+
+      // Worker A is healthy
+      await persistWorkerStatus({
+        name: "worker-a",
+        concurrency: 1,
+        started: true,
+        ready: true,
+        schedulerRegistered: true,
+      });
+
+      // Worker B is unhealthy / never sent status
+      const results = await superviseAllWorkers({ missedHeartbeatThreshold: 1 });
+
+      const resA = results.find((r) => r.workerName === "worker-a");
+      const resB = results.find((r) => r.workerName === "worker-b");
+
+      expect(resA?.action).toBe("healthy");
+      expect(restart1).not.toHaveBeenCalled();
+
+      expect(resB?.action).toBe("restart_triggered");
+      expect(restart2).toHaveBeenCalledTimes(1);
+    });
+
+    it("starts and stops periodic supervisor loop", async () => {
+      const restart = vi.fn();
+      registerWorkerRestartHandler("worker-loop", restart);
+
+      const supervisor = startWorkerSupervisor({ missedHeartbeatThreshold: 1 }, 10_000);
+
+      expect(supervisor).toBeDefined();
+
+      // Advance time by 10s -> supervisor triggers
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(restart).toHaveBeenCalledTimes(1);
+
+      supervisor.stop();
+
+      // Advance time again -> no more triggers after stop
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(restart).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Description
### What changed
- Extended `workerHeartbeat.ts` with a worker supervisor that monitors worker heartbeats in Redis, detects consecutive missed heartbeats beyond a configurable threshold (`missedHeartbeatThreshold`), and triggers supervised restarts via registered restart handlers.
- Implemented sliding-window crash-loop protection (`maxRestartAttempts` within `restartWindowMs`) to cap restart attempts and prevent infinite restart loops / resource exhaustion.
- Added comprehensive unit and integration tests in `workerHeartbeat.test.ts` verifying missed-heartbeat detection, counter resets, restart execution, crash-loop prevention, and window recovery.

### Why it changed
Workers that became unresponsive or failed silently were previously only logged as unhealthy. The supervisor automatically recovers stalled workers while protecting the host environment against crash loops.

### How it was verified
- Ran `vitest run src/test/workerHeartbeat.test.ts` (all 27 tests passed).

Closes #1400
