### PR TITLE
docs: document storage-spam DoS risk on create_portfolio

### DIFF
--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -1,4 +1,4 @@
-# Security Audit — stellar-portfolio-rebalancer
+# Security Audit â€” stellar-portfolio-rebalancer
 
 This document records security findings identified during internal and external audits of the
 `stellar-portfolio-rebalancer` smart contract. Each entry includes a description, impact
@@ -11,6 +11,7 @@ assessment, reproduction steps, recommended remediation, and current status.
 | ID | Title | Severity | Status |
 |----|-------|----------|--------|
 | [SPR-001](#spr-001) | `get_fee_config` default `fee_recipient` falls back to the contract's own address | **High** | Open — fix tracked in #1519 |
+| [SPR-002](#spr-002) | Unbounded `create_portfolio` allows storage-spam DoS | **Medium** | Open — mitigation recommended |
 
 ---
 
@@ -20,7 +21,7 @@ assessment, reproduction steps, recommended remediation, and current status.
 
 **Severity:** High
 
-**Status:** Open — remediation required (tracked in issue #1519)
+**Status:** Open â€” remediation required (tracked in issue #1519)
 
 **Reported:** 2026-07-27
 
@@ -34,7 +35,7 @@ assessment, reproduction steps, recommended remediation, and current status.
 
 `get_fee_config` returns an in-memory default `FeeConfig` when no fee configuration has been
 stored in contract storage. The default value hardcodes `fee_recipient` to
-`env.current_contract_address()` — the contract's own address:
+`env.current_contract_address()` â€” the contract's own address:
 
 ```rust
 // contracts/src/lib.rs
@@ -45,7 +46,7 @@ pub fn get_fee_config(env: Env) -> FeeConfig {
         .unwrap_or(FeeConfig {
             platform_name: String::from_str(&env, ""),
             fee_bps: 0,
-            fee_recipient: env.current_contract_address(), // ← self-referential default
+            fee_recipient: env.current_contract_address(), // â†� self-referential default
             enabled: false,
         })
 }
@@ -105,9 +106,9 @@ creates a critical trap under the following conditions:
 
 | Dimension | Assessment |
 |-----------|-----------|
-| **Funds at risk** | Yes — any fee-denominated token amount sent to the contract address is permanently unrecoverable without an upgrade |
-| **Requires admin action to trigger** | Yes — `enabled: false` in the default prevents automatic triggering today |
-| **Exploitable by external actor** | No — fee collection only runs inside `execute_rebalance_internal`, which requires steward auth |
+| **Funds at risk** | Yes â€” any fee-denominated token amount sent to the contract address is permanently unrecoverable without an upgrade |
+| **Requires admin action to trigger** | Yes â€” `enabled: false` in the default prevents automatic triggering today |
+| **Exploitable by external actor** | No â€” fee collection only runs inside `execute_rebalance_internal`, which requires steward auth |
 | **Scope of affected deployments** | All deployments where `set_fee_config` has not been called before fee collection is enabled |
 | **Recoverability** | None without a contract upgrade that adds a sweep function |
 
@@ -117,13 +118,13 @@ creates a critical trap under the following conditions:
 
 Two complementary fixes are required. Both should be delivered together.
 
-#### Fix 1 — Remove the unsafe default recipient (required)
+#### Fix 1 â€” Remove the unsafe default recipient (required)
 
 Replace the self-referential fallback in `get_fee_config` with a value that cannot silently
 route funds anywhere. The safest approach is to make the absence of a stored config
 unambiguously "fees disabled" at the type level:
 
-**Option A — Panic on access when not configured (strictest):**
+**Option A â€” Panic on access when not configured (strictest):**
 
 ```rust
 pub fn get_fee_config(env: Env) -> FeeConfig {
@@ -134,7 +135,7 @@ pub fn get_fee_config(env: Env) -> FeeConfig {
 }
 ```
 
-**Option B — Return a disabled sentinel with no recipient (recommended):**
+**Option B â€” Return a disabled sentinel with no recipient (recommended):**
 
 Introduce an `Option<Address>` for `fee_recipient`, or use a dedicated
 `fee_config_is_set: bool` flag in storage, so that the execution path can detect
@@ -160,7 +161,7 @@ let effective_fee_bps = match &fee_config {
 This eliminates the unsafe default entirely. Fee collection is off unless a `FeeConfig` is
 explicitly stored.
 
-#### Fix 2 — Add an admin fee sweep / withdrawal function (defence in depth)
+#### Fix 2 â€” Add an admin fee sweep / withdrawal function (defence in depth)
 
 Even with Fix 1 applied, add a recovery path so that any tokens inadvertently sent to the
 contract address can be retrieved:
@@ -178,10 +179,10 @@ pub fn admin_sweep_token(env: Env, token: Address, amount: i128, destination: Ad
 ```
 
 This function should require admin auth, emit an auditable event, and be callable only when
-the contract is not in emergency stop — or alternatively, only when emergency stop is active,
+the contract is not in emergency stop â€” or alternatively, only when emergency stop is active,
 depending on the operator's threat model.
 
-#### Fix 3 — Require explicit fee recipient in `initialize` (optional hardening)
+#### Fix 3 â€” Require explicit fee recipient in `initialize` (optional hardening)
 
 Add `fee_recipient: Option<Address>` to `initialize` so that deployments must declare an
 intent at construction time:
@@ -229,12 +230,53 @@ After applying the fix:
 
 ### References
 
-- Issue: [#1519 — Security audit: set_fee_config default recipient defaults to contract's own address](../../issues/1519)
-- Affected code: [`contracts/src/lib.rs` — `get_fee_config`](../contracts/src/lib.rs)
-- Affected code: [`contracts/src/lib.rs` — `execute_rebalance_internal`](../contracts/src/lib.rs)
+- Issue: [#1519 â€” Security audit: set_fee_config default recipient defaults to contract's own address](../../issues/1519)
+- Affected code: [`contracts/src/lib.rs` â€” `get_fee_config`](../contracts/src/lib.rs)
+- Affected code: [`contracts/src/lib.rs` â€” `execute_rebalance_internal`](../contracts/src/lib.rs)
 - Soroban token interface: https://developers.stellar.org/docs/smart-contracts/tokens
 
 ---
 
 *Last updated: 2026-07-27*
 *Audited by: Kiro (automated security review, issue #1519)*
+
+---
+
+## SPR-002
+
+**Title:** Unbounded `create_portfolio` allows storage-spam DoS
+
+**Severity:** Medium
+
+**Status:** Open — mitigation recommended
+
+**Reported:** 2026-08-31
+
+**Affected file:** `contracts/src/lib.rs`
+
+**Affected function:** `create_portfolio`, `create_portfolio_with_strategy`, `create_portfolio_from_template`
+
+---
+
+### Description
+
+Currently, the `stellar-portfolio-rebalancer` contract does not restrict how many portfolios can be created globally or across multiple accounts. While a per-user cap is being tracked separately, an attacker could still circumvent this by generating numerous unique accounts and calling `create_portfolio` (or its variants) from each one.
+
+Each new portfolio increments the global `NextPortfolioId` and writes a new `Portfolio` struct to `persistent` storage via `DataKey::PortfolioV2(portfolio_id)`. 
+
+### Storage-Rent and Cost Implications
+
+In Soroban, persistent storage entries require a minimum rent. While the invoker of `create_portfolio` pays the transaction fees and initial storage rent, the long-term rent burden falls on the contract or requires ongoing community effort to bump the ledger entries to prevent them from being archived. 
+
+If an attacker aggressively spams portfolio creation:
+1. **Ledger Bloat & Rent Costs:** It increases the storage footprint of the contract significantly. Keeping these entries alive (if necessary for global state operations) will consume excessive rent fees.
+2. **Archival DoS Risk:** If the contract relies on querying active portfolios (e.g., via off-chain indexers or future on-chain aggregations) or if the sheer volume of data makes RPC queries expensive, it degrades system performance. If entries are archived, unarchiving them incurs additional costs.
+3. **ID Exhaustion:** While a `u64` is unlikely to wrap around, a massive number of portfolios might hit theoretical limits or cause issues for off-chain systems indexing `NextPortfolioId`.
+
+### Recommended Mitigation
+
+To prevent storage-spam and unbounded creation of portfolios, we recommend implementing a multi-layered defense:
+
+1. **Per-Account Cap (Cross-Reference):** Enforce a strict limit on the number of portfolios a single user can create (this is currently being tracked separately as a per-user cap issue).
+2. **Minimum Balance / Fee Requirement (Recommended):** Require users to deposit a minimum balance of a supported asset into the portfolio upon creation, or charge a non-refundable protocol fee in XLM or USDC for each `create_portfolio` call. This imposes a direct economic cost on the attacker, effectively neutralizing sybil-based spam.
+3. **Admin-Configurable Global Cap (Defense in Depth):** Add a `max_global_portfolios` configuration setting that the admin can adjust. If the global limit is reached, new creations are paused until the admin evaluates the system's capacity and raises the limit.


### PR DESCRIPTION
Closes #1313 

Fixes the issue regarding storage-spam DoS in `create_portfolio`.

- Assessed the lack of rate limiting on `create_portfolio` beyond the per-user cap.
- Evaluated storage-rent and cost implications of an attacker creating many portfolios across many accounts.
- Documented findings under a new `SPR-002` entry in `docs/SECURITY_AUDIT.md`.
- Assessed severity as **Medium** and provided concrete mitigation recommendations (minimum balance/fee requirement, and admin-configurable global cap), cross-referenced with the per-user cap issue.