### PR TITLE
fix: circuit breaker trip must actually engage EmergencyStop

### DIFF
--- a/contracts/src/circuit_breaker.rs
+++ b/contracts/src/circuit_breaker.rs
@@ -29,10 +29,15 @@ pub fn check_volatility(
                 let deviation_bps = (diff_abs * 10000) / historical_price;
                 
                 if deviation_bps > config.spike_threshold_bps as i128 {
+                    // Engage the same EmergencyStop guard `set_emergency_stop`
+                    // uses, not just the reason — otherwise the trip is
+                    // recorded but deposits/withdrawals/rebalances (which all
+                    // gate on `DataKey::EmergencyStop`) stay unblocked.
+                    env.storage().instance().set(&DataKey::EmergencyStop, &true);
                     env.storage()
                         .instance()
                         .set(&DataKey::ContractPauseReason, &PauseReason::VolatilityCircuitBreaker);
-                    
+
                     env.events().publish(
                         (Symbol::new(env, "circuit_breaker_tripped"), asset.clone()),
                         (deviation_bps, PauseReason::VolatilityCircuitBreaker, env.ledger().timestamp() + config.window_seconds)

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -3332,11 +3332,15 @@ fn test_circuit_breaker_boundary_just_above_threshold_trips_with_exact_reason() 
     assert_ne!(pause_reason, PauseReason::AdminEmergency);
     assert_ne!(pause_reason, PauseReason::UserPaused);
     assert_ne!(pause_reason, PauseReason::CooldownActive);
-    // NOTE: check_volatility() only persists ContractPauseReason — it does not
-    // flip DataKey::EmergencyStop, which is the only flag execute_rebalance
-    // actually checks. So this attempt is not currently blocked by the trip.
-    // Flagging this as a pre-existing gap rather than asserting a false pass.
-    let _ = client.try_execute_rebalance(&pid, &Map::new(&env));
+    // check_volatility() now flips DataKey::EmergencyStop alongside
+    // ContractPauseReason, so the trip actually blocks further calls —
+    // not just records a reason nothing else checks.
+    let result = client.try_execute_rebalance(&pid, &Map::new(&env));
+    assert_eq!(
+        result,
+        Err(Ok(Error::EmergencyStop)),
+        "a circuit breaker trip must actually block execute_rebalance, not just record a reason"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`check_volatility()` persisted `PauseReason::VolatilityCircuitBreaker` on a trip but never flipped `DataKey::EmergencyStop` — the only flag `deposit`/`withdraw`/`execute_rebalance` actually check before proceeding. A volatility spike got recorded as a reason but didn't block anything, unlike the admin `set_emergency_stop()` path, which sets both.

Now sets `EmergencyStop` alongside the pause reason, matching `set_emergency_stop()`'s existing behavior. Also updates `test_circuit_breaker_boundary_just_above_threshold_trips_with_exact_reason`, which previously had a comment documenting this exact gap and asserted nothing about it — it now asserts `execute_rebalance` is actually blocked by a trip.

All 163 contract tests pass (`cargo test --features testutils`).

Closes #1344
Closes #1339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Circuit breaker trips now activate the emergency stop when volatility exceeds the configured threshold.
  * Guarded operations, including rebalancing, are blocked while the emergency stop is active.
  * Improved validation confirms the correct emergency-stop error is returned after a circuit-breaker trip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->