### PR TITLE
docs: clarify on-chain strategy execution ADR

### DIFF
--- a/docs/adr/0003-on-chain-strategy-execution.md
+++ b/docs/adr/0003-on-chain-strategy-execution.md
@@ -6,27 +6,53 @@ Accepted
 
 ## Context
 
-The stellar-portfolio-rebalancer needs to execute rebalancing strategies such as periodic, volatility, and custom strategies. We need to decide whether to implement these strategies fully on-chain via smart contracts or purely in a centralized backend that triggers transactions. 
-Key considerations involve gas costs, the trust model required by users, and the flexibility needed to upgrade or change strategies over time.
+The rebalancer supports threshold, periodic, volatility, and custom rules for deciding when a portfolio may be rebalanced. The system must define which component is authoritative for that decision:
+
+- A backend-only strategy can calculate a signal and ask the contract to execute it.
+- An on-chain strategy can evaluate its own rules and enforce the resulting trade constraints in the same environment that holds the portfolio state.
+
+The decision has to balance Soroban gas and resource budgets, the trust users place in the relayer, and the ability to evolve strategy rules without putting existing portfolios at risk. It also needs to preserve liveness: a periodic rule can become eligible on-chain, but a transaction still has to be submitted by a relayer or another caller.
 
 ## Decision
 
-We have decided to implement the rebalancing strategies on-chain. The strategy logic is encapsulated within specific contract modules.
+Strategy eligibility and execution will be enforced on-chain. The selected strategy and its configuration are stored with each portfolio. Contract code reads validated prices and ledger state, evaluates the strategy (including interval, volatility, or custom-rule constraints), builds the rebalance preview, and enforces the preview and slippage checks before applying trades.
 
-This approach was chosen over a purely backend-driven model because it provides a superior trust model. Users can independently verify the logic and rules of the rebalancing strategies on the blockchain, eliminating the need to trust a centralized off-chain entity to calculate and execute the rebalances fairly and accurately.
-
-## Consequences
-
-Positive:
-* **Trust Model:** High transparency and trustlessness. Strategy rules are verifiable on-chain.
-* **Security:** Decentralized execution prevents a single point of failure (a centralized backend) from compromising strategy execution.
-
-Negative:
-* **Gas Cost:** Executing complex strategies on-chain incurs higher transaction fees (gas costs) for users compared to off-chain computation.
-* **Upgrade Flexibility:** On-chain contracts are inherently more difficult to upgrade. Changes to strategy logic require careful contract upgrades or the deployment of new strategy contracts, unlike a backend where code can be updated seamlessly.
+The backend remains responsible for scheduling checks, submitting transactions, and providing analytics and user experience. It is not authoritative for the strategy outcome: a relayer cannot bypass the contract's rules by submitting a different signal or set of trades.
 
 ## Implementation Context
 
-* `strategies/periodic.rs`
-* `strategies/volatility.rs`
-* `strategies/custom.rs`
+The following paths are the intended module boundaries for the strategy implementations; shared types and preview/trade mechanics remain in the existing contract modules:
+
+- `contracts/src/strategies/periodic.rs` for fixed-interval eligibility.
+- `contracts/src/strategies/volatility.rs` for price-movement triggers.
+- `contracts/src/strategies/custom.rs` for configurable minimum intervals and rule combinations.
+
+The shared on-chain context is `contracts/src/types.rs` (the `StrategyType` and `StrategyConfig` values) and `contracts/src/portfolio.rs` (price validation, previews, and trade calculation).
+
+## Alternatives Considered
+
+| Option | Gas and resources | Trust model | Upgrade flexibility | Decision |
+| :--- | :--- | :--- | :--- | :--- |
+| Backend-only execution | Lower contract CPU and storage use; still pays for the final transaction. | Users must trust the backend to calculate an honest signal and trade set. | High; backend code can be replaced without a contract upgrade. | Rejected because the backend would be an authority over user funds. |
+| Backend signal with on-chain verification | Moderate cost and implementation complexity; duplicates rules across two layers. | Better than backend-only, but verification can leave strategy-specific gaps. | Moderate; contract verification rules still require upgrades. | Rejected as the default because duplicated logic is difficult to keep equivalent. |
+| On-chain strategy enforcement (chosen) | Higher CPU, storage, oracle-read, and transaction costs. | Rules and constraints are auditable and enforced by the contract; the relayer is not trusted with the decision. | Lower; changes require a reviewed contract upgrade or a new version with migration. | Chosen for deterministic, verifiable execution. |
+
+## Consequences
+
+### Positive
+
+- **Verifiable trust boundary:** Users and independent callers can inspect the strategy rules and verify that a submitted rebalance satisfies them.
+- **Consistent enforcement:** Periodic, volatility, and custom constraints are checked against the same on-chain portfolio, timestamp, and validated-price state used to execute the trade.
+- **Safer relaying:** The backend can be replaced or fail without granting it authority to override strategy rules; another relayer can submit an eligible transaction.
+
+### Negative
+
+- **Gas and resource cost:** Strategy evaluation, oracle reads, preview generation, and storage consume Soroban resources and increase transaction fees compared with calculating the signal off-chain.
+- **Upgrade friction:** A strategy change requires a reviewed contract upgrade or a new version and migration. Existing portfolios must retain compatible defaults and configuration semantics.
+- **Liveness dependency:** On-chain eligibility does not submit a transaction by itself. Relayers, fees, and available oracle data remain operational dependencies, and stale or missing prices can defer a rebalance.
+
+### Operational guardrails
+
+- Keep strategy configuration data-driven and bounded so invalid intervals, thresholds, and trade sizes are rejected before execution.
+- Emit strategy and rebalance events so relayers and indexers can reconcile eligibility with execution.
+- Use the contract's existing stale-price, slippage, emergency-stop, and upgrade controls when adding or changing strategy implementations.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,4 +17,5 @@ An Architecture Decision Record (ADR) is a document that captures an important a
 
 - [ADR 0001: Record Architecture Decisions](0001-record-architecture-decisions.md)
 - [ADR 0002: Reflector Oracle Selection](0002-reflector-oracle-selection.md)
+- [ADR 0003: On-Chain Strategy Execution Architecture](0003-on-chain-strategy-execution.md)
 - [ADR 0004: Asset Custody / Token Transfer Model](0004-asset-custody-model.md)


### PR DESCRIPTION
Summary:
- Expand ADR 0003 with explicit alternatives, tradeoffs, backend/on-chain responsibilities, and consequences.
- Reference periodic, volatility, and custom strategy module paths plus shared contract context.
- Add ADR 0003 to the ADR directory index.

Test evidence:
- `git diff --check` passed.
- ADR acceptance structure/reference check passed.
- `npm run validate:env-examples` reports pre-existing duplicate keys: `CONSENT_AUDIT_RETENTION_DAYS` and `READINESS_CACHE_TTL_MS`.
- No code tests, lint, or type checks were applicable to this Markdown-only change.

Fixes #1299

### Verification
- `git diff --check (passed)`
- `ADR acceptance structure/reference check (passed)`
- `npm run validate:env-examples (pre-existing duplicate env keys)`

### Diagnostics
Recovered command failures: `/bin/zsh -lc "find contracts/src -maxdepth 3 -type f -print | sort | rg 'strategy|periodic|volatility|custom' && for f in contracts/src/strategies/periodic.rs contracts/src/strategies/volatility.rs contracts/src/strategies/custom.rs; do printf '\\n--- %s ---\\n' \""'$f"; nl -ba "$f" | sed -n '"'1,260p'; done"` (1), `/bin/zsh -lc 'npm run validate:env-examples'` (1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the ADR describing on-chain strategy execution and clarified component responsibilities.
  * Added comparisons of alternative execution approaches and documented their trade-offs.
  * Added operational guardrails and reorganized the documented consequences.
  * Added the architecture decision record to the documentation index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->