### PR TITLE
feat: readiness queue backlog depth check + rebalance lock contention metrics

### DIFF
--- a/backend/src/monitoring/readiness.ts
+++ b/backend/src/monitoring/readiness.ts
@@ -92,6 +92,67 @@ async function checkQueueReady(
   }
 }
 
+// ── Queue backlog depth readiness (#1404) ──────────────────────────────────
+//
+// A queue can report "ready" (connected, waitUntilReady() resolves) while
+// still carrying a backlog so deep that new jobs will sit for minutes before
+// a worker picks them up. That's a real degradation the connectivity check
+// above can't see. This adds a `waiting + delayed` count check against a
+// configurable threshold so orchestrators can route traffic away from an
+// instance whose queue is falling behind, before it becomes a customer-
+// visible incident.
+let backlogReadyThreshold = parseInt(
+  process.env.QUEUE_BACKLOG_READY_THRESHOLD || "500",
+  10,
+);
+if (!Number.isInteger(backlogReadyThreshold) || backlogReadyThreshold < 0) {
+  backlogReadyThreshold = 500;
+}
+
+export function setQueueBacklogReadyThreshold(threshold: number): void {
+  backlogReadyThreshold = threshold;
+}
+
+interface BacklogQueueLike {
+  getJobCounts(...types: string[]): Promise<Record<string, number>>;
+}
+
+async function checkQueueBacklogDepth(
+  name: string,
+  queue: BacklogQueueLike | null,
+): Promise<ReadinessCheck> {
+  if (!queue) {
+    // Connectivity check above already reports "not_ready" for a missing
+    // queue — backlog depth is meaningless without a queue to measure, so
+    // this sub-check is simply disabled rather than double-reporting.
+    return buildCheck("disabled", false, `${name} queue is not initialized`);
+  }
+
+  try {
+    const counts = await withTimeout(
+      queue.getJobCounts("waiting", "delayed"),
+      3000,
+      `${name} queue backlog depth check timed out`,
+    );
+    const depth = (counts.waiting || 0) + (counts.delayed || 0);
+    const status: ReadinessState = depth > backlogReadyThreshold ? "not_ready" : "ready";
+    return buildCheck(
+      status,
+      true,
+      status === "ready"
+        ? `${name} queue backlog is within threshold`
+        : `${name} queue backlog (${depth}) exceeds threshold (${backlogReadyThreshold})`,
+      { depth, threshold: backlogReadyThreshold, waiting: counts.waiting || 0, delayed: counts.delayed || 0 },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return buildCheck("not_ready", true, `${name} queue backlog depth check failed`, {
+      error: message,
+      degradedReason: message,
+    });
+  }
+}
+
 export async function buildReadinessReport() {
   const now = Date.now()
   if (cache && cache.expiresAt > now) {
@@ -305,9 +366,32 @@ export async function buildReadinessReport() {
           autoRebalancerStatus as unknown as Record<string, unknown>,
         );
 
+  const queueBacklogCheck = !redisConnected
+    ? buildCheck("disabled", false, "Queue backlog check disabled — Redis unavailable")
+    : await (async () => {
+        const [portfolioBacklog, rebalanceBacklog] = await Promise.all([
+          checkQueueBacklogDepth(QUEUE_NAMES.PORTFOLIO_CHECK, getPortfolioCheckQueue()),
+          checkQueueBacklogDepth(QUEUE_NAMES.REBALANCE, getRebalanceQueue()),
+        ]);
+        const queues = {
+          [QUEUE_NAMES.PORTFOLIO_CHECK]: portfolioBacklog,
+          [QUEUE_NAMES.REBALANCE]: rebalanceBacklog,
+        };
+        const allReady = [portfolioBacklog, rebalanceBacklog].every(
+          (c) => !c.required || c.status === "ready",
+        );
+        return buildCheck(
+          allReady ? "ready" : "not_ready",
+          true,
+          allReady ? "Queue backlogs are within threshold" : "One or more queue backlogs exceed threshold",
+          { queues },
+        );
+      })();
+
   const checks = {
     database: databaseCheck,
     queue: queueCheck,
+    queueBacklog: queueBacklogCheck,
     workers: workersCheck,
     contractEventIndexer: indexerCheck,
     autoRebalancer: autoRebalancerCheck,

--- a/backend/src/observability/metrics.ts
+++ b/backend/src/observability/metrics.ts
@@ -352,3 +352,47 @@ export function recordNotificationDeliveryAttempt(
 ): void {
     notificationDeliveryAttemptsTotal.inc({ channel, outcome })
 }
+
+// ── Per-portfolio rebalance lock contention metrics (#1399) ─────────────────
+//
+// `rebalanceLockService.acquireLock` returning false means a second caller
+// (auto-rebalancer job + a manual API call, or two overlapping scheduled
+// runs) collided on the same portfolio's lock. That's invisible today —
+// silently rejected with no signal — which makes "is our lock actually
+// preventing double-rebalances, or is it just failing quietly all the time"
+// unanswerable from the outside. `backend` here is `redis` or `memory` so a
+// spike in `memory`-backed contention (single-node fallback, no real mutual
+// exclusion across instances) is distinguishable from expected `redis`
+// contention.
+//
+// No portfolio_id label: with potentially thousands of portfolios this would
+// blow up cardinality for a metric whose value is in aggregate rate/trend,
+// not per-ID inspection — use logs (rebalanceLock.ts already logs failures)
+// to drill into a specific portfolio.
+
+const lockContentionTotal = new Counter({
+    name: `${observabilityConfig.metrics.prefix}rebalance_lock_contention_total`,
+    help: 'Total rebalance lock acquisition attempts that failed because the lock was already held',
+    labelNames: ['backend'] as const,
+    registers: [register],
+})
+
+const lockHoldDuration = new Histogram({
+    name: `${observabilityConfig.metrics.prefix}rebalance_lock_hold_duration_seconds`,
+    help: 'Duration a rebalance lock was held, from acquire to release',
+    labelNames: ['backend'] as const,
+    buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300],
+    registers: [register],
+})
+
+export type LockBackend = 'redis' | 'memory'
+
+/** Call when `acquireLock` returns false — the lock was already held. */
+export function recordLockContention(backend: LockBackend): void {
+    lockContentionTotal.inc({ backend })
+}
+
+/** Call from `releaseLock` with the elapsed time since the matching `acquireLock` succeeded. */
+export function recordLockHoldDuration(backend: LockBackend, durationSeconds: number): void {
+    lockHoldDuration.observe({ backend }, durationSeconds)
+}

--- a/backend/src/services/rebalanceLock.ts
+++ b/backend/src/services/rebalanceLock.ts
@@ -2,6 +2,7 @@ import Redis from 'ioredis'
 import { REDIS_URL, isRedisAvailable } from '../queue/connection.js'
 import { logger } from '../utils/logger.js'
 import { getRebalanceLockConfig } from '../config/rebalanceLockConfig.js'
+import { recordLockContention, recordLockHoldDuration, type LockBackend } from '../observability/metrics.js'
 
 /**
  * Service to manage concurrency locks for portfolio rebalancing.
@@ -12,6 +13,8 @@ export class RebalanceLockService {
     private redis: Redis | null = null
     private fallbackLocks: Map<string, number> = new Map()
     private fallbackHeartbeats: Map<string, number> = new Map()
+    // #1399 — acquire timestamp per lock, used to record hold duration on release.
+    private acquiredAt: Map<string, number> = new Map()
     private isInitialized: boolean = false
     private useRedis: boolean = false
     private static instance: RebalanceLockService | null = null
@@ -71,7 +74,14 @@ export class RebalanceLockService {
             try {
                 const result = await this.redis.set(lockKey, Date.now().toString(), 'PX', ttlMs, 'NX')
 
-                return result === 'OK'
+                const acquired = result === 'OK'
+                if (acquired) {
+                    this.acquiredAt.set(lockKey, Date.now())
+                } else {
+                    // #1399 — the lock was already held by another caller.
+                    recordLockContention('redis')
+                }
+                return acquired
             } catch (error) {
                 logger.error(`[LOCK_SERVICE] Failed to acquire Redis lock for ${portfolioId}`, {
                     error: error instanceof Error ? error.message : String(error)
@@ -93,6 +103,16 @@ export class RebalanceLockService {
 
         const lockKey = this.getLockKey(portfolioId)
 
+        // #1399 — record how long this lock was held, backend-labeled so a
+        // spike in memory-backed holds (no real cross-instance exclusion) is
+        // distinguishable from expected Redis contention.
+        const acquiredAt = this.acquiredAt.get(lockKey)
+        if (acquiredAt !== undefined) {
+            const backend: LockBackend = this.useRedis ? 'redis' : 'memory'
+            recordLockHoldDuration(backend, (Date.now() - acquiredAt) / 1000)
+            this.acquiredAt.delete(lockKey)
+        }
+
         if (this.useRedis && this.redis) {
             try {
                 await this.redis.del(lockKey)
@@ -101,8 +121,8 @@ export class RebalanceLockService {
                     error: error instanceof Error ? error.message : String(error)
                 })
             }
-        } 
-        
+        }
+
         // Always clean up memory lock just in case
         this.fallbackLocks.delete(lockKey)
     }
@@ -256,11 +276,14 @@ export class RebalanceLockService {
         const existingExpiry = this.fallbackLocks.get(lockKey)
 
         if (existingExpiry && existingExpiry > now) {
-            return false // Lock is currently held and active
+            // #1399 — the lock is currently held and active.
+            recordLockContention('memory')
+            return false
         }
 
         // Lock is either not held or expired
         this.fallbackLocks.set(lockKey, now + ttlMs)
+        this.acquiredAt.set(lockKey, now)
         return true
     }
 


### PR DESCRIPTION
## Summary

- **#1404** — `buildReadinessReport` only checked that queues were connected, not whether they were actually falling behind. Added `checkQueueBacklogDepth` (`waiting + delayed` job count vs `QUEUE_BACKLOG_READY_THRESHOLD`, default 500) for the portfolio-check and rebalance queues, surfaced as a new required `queueBacklog` check.
- **#1399** — `RebalanceLockService` had no observability into lock contention. Added `rebalance_lock_contention_total` (Counter, labeled by `backend`: redis/memory) incremented on every failed acquire, and `rebalance_lock_hold_duration_seconds` (Histogram) recorded on release.

## Test plan
- [ ] `GET /ready` with an artificially inflated queue backlog (push > 500 jobs to portfolio-check queue) — confirm `queueBacklog` reports `not_ready` and overall status flips
- [ ] `GET /metrics` — confirm `rebalance_lock_contention_total` increments when two concurrent `acquireLock` calls target the same portfolio
- [ ] `rebalance_lock_hold_duration_seconds` records a sample on `releaseLock`

Closes #1404
Closes #1399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added readiness monitoring for queue backlogs, including configurable thresholds and overall system status reporting.
  * Added metrics for rebalance lock contention and lock hold duration across Redis and in-memory processing.

* **Monitoring**
  * Improved visibility into queue congestion and lock performance to support faster operational diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->