### PR TITLE
feat(contracts): add two-step admin transfer (propose/accept)

### DIFF
--- a/contracts/CONTRACT_ABI.md
+++ b/contracts/CONTRACT_ABI.md
@@ -35,6 +35,36 @@ For main domain terms used in this contract, see [docs/GLOSSARY.md](../docs/GLOS
 - **Notes:**
   - External clients can use this to confirm the configured governance/admin address before invoking privileged actions.
 
+### `propose_admin(env: Env, new_admin: Address) -> Result<(), Error>`
+
+- **Purpose:** Step 1 of the two-step admin transfer — nominates `new_admin` as the pending admin and emits `admin_proposed`.
+- **Auth:** Requires auth from the current admin (`DataKey::Admin`).
+- **Parameters:**
+  - `new_admin`: address nominated to take over the admin role.
+- **Errors:**
+  - `InvalidAdminProposal` (39) when `new_admin` is already the current admin.
+- **Notes:**
+  - Nomination alone grants nothing: every admin-gated entrypoint keeps reading `DataKey::Admin`, which is only rewritten by `accept_admin`.
+  - Calling it again **replaces** a proposal still in flight, so the current admin can retarget — or effectively cancel — a mistaken nomination by proposing a different address.
+  - This is the only path that changes the admin after `initialize`; there is no single-call `set_admin`.
+
+### `accept_admin(env: Env) -> Result<(), Error>`
+
+- **Purpose:** Step 2 of the two-step admin transfer — the pending admin claims the role. Rewrites `DataKey::Admin`, clears `DataKey::PendingAdmin`, and emits `admin_transferred`.
+- **Auth:** Requires auth from the address stored by `propose_admin`; any other caller fails the invocation. Requiring the incoming admin to sign is what proves the key is controllable, so a handover can never complete against a typo'd or unusable address.
+- **Errors:**
+  - `NoPendingAdmin` (38) when no transfer is in flight (never proposed, or already accepted).
+- **Notes:**
+  - The previous admin loses every admin right the moment this returns.
+  - Not replayable — the nomination is consumed, so a second call returns `NoPendingAdmin`.
+
+### `get_pending_admin(env: Env) -> Option<Address>`
+
+- **Purpose:** Reads the address nominated by `propose_admin` and still awaiting its `accept_admin` call.
+- **Returns:** `Some(address)` while a transfer is in flight, `None` otherwise.
+- **Notes:**
+  - Lets clients and monitoring surface a pending governance handover before it takes effect.
+
 ### `create_portfolio(env: Env, user: Address, target_allocations: Map<Address, u32>, asset_decimals: Map<Address, u32>, rebalance_threshold: u32, slippage_tolerance: u32, slippage_policy_version: u32) -> Result<u64, Error>`
 
 - **Purpose:** Creates a new user portfolio (with default `StrategyType::Threshold` strategy) and emits a `("portfolio","created")` event.
@@ -359,6 +389,8 @@ For main domain terms used in this contract, see [docs/GLOSSARY.md](../docs/GLOS
 | `31` | `TemplateNotFound` | `update_template` or `create_portfolio_from_template` referenced a template name that does not exist. | Call `list_templates` to see available names, or `create_template` first. |
 | `32` | `TemplateAlreadyExists` | `create_template` was called with a name that is already in use. | Use `update_template` to change an existing template, or choose a different name. |
 | `33` | `TooManyTemplates` | The template registry already holds `MAX_TEMPLATES` (50) entries. | There is no delete entrypoint. Repurpose an existing template's allocations via `update_template` instead of creating a new one. |
+| `38` | `NoPendingAdmin` | `accept_admin` was called while no admin transfer is in flight. | Have the current admin call `propose_admin` first, or check `get_pending_admin` before accepting. |
+| `39` | `InvalidAdminProposal` | `propose_admin` was called with the address that is already the current admin. | Propose a different address; re-proposing the incumbent would be a no-op transfer. |
 
 For common invocation examples and debugging commands, see the [Soroban Cookbook](../docs/soroban-cookbook.md).
 

--- a/contracts/src/events.rs
+++ b/contracts/src/events.rs
@@ -49,3 +49,22 @@ pub fn emit_dca_executed(env: &Env, invoker: &Address, portfolio_id: u64, amount
     );
 }
 
+/// Step 1 of the two-step admin transfer: `current_admin` nominated
+/// `pending_admin`, which does not hold any admin rights until it calls
+/// `accept_admin`. Re-emitted whenever a proposal overwrites an earlier one.
+pub fn emit_admin_proposed(env: &Env, current_admin: &Address, pending_admin: &Address) {
+    env.events().publish(
+        (Symbol::new(env, "admin_proposed"), current_admin.clone()),
+        pending_admin.clone(),
+    );
+}
+
+/// Step 2 of the two-step admin transfer: `new_admin` accepted the pending
+/// proposal and is now the contract admin; `previous_admin` has lost all
+/// admin rights as of this event.
+pub fn emit_admin_transferred(env: &Env, previous_admin: &Address, new_admin: &Address) {
+    env.events().publish(
+        (Symbol::new(env, "admin_transferred"), previous_admin.clone()),
+        new_admin.clone(),
+    );
+}

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -110,6 +110,63 @@ impl PortfolioRebalancer {
         env.storage().instance().get(&DataKey::Admin).unwrap()
     }
 
+    /// Step 1 of the two-step admin transfer: nominate `new_admin`.
+    ///
+    /// Admin-only. Nomination alone grants `new_admin` nothing — every
+    /// admin-gated entrypoint keeps checking `DataKey::Admin`, which is only
+    /// rewritten once `new_admin` calls [`accept_admin`] itself. This makes
+    /// an admin handover impossible to complete against an address that
+    /// cannot sign (a typo, a contract with no auth path, a lost key).
+    ///
+    /// Calling this again replaces any proposal still in flight, so the
+    /// current admin can retarget or effectively cancel a mistaken nomination
+    /// by proposing a different address.
+    pub fn propose_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+
+        if new_admin == admin {
+            return Err(Error::InvalidAdminProposal);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingAdmin, &new_admin);
+        events::emit_admin_proposed(&env, &admin, &new_admin);
+        Ok(())
+    }
+
+    /// Step 2 of the two-step admin transfer: the pending admin claims the role.
+    ///
+    /// Callable only by the address stored by [`propose_admin`] — it must
+    /// authorize this call itself, which is what proves the incoming admin
+    /// controls the key. On success `DataKey::Admin` is rewritten, the
+    /// pending nomination is cleared, and the previous admin loses every
+    /// admin right immediately.
+    ///
+    /// Returns [`Error::NoPendingAdmin`] when no transfer is in flight.
+    pub fn accept_admin(env: Env) -> Result<(), Error> {
+        let pending_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(Error::NoPendingAdmin)?;
+        pending_admin.require_auth();
+
+        let previous_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        env.storage().instance().set(&DataKey::Admin, &pending_admin);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+
+        events::emit_admin_transferred(&env, &previous_admin, &pending_admin);
+        Ok(())
+    }
+
+    /// The address nominated by [`propose_admin`] and still awaiting its
+    /// [`accept_admin`] call, or `None` when no transfer is in flight.
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::PendingAdmin)
+    }
+
     pub fn create_portfolio(
         env: Env,
         user: Address,

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -5116,3 +5116,407 @@ fn test_create_portfolio_from_unknown_template_rejected() {
     );
     assert_eq!(result, Err(Ok(Error::TemplateNotFound)));
 }
+
+// ── Two-step admin transfer (propose / accept) ───────────────────────────
+
+/// Register and initialize the contract with a known admin *without* leaning
+/// on `env.mock_all_auths()`, so the admin-transfer tests below can mock auth
+/// per-address and prove who is actually allowed to call what.
+///
+/// Returns `(contract_id, admin)`; callers build their own client so each test
+/// keeps control of the auth entries it mocks.
+fn init_with_scoped_auth(env: &Env) -> (Address, Address) {
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(env);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize",
+                args: (&admin, &reflector_id).into_val(env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(&admin, &reflector_id);
+
+    (contract_id, admin)
+}
+
+#[test]
+fn test_two_step_admin_transfer_happy_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    assert_eq!(client.get_pending_admin(), None, "no transfer in flight yet");
+
+    // Step 1: propose. The incumbent is still the admin at this point.
+    client.propose_admin(&new_admin);
+    assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+    assert_eq!(
+        client.get_admin(),
+        admin,
+        "proposing must not hand over admin rights on its own"
+    );
+
+    // Step 2: accept. Only now does the admin actually change.
+    client.accept_admin();
+    assert_eq!(client.get_admin(), new_admin);
+    assert_eq!(
+        client.get_pending_admin(),
+        None,
+        "pending nomination is cleared once accepted"
+    );
+}
+
+#[test]
+fn test_two_step_admin_transfer_emits_events_at_each_step() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    client.propose_admin(&new_admin);
+
+    let proposed = all_events(&env)
+        .into_iter()
+        .rev()
+        .find(|(_, topics, _)| match topics.first() {
+            Some(topic) => match Symbol::try_from_val(&env, &topic) {
+                Ok(sym) => sym == Symbol::new(&env, "admin_proposed"),
+                Err(_) => false,
+            },
+            None => false,
+        })
+        .expect("propose_admin emits admin_proposed");
+    assert_eq!(
+        Address::try_from_val(&env, &proposed.1.get(1).unwrap()).unwrap(),
+        admin,
+        "admin_proposed is topic-indexed by the proposing admin"
+    );
+    let proposed_data: Address = proposed.2.into_val(&env);
+    assert_eq!(proposed_data, new_admin);
+
+    client.accept_admin();
+
+    let transferred = all_events(&env)
+        .into_iter()
+        .rev()
+        .find(|(_, topics, _)| match topics.first() {
+            Some(topic) => match Symbol::try_from_val(&env, &topic) {
+                Ok(sym) => sym == Symbol::new(&env, "admin_transferred"),
+                Err(_) => false,
+            },
+            None => false,
+        })
+        .expect("accept_admin emits admin_transferred");
+    assert_eq!(
+        Address::try_from_val(&env, &transferred.1.get(1).unwrap()).unwrap(),
+        admin,
+        "admin_transferred is topic-indexed by the outgoing admin"
+    );
+    let transferred_data: Address = transferred.2.into_val(&env);
+    assert_eq!(transferred_data, new_admin);
+}
+
+#[test]
+fn test_propose_admin_overwrites_pending_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let first_candidate = Address::generate(&env);
+    let second_candidate = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    client.propose_admin(&first_candidate);
+    client.propose_admin(&second_candidate);
+
+    assert_eq!(
+        client.get_pending_admin(),
+        Some(second_candidate.clone()),
+        "the newest proposal replaces the one in flight"
+    );
+
+    // The superseded candidate can no longer claim the role; the live one can.
+    client.accept_admin();
+    assert_eq!(client.get_admin(), second_candidate);
+}
+
+#[test]
+#[should_panic]
+fn test_superseded_candidate_cannot_accept_admin() {
+    let env = Env::default();
+
+    let (contract_id, admin) = init_with_scoped_auth(&env);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let first_candidate = Address::generate(&env);
+    let second_candidate = Address::generate(&env);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "propose_admin",
+                args: (&first_candidate,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .propose_admin(&first_candidate);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "propose_admin",
+                args: (&second_candidate,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .propose_admin(&second_candidate);
+
+    // `accept_admin` requires auth from the *stored* pending admin, which the
+    // second proposal overwrote, so the superseded candidate cannot finalize.
+    client
+        .mock_auths(&[MockAuth {
+            address: &first_candidate,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "accept_admin",
+                args: vec![&env],
+                sub_invokes: &[],
+            },
+        }])
+        .accept_admin();
+}
+
+#[test]
+#[should_panic]
+fn test_accept_admin_by_non_pending_address_rejected() {
+    let env = Env::default();
+
+    let (contract_id, admin) = init_with_scoped_auth(&env);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let new_admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "propose_admin",
+                args: (&new_admin,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .propose_admin(&new_admin);
+
+    // Only the nominated address can finalize: `accept_admin` calls
+    // `require_auth()` on the address read from `DataKey::PendingAdmin`, so an
+    // auth entry signed by anyone else fails the invocation.
+    client
+        .mock_auths(&[MockAuth {
+            address: &attacker,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "accept_admin",
+                args: vec![&env],
+                sub_invokes: &[],
+            },
+        }])
+        .accept_admin();
+}
+
+#[test]
+#[should_panic]
+fn test_propose_admin_by_non_admin_rejected() {
+    let env = Env::default();
+
+    let (contract_id, _admin) = init_with_scoped_auth(&env);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let attacker = Address::generate(&env);
+    let attacker_pick = Address::generate(&env);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &attacker,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "propose_admin",
+                args: (&attacker_pick,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .propose_admin(&attacker_pick);
+}
+
+#[test]
+fn test_accept_admin_without_pending_proposal_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    assert_eq!(client.try_accept_admin(), Err(Ok(Error::NoPendingAdmin)));
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_accept_admin_is_not_replayable() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    client.propose_admin(&new_admin);
+    client.accept_admin();
+
+    // The nomination was consumed, so a replay finds nothing pending rather
+    // than re-running the handover.
+    assert_eq!(client.try_accept_admin(), Err(Ok(Error::NoPendingAdmin)));
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+#[test]
+fn test_propose_admin_rejects_current_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PortfolioRebalancer);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &reflector_id);
+
+    assert_eq!(
+        client.try_propose_admin(&admin),
+        Err(Ok(Error::InvalidAdminProposal))
+    );
+    assert_eq!(client.get_pending_admin(), None);
+}
+
+#[test]
+fn test_admin_rights_move_to_new_admin_after_transfer() {
+    let env = Env::default();
+
+    let (contract_id, admin) = init_with_scoped_auth(&env);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let new_admin = Address::generate(&env);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "propose_admin",
+                args: (&new_admin,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .propose_admin(&new_admin);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &new_admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "accept_admin",
+                args: vec![&env],
+                sub_invokes: &[],
+            },
+        }])
+        .accept_admin();
+
+    assert_eq!(client.get_admin(), new_admin);
+
+    // The new admin can exercise an admin-only entrypoint...
+    client
+        .mock_auths(&[MockAuth {
+            address: &new_admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "set_emergency_stop",
+                args: vec![&env, true.into_val(&env)],
+                sub_invokes: &[],
+            },
+        }])
+        .set_emergency_stop(&true);
+}
+
+#[test]
+#[should_panic]
+fn test_previous_admin_loses_rights_after_transfer() {
+    let env = Env::default();
+
+    let (contract_id, admin) = init_with_scoped_auth(&env);
+    let client = PortfolioRebalancerClient::new(&env, &contract_id);
+    let new_admin = Address::generate(&env);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "propose_admin",
+                args: (&new_admin,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .propose_admin(&new_admin);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &new_admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "accept_admin",
+                args: vec![&env],
+                sub_invokes: &[],
+            },
+        }])
+        .accept_admin();
+
+    // ...and the outgoing admin can no longer: admin-gated entrypoints read
+    // `DataKey::Admin`, which now holds `new_admin`.
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "set_emergency_stop",
+                args: vec![&env, true.into_val(&env)],
+                sub_invokes: &[],
+            },
+        }])
+        .set_emergency_stop(&true);
+}

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -286,6 +286,10 @@ pub enum DataKey {
     /// Marks `Address` as a registered operator (scoped permission distinct
     /// from full Admin rights) when present and `true`.
     Operator(Address),
+    /// Address nominated by the current admin via `propose_admin`, pending
+    /// its own `accept_admin` call. Cleared once the transfer completes.
+    /// Absence of this key means no admin transfer is in flight.
+    PendingAdmin,
 }
 
 #[contracttype]
@@ -341,6 +345,12 @@ pub enum Error {
     /// Caller authenticated successfully but is neither the contract admin
     /// nor a registered operator for an operator-eligible entrypoint.
     Unauthorized = 37,
+    /// `accept_admin` was called while no admin transfer is in flight
+    /// (`propose_admin` has never run, or the transfer already completed).
+    NoPendingAdmin = 38,
+    /// A proposed admin is required to differ from the current admin;
+    /// re-proposing the incumbent would be a no-op transfer.
+    InvalidAdminProposal = 39,
 }
 
 #[contracttype]

--- a/docs/CONTRACT_EVENTS.md
+++ b/docs/CONTRACT_EVENTS.md
@@ -80,6 +80,19 @@ Aligned with `contracts/src/lib.rs` and `contracts/src/portfolio.rs`.
 
 **Synonyms:** the indexer accepts `rebalance_executed` or `executed` as the second topic for the rebalance event (same payload rules).
 
+### Governance: two-step admin transfer
+
+Admin handover does not use the `portfolio` topic domain — both events are topic-indexed by the **admin address acting at that step**, so a watcher can filter on the outgoing admin:
+
+| Topic[0]             | Topic[1]                  | Payload      | Emitted by       |
+| -------------------- | ------------------------- | ------------ | ---------------- |
+| `admin_proposed`     | `current_admin: Address`  | `Address`    | `propose_admin`  |
+| `admin_transferred`  | `previous_admin: Address` | `Address`    | `accept_admin`   |
+
+The payload is the incoming admin in both cases: the nominee for `admin_proposed`, the address that actually took the role for `admin_transferred`.
+
+Because the transfer is two-step, `admin_proposed` is **not** a change of authority — `DataKey::Admin` is untouched until the matching `admin_transferred` lands. A proposal may be superseded by a later `admin_proposed` from the same admin (the newest nomination wins) and may never be accepted at all, so consumers must treat `admin_transferred` as the only authoritative signal that the admin changed. There is no single-call `set_admin`: after `initialize`, every admin change produces exactly this pair of events.
+
 The `deposit` event now includes a `memo: String` field at tuple index `3`. Backend indexers must decode the 4-tuple `(u64, Address, i128, String)` instead of the previous 3-tuple.
 
 ## Payload parsing (backend)


### PR DESCRIPTION
Admin was set once at `initialize` with no transfer path at all, so handing over governance meant redeploying. Adding a single-call `set_admin` would have made the handover irreversible against a typo'd or unusable address, so this uses the propose/accept pattern instead.

- `propose_admin(new_admin)` is admin-only and records the nominee under the new `DataKey::PendingAdmin`. It grants nothing on its own: every admin-gated entrypoint keeps reading `DataKey::Admin`. Calling it again replaces a proposal still in flight, so the current admin can retarget or effectively cancel a mistaken nomination.
- `accept_admin()` requires auth from the stored pending admin, which is what proves the incoming key is controllable. It rewrites `DataKey::Admin`, clears the nomination (so it is not replayable), and drops the previous admin's rights immediately.
- `get_pending_admin()` exposes an in-flight handover to clients.
- Both steps emit an event (`admin_proposed`, `admin_transferred`), topic-indexed by the admin acting at that step.
- New errors: `NoPendingAdmin` (38), `InvalidAdminProposal` (39).

`DataKey::PendingAdmin` is appended to the enum; `#[contracttype]` unit variants serialize by name, so no stored key changes shape and no storage schema bump is needed.

Tests cover the happy path, both events, proposal overwrite, replay, accept with no proposal, and rejection of accept by a non-pending or superseded address, plus the rights actually moving off the old admin.

Also documents the entrypoints, error codes, and events in contracts/CONTRACT_ABI.md and docs/CONTRACT_EVENTS.md.

Closes #1352
Closes #1351
Closes #1350
Closes #1349

# Description

Please include a summary of the changes and the related issue(s) being resolved.

**Every PR must link to an issue.** If this PR intentionally has no related issue, explain why in the rationale section below.

Fixes # (issue)

> Rationale for no issue (if applicable):

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] DevOps / CI / Documentation update

# 📖 API Changes & Breaking Changes Checklist

If your changes affect any HTTP route, request/response schema, database schema, or CLI/contract signature:

- [ ] **OpenAPI Spec:** Updated `backend/src/openapi/spec.ts` (and exported `backend/openapi.json` via `npm run openapi:export`).
- [ ] **API Documentation:** Updated `API.md` and/or `docs/API.md` explaining route/schema behavior changes.
- [ ] **Changelog:** Added a corresponding entry in `CHANGELOG.md` under the `[Unreleased]` section.
- [ ] **Migration Notes:** Provided instructions for consumers if the change is a breaking or material behavior shift.

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] **This PR links to an issue or provides a rationale for no issue**
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a two-step admin transfer process: administrators can propose a replacement, who must accept the transfer.
  * Added visibility into pending admin proposals.
  * Added events for proposed and completed admin transfers.
  * Added validation to prevent invalid, unauthorized, or repeated transfers.

* **Documentation**
  * Documented the new admin transfer functions, events, and related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->