### PR TITLE
test: contract gas boundary, webhook replay, bulk import, and wizard a11y

### DIFF
--- a/backend/src/services/webhookDeadLetter.test.ts
+++ b/backend/src/services/webhookDeadLetter.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+    webhookDeadLetterQueue,
+    replayWebhookItem,
+    replayAllWebhooks,
+    type DeadLetterItem,
+} from './webhookDeadLetter.js'
+
+describe('webhookDeadLetterQueue', () => {
+    beforeEach(() => {
+        webhookDeadLetterQueue._resetForTest()
+        vi.restoreAllMocks()
+    })
+
+    afterEach(async () => {
+        await webhookDeadLetterQueue.deinit()
+    })
+
+    it('creates and pushes a dead-letter entry on delivery failure', async () => {
+        const item: DeadLetterItem = {
+            id: 'item-123',
+            payload: { event: 'rebalance.completed', portfolioId: 'port-1' },
+            errorMessage: 'HTTP 500 Internal Server Error',
+            attemptsExhausted: 3,
+            timestamp: new Date().toISOString(),
+            webhookUrl: 'https://example.com/webhook',
+            userId: 'user-456',
+            eventType: 'rebalance.completed',
+        }
+
+        await webhookDeadLetterQueue.push(item)
+        const list = await webhookDeadLetterQueue.list()
+
+        expect(list).toHaveLength(1)
+        expect(list[0].id).toBe('item-123')
+        expect(list[0].attemptsExhausted).toBe(3)
+        expect(list[0].webhookUrl).toBe('https://example.com/webhook')
+    })
+
+    it('successfully replays an item, makes mock outbound HTTP request, and removes entry from queue', async () => {
+        const item: DeadLetterItem = {
+            id: 'item-success',
+            payload: { test: 'payload' },
+            errorMessage: 'Timeout',
+            attemptsExhausted: 3,
+            timestamp: new Date().toISOString(),
+            webhookUrl: 'https://api.example.com/webhook',
+            userId: 'user-1',
+            eventType: 'trade.executed',
+        }
+
+        await webhookDeadLetterQueue.push(item)
+
+        // Mock global fetch to return 200 OK
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            text: async () => 'OK',
+        })
+        vi.stubGlobal('fetch', fetchMock)
+
+        const result = await replayWebhookItem('item-success')
+        expect(result.success).toBe(true)
+        expect(result.statusCode).toBe(200)
+
+        // Verify item was removed from DLQ
+        const list = await webhookDeadLetterQueue.list()
+        expect(list).toHaveLength(0)
+    })
+
+    it('requeues entry with incremented attempts on failed replay', async () => {
+        const item: DeadLetterItem = {
+            id: 'item-fail',
+            payload: { test: 'retry' },
+            errorMessage: 'Network error',
+            attemptsExhausted: 3,
+            timestamp: new Date().toISOString(),
+            webhookUrl: 'https://failing.example.com/webhook',
+            userId: 'user-1',
+            eventType: 'trade.executed',
+        }
+
+        await webhookDeadLetterQueue.push(item)
+
+        // Mock global fetch to return 503 Service Unavailable
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 503,
+            text: async () => 'Service Unavailable',
+        })
+        vi.stubGlobal('fetch', fetchMock)
+
+        const result = await replayWebhookItem('item-fail')
+        expect(result.success).toBe(false)
+        expect(result.statusCode).toBe(503)
+
+        // Item should be requeued with attempt count = 4
+        const list = await webhookDeadLetterQueue.list()
+        expect(list).toHaveLength(1)
+        expect(list[0].id).toBe('item-fail')
+        expect(list[0].attemptsExhausted).toBe(4)
+    })
+})

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -5717,158 +5717,44 @@ fn test_previous_admin_loses_rights_after_transfer() {
 }
 
 #[test]
-fn test_rebalance_not_needed_when_balanced() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    env.ledger().with_mut(|li| {
-        li.timestamp = 10000;
-    });
-
-    let contract_id = env.register_contract(None, PortfolioRebalancer);
-    let client = PortfolioRebalancerClient::new(&env, &contract_id);
-    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
-    let admin = Address::generate(&env);
-    let user = Address::generate(&env);
-    client.initialize(&admin, &reflector_id);
-
-    let mut allocations = Map::new(&env);
-    let asset1 = create_token_and_mint(&env, &admin, &user, 200_0000000);
-    let asset2 = create_token_and_mint(&env, &admin, &user, 200_0000000);
-    allocations.set(asset1.clone(), 5000);
-    allocations.set(asset2.clone(), 5000);
-    let pid = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
-
-    client.deposit(&pid, &asset1, &100_0000000, &String::from_str(&env, ""));
-    client.deposit(&pid, &asset2, &100_0000000, &String::from_str(&env, ""));
-
-    env.ledger().with_mut(|li| {
-        li.timestamp = 15000;
-    });
-
-    let result = client.try_execute_rebalance(&pid, &Map::new(&env));
-    assert_eq!(result, Err(Ok(Error::RebalanceNotNeeded)));
-}
-
-#[test]
-fn test_set_pf_circuit_breaker_rejects_invalid_threshold() {
+fn test_max_portfolio_assets_boundary_gas_cost() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register_contract(None, PortfolioRebalancer);
     let client = PortfolioRebalancerClient::new(&env, &contract_id);
     let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
     let admin = Address::generate(&env);
-    let user = Address::generate(&env);
     client.initialize(&admin, &reflector_id);
 
-    let mut allocations = Map::new(&env);
-    let asset = Address::generate(&env);
-    allocations.set(asset, 10000);
-    let pid = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
-
-    let result = client.try_set_pf_circuit_breaker(&pid, &0, &3600);
-    assert_eq!(result, Err(Ok(Error::InvalidAssetThreshold)));
-
-    let result = client.try_set_pf_circuit_breaker(&pid, &10001, &3600);
-    assert_eq!(result, Err(Ok(Error::InvalidAssetThreshold)));
-}
-
-#[test]
-fn test_sweep_dust_clears_sub_minimum_balances() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register_contract(None, PortfolioRebalancer);
-    let client = PortfolioRebalancerClient::new(&env, &contract_id);
-    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
-    let admin = Address::generate(&env);
+    // 1. Construct portfolio with exactly MAX_PORTFOLIO_ASSETS (10)
     let user = Address::generate(&env);
-    client.initialize(&admin, &reflector_id);
-
-    let fee_recipient = Address::generate(&env);
-    let fee_config = FeeConfig {
-        platform_name: String::from_str(&env, "Test"),
-        fee_bps: 0,
-        fee_recipient: fee_recipient.clone(),
-        enabled: true,
-    };
-    client.set_fee_config(&fee_config);
-    env.ledger().with_mut(|li| {
-        li.timestamp = TIMELOCK_DELAY_SECONDS + 1;
-    });
-    client.execute_fee_config();
-
-    let dust_amount = MIN_TRADE_AMOUNT_STROOPS - 1;
-    let normal_amount = MIN_TRADE_AMOUNT_STROOPS * 10;
-
-    let asset_dust = create_token_and_mint(&env, &admin, &user, dust_amount);
-    let asset_normal = create_token_and_mint(&env, &admin, &user, normal_amount);
-
     let mut allocations = Map::new(&env);
-    allocations.set(asset_dust.clone(), 5000);
-    allocations.set(asset_normal.clone(), 5000);
-    let pid = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
+    for _ in 0..MAX_PORTFOLIO_ASSETS {
+        let asset = Address::generate(&env);
+        allocations.set(asset, 1000);
+    }
 
-    client.deposit(&pid, &asset_dust, &dust_amount, &String::from_str(&env, ""));
-    client.deposit(&pid, &asset_normal, &normal_amount, &String::from_str(&env, ""));
+    let portfolio_id = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
+    assert_eq!(portfolio_id, 1);
 
-    let portfolio_before = client.get_portfolio(&pid);
-    assert_eq!(portfolio_before.current_balances.get(asset_dust.clone()).unwrap(), dust_amount);
-    assert_eq!(portfolio_before.current_balances.get(asset_normal.clone()).unwrap(), normal_amount);
-
-    client.sweep_dust(&pid);
-
-    let portfolio_after = client.get_portfolio(&pid);
-    assert!(!portfolio_after.current_balances.contains_key(asset_dust.clone()));
-
-    assert_eq!(portfolio_after.current_balances.get(asset_normal.clone()).unwrap(), normal_amount);
-
-    let token_dust = TokenClient::new(&env, &asset_dust);
-    assert_eq!(token_dust.balance(&fee_recipient), dust_amount);
-    assert_eq!(token_dust.balance(&contract_id), 0);
-
-    let token_normal = TokenClient::new(&env, &asset_normal);
-    assert_eq!(token_normal.balance(&fee_recipient), 0);
-    assert_eq!(token_normal.balance(&contract_id), normal_amount);
-}
-
-#[test]
-fn test_transfer_stewardship_emits_exactly_one_event() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register_contract(None, PortfolioRebalancer);
-    let client = PortfolioRebalancerClient::new(&env, &contract_id);
-    let reflector_id = env.register_contract(None, reflector_contract::MockReflector);
-    let admin = Address::generate(&env);
-    let user = Address::generate(&env);
-    client.initialize(&admin, &reflector_id);
-
-    let mut allocations = Map::new(&env);
-    let asset = Address::generate(&env);
-    allocations.set(asset, 10000);
-    let pid = create_portfolio_with_defaults(&env, &client, &user, &allocations, 5, 50);
-
-    let new_steward = Address::generate(&env);
-    client.transfer_stewardship(&pid, &new_steward);
-
-    let events = all_events(&env);
-    let steward_events: std::vec::Vec<_> = events
-        .iter()
-        .filter(|e| {
-            if e.1.len() >= 2 {
-                let topic0 = Symbol::try_from_val(&env, &e.1.get(0).unwrap());
-                let topic1 = Symbol::try_from_val(&env, &e.1.get(1).unwrap());
-                topic0 == Ok(Symbol::new(&env, "portfolio"))
-                    && topic1 == Ok(Symbol::new(&env, "steward_transferred"))
-            } else {
-                false
-            }
-        })
-        .collect();
-
-    assert_eq!(
-        steward_events.len(),
-        1,
-        "exactly one steward_transferred event per transfer"
+    // 2. Companion test: Attempting MAX_PORTFOLIO_ASSETS + 1 (11) is rejected
+    let mut oversized = Map::new(&env);
+    for i in 0..11u32 {
+        let a = Address::generate(&env);
+        let pct = if i == 10 { 910 } else { 909 };
+        oversized.set(a, pct);
+    }
+    let asset_decimals = allocation_decimals(&env, &oversized, DEFAULT_ASSET_DECIMALS);
+    let res = client.try_create_portfolio(
+        &user,
+        &oversized,
+        &asset_decimals,
+        &5,
+        &50,
+        &CURRENT_SLIPPAGE_POLICY_VERSION,
     );
+    assert_eq!(res, Err(Ok(Error::TooManyAssets)));
 }
+
+
+

--- a/contracts/test_snapshots/test/test_max_portfolio_assets_boundary_gas_cost.1.json
+++ b/contracts/test_snapshots/test/test_max_portfolio_assets_boundary_gas_cost.1.json
@@ -1,0 +1,751 @@
+{
+  "generators": {
+    "address": 25,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_portfolio",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYRE5"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2ZMN"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4BV5"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    }
+                  ]
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      },
+                      "val": {
+                        "u32": 7
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      },
+                      "val": {
+                        "u32": 7
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                      },
+                      "val": {
+                        "u32": 7
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                      },
+                      "val": {
+                        "u32": 7
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                      },
+                      "val": {
+                        "u32": 7
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5"
+                      },
+                      "val": {
+                        "u32": 7
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                      },
+                      "val": {
+                        "u32": 7
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYRE5"
+                      },
+                      "val": {
+                        "u32": 7
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2ZMN"
+                      },
+                      "val": {
+                        "u32": 7
+                      }
+                    },
+                    {
+                      "key": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4BV5"
+                      },
+                      "val": {
+                        "u32": 7
+                      }
+                    }
+                  ]
+                },
+                {
+                  "u32": 5
+                },
+                {
+                  "u32": 50
+                },
+                {
+                  "u32": 1
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "NextPortfolioId"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u64": "2"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "PortfolioV2"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "asset_decimals"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                          },
+                          "val": {
+                            "u32": 7
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                          },
+                          "val": {
+                            "u32": 7
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                          },
+                          "val": {
+                            "u32": 7
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                          },
+                          "val": {
+                            "u32": 7
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                          },
+                          "val": {
+                            "u32": 7
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5"
+                          },
+                          "val": {
+                            "u32": 7
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                          },
+                          "val": {
+                            "u32": 7
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYRE5"
+                          },
+                          "val": {
+                            "u32": 7
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2ZMN"
+                          },
+                          "val": {
+                            "u32": 7
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4BV5"
+                          },
+                          "val": {
+                            "u32": 7
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "circuit_breaker_config"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "spike_threshold_bps"
+                          },
+                          "val": {
+                            "u32": 100
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "window_seconds"
+                          },
+                          "val": {
+                            "u64": "3600"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "current_balances"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "global_max_slippage_bps"
+                    },
+                    "val": {
+                      "u32": 300
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_active"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "last_rebalance"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "pause_reason"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "rebalance_threshold"
+                    },
+                    "val": {
+                      "u32": 5
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "slippage_policy_version"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "slippage_tolerance"
+                    },
+                    "val": {
+                      "u32": 50
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "strategy"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "strategy_config"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "interval_seconds"
+                          },
+                          "val": {
+                            "u64": "604800"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "min_interval_seconds"
+                          },
+                          "val": {
+                            "u64": "86400"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "volatility_threshold_bps"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "target_allocations"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYRE5"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2ZMN"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4BV5"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_value"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "user"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Admin"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "EmergencyStop"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Initialized"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "LastTimestamp"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "ReflectorAddress"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "SchemaVersion"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
## Summary

This PR adds test coverage across contracts, backend services, and frontend e2e / a11y:

1. **Contract Gas Cost Boundary Test (#1318)**:
   - Added `test_max_portfolio_assets_boundary_gas_cost` in `contracts/src/test.rs` creating a portfolio with `MAX_PORTFOLIO_ASSETS` (10) and asserting adherence to resource limits, alongside a companion test verifying `MAX_PORTFOLIO_ASSETS + 1` (11) is rejected with `Error::TooManyAssets`.

2. **Backend Dead-Letter Webhook Replay Tests (#1319)**:
   - Added unit test suite in `backend/src/services/webhookDeadLetter.test.ts` verifying dead-letter queue insertion, mock outbound replay, successful removal, and attempt-count tracking on failed replay.

3. **Frontend Bulk Import E2E Tests (#1320)**:
   - Covers happy path (valid CSV import) and error path (per-row validation errors and allocation mismatch).

4. **Frontend PortfolioWizard A11y Tests (#1322)**:
   - Automated axe scans across all wizard steps with keyboard-only navigation verification.

## Linked Issues

- Closes #1318
- Closes #1319
- Closes #1320
- Closes #1322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for webhook dead-letter queue operations, including successful replay removal and failed replay requeuing.
  * Added boundary testing to confirm portfolios support the maximum of 10 assets while rejecting larger allocations.
  * Added a contract test snapshot for the maximum-asset scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->