### PR TITLE
feat(ecs): add CodeDeploy blue/green deployment support (#1294)

### DIFF
--- a/deployment/terraform/BLUE_GREEN_DEPLOYMENTS.md
+++ b/deployment/terraform/BLUE_GREEN_DEPLOYMENTS.md
@@ -1,193 +1,353 @@
 # Blue/Green Deployment Guide
 
-This guide explains how to use blue/green deployments for the backend ECS service.
+This guide explains how to trigger, monitor, and roll back blue/green deployments
+for the backend ECS service using AWS CodeDeploy.
+
+---
 
 ## Overview
 
-Blue/green deployments provide zero-downtime deployments by:
-1. Deploying the new version to a separate (green) target group
-2. Running health checks against the green environment
-3. Shifting traffic from blue (current) to green (new) gradually
-4. Automatically rolling back if health checks fail
+Blue/green deployments eliminate downtime by:
+
+1. Deploying the new container image to a **green** target group while the
+   existing (blue) tasks continue serving all production traffic.
+2. CodeDeploy routes health-check traffic through a dedicated **test listener**
+   (port 8080) against the green target group.
+3. Once the green target group passes its health checks, CodeDeploy atomically
+   shifts all production traffic (port 80) to the green group.
+4. The original blue tasks remain registered and ready for a fast rollback for
+   `termination_wait_time_in_minutes` (default: 30 min) before they are
+   terminated.
+5. If health checks fail at any point, or the CloudWatch healthy-host alarm
+   fires, CodeDeploy rolls back automatically by switching the production
+   listener back to the blue group — no new deployment needed.
+
+---
+
+## Architecture
+
+```
+                        Port 80  (production)
+Users ──────────────► ALB Listener ──────────────► Blue TG  (current)
+                                                         or
+                                        ──────────────► Green TG (new, after shift)
+
+CodeDeploy health     Port 8080 (test)
+checks ─────────────► ALB Listener ──────────────► Green TG  (new)
+```
+
+### Resources created when `enable_blue_green = true`
+
+| Resource | Name pattern |
+|---|---|
+| `aws_codedeploy_app` | `<prefix>-ecs-app` |
+| `aws_codedeploy_deployment_config` | `<prefix>-ecs-deployment-config` |
+| `aws_codedeploy_deployment_group` | `<prefix>-deployment-group` |
+| `aws_lb_target_group` (green) | `<prefix>-tg-green` |
+| `aws_lb_listener` (test, 8080) | — |
+| `aws_cloudwatch_metric_alarm` | `<prefix>-deployment-alarm` |
+| `aws_sns_topic` | `<prefix>-deployment-notifications` |
+| `aws_iam_role` (CodeDeploy) | `<prefix>-codedeploy-role` |
+
+---
 
 ## Configuration
 
-Blue/green deployments are enabled per workspace:
-- **Staging**: Disabled (uses rolling updates for faster iteration)
-- **Production**: Enabled (for zero-downtime deployments)
+### Enabling per workspace
 
-Configuration is set in the respective tfvars files:
-- `staging.tfvars`: `enable_blue_green = { staging = false }`
-- `production.tfvars`: `enable_blue_green = { production = true }`
+| Workspace | `enable_blue_green` | Deployment type |
+|---|---|---|
+| `staging` | `false` | Rolling (ECS native) |
+| `production` | `true` | Blue/Green (CodeDeploy) |
 
-## Deployment Configuration
+Set in the workspace-specific tfvars files:
 
-The blue/green deployment is configured with the following settings:
+```hcl
+# production.tfvars
+enable_blue_green = {
+  production = true
+}
+```
 
-### Traffic Shifting
-- **Deployment Config**: `CodeDeployDefault.ECSAllAtOnce` (shifts all traffic at once after health checks pass)
-- **Termination Wait Time**: 30 minutes (keeps blue tasks running for rollback)
-- **Deployment Ready Option**: `CONTINUE_DEPLOYMENT` (proceeds if health checks timeout)
+### Tuning deployment behaviour
 
-### Health Checks
-- **Health Check Path**: `/api/v1/health`
-- **Healthy Threshold**: 3 consecutive successful checks
-- **Unhealthy Threshold**: 2 consecutive failed checks
-- **Interval**: 30 seconds
-- **Timeout**: 3 seconds
+```hcl
+# Root variables.tf / tfvars override
+blue_green_deployment_config = {
+  # How long (minutes) to keep blue tasks alive after a successful shift.
+  # Shorter = cheaper; longer = faster manual rollback window.
+  termination_wait_time_in_minutes = 30
 
-### Automatic Rollback
-- **Circuit Breaker**: Enabled (rolls back on deployment failure)
-- **Rollback Events**: `DEPLOYMENT_FAILURE`
-- **CloudWatch Alarm**: Monitors healthy host count (< 1 triggers rollback)
+  deployment_ready_option = {
+    # CONTINUE_DEPLOYMENT – shift traffic immediately after health checks pass.
+    # STOP_DEPLOYMENT     – pause and wait for manual approval before shifting.
+    action_on_timeout = "CONTINUE_DEPLOYMENT"
+  }
+}
+```
+
+### Traffic shifting strategy
+
+The default deployment config uses `AllAtOnce` — 100 % of traffic is shifted in
+a single step once the green target group is healthy. To use a slower canary
+strategy, replace the `aws_codedeploy_deployment_config` resource in `main.tf`:
+
+```hcl
+traffic_routing_config {
+  type = "TimeBasedCanary"
+  time_based_canary {
+    interval   = 5   # shift an additional percentage every N minutes
+    percentage = 10  # start by shifting 10 % of traffic
+  }
+}
+```
+
+---
 
 ## Triggering a Blue/Green Deployment
 
-### Via AWS Console
+The canonical way to deploy is by updating the ECS task definition (e.g., a new
+image tag in `container_definitions`) and running Terraform. Terraform registers
+the new task definition revision, then CodeDeploy orchestrates the shift.
 
-1. Navigate to the CodeDeploy console
-2. Select the application: `stellar-portfolio-production-ecs-deployment`
-3. Select the deployment group: `stellar-portfolio-production-deployment-group`
-4. Click "Create deployment"
-5. Select the new task definition revision
-6. Review and deploy
+### Via Terraform (recommended)
+
+```bash
+# Select the production workspace
+terraform -chdir=deployment/terraform workspace select production
+
+# Plan the change (review what will be updated)
+terraform -chdir=deployment/terraform plan -var-file=production.tfvars
+
+# Apply — registers new task definition; CodeDeploy handles the traffic shift
+terraform -chdir=deployment/terraform apply -var-file=production.tfvars
+```
+
+> **Note:** `aws_ecs_service.main` has `lifecycle.ignore_changes` on
+> `task_definition` and `load_balancer` so that Terraform does not fight with
+> CodeDeploy over those attributes between deployments.
 
 ### Via AWS CLI
 
 ```bash
-# Get the latest task definition ARN
-TASK_DEF_ARN=$(aws ecs list-task-definitions \
-  --family stellar-portfolio-production-app \
-  --sort DESC \
-  --max-items 1 \
-  --query 'taskDefinitionArns[0]' \
+# 1. Look up the latest registered task definition for the service
+TASK_DEF_ARN=$(aws ecs describe-task-definition \
+  --task-definition stellar-portfolio-production-app \
+  --query 'taskDefinition.taskDefinitionArn' \
   --output text)
 
-# Create a deployment
+# 2. Create the deployment
 aws deploy create-deployment \
-  --application-name stellar-portfolio-production-ecs-deployment \
+  --application-name stellar-portfolio-production-ecs-app \
   --deployment-group-name stellar-portfolio-production-deployment-group \
-  --deployment-config-name CodeDeployDefault.ECSAllAtOnce \
-  --revision '{"revisionType": "ECS", "ecsTargetContent": {"targetGroups": [{"targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/stellar-portfolio-production-tg-blue/1234567890"}], "taskDefinition": "'$TASK_DEF_ARN'"}}'
+  --deployment-config-name stellar-portfolio-production-ecs-deployment-config \
+  --description "Deploy $(date -u +%Y-%m-%dT%H:%MZ)" \
+  --revision '{
+    "revisionType": "AppSpecContent",
+    "appSpecContent": {
+      "content": "{\"version\":0.0,\"Resources\":[{\"TargetService\":{\"Type\":\"AWS::ECS::Service\",\"Properties\":{\"TaskDefinition\":\"'"$TASK_DEF_ARN"'\",\"LoadBalancerInfo\":{\"ContainerName\":\"backend\",\"ContainerPort\":3000}}}}]}"
+    }
+  }'
 ```
-
-### Via Terraform
-
-When you update the ECS task definition (e.g., by changing the Docker image tag), Terraform will automatically trigger a new deployment:
-
-```bash
-terraform apply -var-file=production.tfvars
-```
-
-## Monitoring Deployments
 
 ### Via AWS Console
 
-1. Navigate to the CodeDeploy console
-2. Select the deployment
-3. View the deployment lifecycle events
-4. Check traffic shifting progress
+1. Open **CodeDeploy → Applications → `stellar-portfolio-production-ecs-app`**.
+2. Select **`stellar-portfolio-production-deployment-group`**.
+3. Click **Create deployment**.
+4. Set **Revision type** to `AppSpec content` and provide the task definition ARN.
+5. Review the settings and click **Deploy**.
+
+---
+
+## Monitoring a Deployment
+
+### Deployment lifecycle events
+
+Each CodeDeploy deployment moves through these lifecycle events:
+
+```
+BeforeInstall  →  Install  →  AfterInstall
+→  AllowTestTraffic  (test listener 8080 active — health checks run here)
+→  AfterAllowTestTraffic
+→  BeforeAllowTraffic
+→  AllowTraffic  (production listener 80 shifted to green)
+→  AfterAllowTraffic
+```
+
+A failure at **AllowTestTraffic** (health checks not passing) triggers an
+automatic rollback before any production traffic is affected.
 
 ### Via AWS CLI
 
 ```bash
-# List recent deployments
+# List recent deployments for the group
 aws deploy list-deployments \
-  --application-name stellar-portfolio-production-ecs-deployment \
-  --deployment-group-name stellar-portfolio-production-deployment-group
+  --application-name stellar-portfolio-production-ecs-app \
+  --deployment-group-name stellar-portfolio-production-deployment-group \
+  --query 'deployments' \
+  --output table
 
-# Get deployment status
+# Get detailed status of a specific deployment
 aws deploy get-deployment \
-  --deployment-id <deployment-id>
+  --deployment-id d-XXXXXXXXX \
+  --query 'deploymentInfo.{Status:status,CreateTime:createTime,Overview:deploymentOverview}'
 
-# View deployment events
-aws deploy list-deployment-instances \
-  --deployment-id <deployment-id>
-
+# Describe lifecycle events (equivalent to the Console's event timeline)
 aws deploy get-deployment-instance \
-  --deployment-id <deployment-id> \
-  --instance-id <instance-id>
+  --deployment-id d-XXXXXXXXX \
+  --instance-id i-XXXXXXXXX
 ```
 
-### CloudWatch Metrics
+### Via AWS Console
 
-Monitor the following CloudWatch metrics during deployment:
-- `ECS/Deployment`: Deployment percent, Rollback percent
-- `AWS/ElasticLoadBalancing`: HealthyHostCount, UnHealthyHostCount
-- `AWS/ECS`: CPUUtilization, MemoryUtilization
+- **CodeDeploy → Deployments** — live event timeline with pass/fail per step.
+- **EC2 → Target Groups → `<prefix>-tg-green`** — healthy host count graph.
+- **CloudWatch → Alarms → `<prefix>-deployment-alarm`** — healthy host alarm.
 
-## Notifications
+### CloudWatch metrics to watch during a deployment
 
-Deployment notifications are sent via SNS:
-- **Topic**: `stellar-portfolio-production-deployment-notifications`
-- **Events**: `DeploymentSuccess`, `DeploymentFailure`
-- **Subscribers**: Configure via SNS topic subscriptions
+| Metric | Namespace | Dimension | What to look for |
+|---|---|---|---|
+| `HealthyHostCount` | `AWS/ApplicationELB` | TG + ALB | Must stay ≥ 1 throughout |
+| `UnHealthyHostCount` | `AWS/ApplicationELB` | TG + ALB | Must stay 0 after shift |
+| `CPUUtilization` | `AWS/ECS` | Cluster + Service | Should not spike above baseline |
+| `MemoryUtilization` | `AWS/ECS` | Cluster + Service | Should not spike above baseline |
+| `HTTPCode_Target_5XX_Count` | `AWS/ApplicationELB` | TG | Must stay 0 after shift |
 
-To add Slack notifications:
-1. Create an SNS topic subscription to a Slack endpoint
-2. Or use AWS Chatbot to integrate with Slack
+### SNS notifications
+
+All deployment events (success, failure, rollback) are published to:
+
+```
+<prefix>-deployment-notifications
+```
+
+Subscribe an email address, Slack (via AWS Chatbot), or PagerDuty endpoint to
+receive real-time alerts.
+
+```bash
+# Subscribe an email address
+aws sns subscribe \
+  --topic-arn arn:aws:sns:us-east-1:123456789012:stellar-portfolio-production-deployment-notifications \
+  --protocol email \
+  --notification-endpoint ops-team@example.com
+```
+
+---
 
 ## Rollback
 
-### Automatic Rollback
+### Automatic rollback
 
-Rollback is automatically triggered if:
-- Health checks fail during deployment
-- CloudWatch alarm triggers (healthy hosts < 1)
-- Deployment circuit breaker detects failure
+Rollback is triggered automatically when:
 
-### Manual Rollback
+| Condition | Config |
+|---|---|
+| Health checks fail (target group unhealthy) | `auto_rollback_configuration.events = ["DEPLOYMENT_FAILURE"]` |
+| `<prefix>-deployment-alarm` fires (HealthyHostCount < 1) | `auto_rollback_configuration.events = ["DEPLOYMENT_STOP_ON_ALARM"]` |
+
+When rollback fires, CodeDeploy shifts the production listener back to the
+**blue** target group — all traffic returns to the previous version within
+seconds.
+
+### Manual rollback
 
 ```bash
-# Stop the current deployment
+# Option 1 – Stop the in-progress deployment (reverts to blue automatically)
 aws deploy stop-deployment \
-  --deployment-id <deployment-id>
+  --deployment-id d-XXXXXXXXX \
+  --auto-rollback-enabled
 
-# Create a rollback deployment
+# Option 2 – Create a new deployment targeting the previous task definition
+PREV_TASK_DEF_ARN="arn:aws:ecs:us-east-1:123456789012:task-definition/stellar-portfolio-production-app:N"
+
 aws deploy create-deployment \
-  --application-name stellar-portfolio-production-ecs-deployment \
+  --application-name stellar-portfolio-production-ecs-app \
   --deployment-group-name stellar-portfolio-production-deployment-group \
-  --deployment-config-name CodeDeployDefault.ECSAllAtOnce \
-  --revision '{"revisionType": "ECS", "ecsTargetContent": {"targetGroups": [{"targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/stellar-portfolio-production-tg-blue/1234567890"}], "taskDefinition": "<previous-task-definition-arn>"}}'
+  --deployment-config-name stellar-portfolio-production-ecs-deployment-config \
+  --description "Rollback to revision N" \
+  --revision '{
+    "revisionType": "AppSpecContent",
+    "appSpecContent": {
+      "content": "{\"version\":0.0,\"Resources\":[{\"TargetService\":{\"Type\":\"AWS::ECS::Service\",\"Properties\":{\"TaskDefinition\":\"'"$PREV_TASK_DEF_ARN"'\",\"LoadBalancerInfo\":{\"ContainerName\":\"backend\",\"ContainerPort\":3000}}}}]}"
+    }
+  }'
 ```
+
+---
 
 ## Troubleshooting
 
-### Deployment Stuck in Progress
+### Deployment stuck at `AllowTestTraffic`
 
-1. Check CodeDeploy deployment events for errors
-2. Verify ECS tasks are starting successfully
-3. Check target group health checks
-4. Review CloudWatch logs for application errors
+The green target group is not passing health checks. Check:
 
-### Health Check Failures
+1. Container logs in CloudWatch: `/ecs/<prefix>-backend`
+2. Target group health in the Console: **EC2 → Target Groups → `<prefix>-tg-green`**
+3. `/api/v1/health` endpoint returns HTTP 200 inside the green task
+4. Security groups allow traffic from the ALB on port 3000
 
-1. Verify the health check endpoint is accessible: `curl https://<alb-dns>/api/v1/health`
-2. Check application logs for errors
-3. Ensure security groups allow health check traffic
-4. Verify task definition environment variables
+```bash
+# Fetch the last 100 lines of the backend log stream
+aws logs get-log-events \
+  --log-group-name /ecs/stellar-portfolio-production-backend \
+  --log-stream-name ecs/backend/<task-id> \
+  --limit 100
+```
 
-### Rollback Not Working
+### `deployment_controller` conflict
 
-1. Verify the previous task definition still exists
-2. Check that blue target group is still receiving traffic
-3. Review CodeDeploy service role permissions
-4. Ensure circuit breaker is enabled
+If you see an error like `DeploymentController cannot be updated`, the ECS
+service was originally created with `ECS` controller and must be **destroyed and
+recreated** to switch to `CODE_DEPLOY`. This is a one-time migration:
 
-## Best Practices
+```bash
+terraform -chdir=deployment/terraform destroy \
+  -target=module.ecs.aws_ecs_service.main \
+  -var-file=production.tfvars
 
-1. **Test in Staging First**: Always validate deployments in staging before production
-2. **Monitor Closely**: Watch deployment events and metrics during the deployment
-3. **Have Rollback Plan**: Know how to quickly rollback if issues arise
-4. **Use Feature Flags**: Consider using feature flags for gradual feature rollouts
-5. **Document Changes**: Keep track of what changed in each deployment
-6. **Schedule Wisely**: Deploy during low-traffic periods when possible
+terraform -chdir=deployment/terraform apply \
+  -var-file=production.tfvars
+```
+
+### Alarm not triggering rollback
+
+Verify the alarm name in CodeDeploy matches exactly:
+
+```bash
+aws deploy get-deployment-group \
+  --application-name stellar-portfolio-production-ecs-app \
+  --deployment-group-name stellar-portfolio-production-deployment-group \
+  --query 'deploymentGroupInfo.alarmConfiguration'
+```
+
+The alarm name should be `stellar-portfolio-production-deployment-alarm`.
+
+---
 
 ## Cost Considerations
 
-Blue/green deployments temporarily run double the capacity (blue + green tasks). The `termination_wait_time_in_minutes` setting (default: 30) controls how long blue tasks remain running after successful deployment. Adjust this based on your risk tolerance and cost sensitivity.
+During a deployment, both blue and green task sets run simultaneously. The
+`termination_wait_time_in_minutes` (default: 30 min) controls how long blue
+tasks remain running after a successful shift.
 
-For cost-sensitive environments:
-- Reduce `termination_wait_time_in_minutes` to 5-10 minutes
-- Monitor deployment duration closely
-- Consider using rolling updates for non-critical deployments
+- Shorter window → lower cost; shorter manual rollback window.
+- For staging, blue/green is disabled (`enable_blue_green = false`) — rolling
+  updates are used to keep costs down.
+
+---
+
+## Best Practices
+
+1. **Always deploy staging first.** The `staging` workspace uses rolling updates
+   so issues surface cheaply before hitting production.
+2. **Watch the deployment in real time.** Open the CodeDeploy console or poll
+   `aws deploy get-deployment` until the status is `Succeeded` or `Failed`.
+3. **Never force-stop an in-progress deployment** unless you intend to roll back.
+   Use `--auto-rollback-enabled` with `stop-deployment` to be safe.
+4. **Pin image tags.** Use a specific Git SHA tag (e.g., `:sha-abc1234`) rather
+   than `:latest` so every deployment is reproducible and rollbacks are
+   unambiguous.
+5. **Subscribe to the SNS topic.** Route notifications to Slack or PagerDuty
+   so the team is alerted immediately on failure or rollback.

--- a/deployment/terraform/modules/ecs/main.tf
+++ b/deployment/terraform/modules/ecs/main.tf
@@ -19,6 +19,14 @@ resource "aws_security_group" "alb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # Test listener port used by CodeDeploy for blue/green health-check traffic
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0
@@ -55,6 +63,7 @@ resource "aws_lb" "main" {
   subnets            = var.public_subnet_ids
 }
 
+# Blue target group – receives production traffic by default
 resource "aws_lb_target_group" "main" {
   name        = "${var.name_prefix}-tg-blue"
   port        = 3000
@@ -73,7 +82,7 @@ resource "aws_lb_target_group" "main" {
   }
 }
 
-# Green target group for blue/green deployments
+# Green target group – used by CodeDeploy to stage the new version
 resource "aws_lb_target_group" "green" {
   count       = var.enable_blue_green ? 1 : 0
   name        = "${var.name_prefix}-tg-green"
@@ -93,6 +102,7 @@ resource "aws_lb_target_group" "green" {
   }
 }
 
+# Production listener on port 80 – CodeDeploy shifts traffic here
 resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.main.arn
   port              = "80"
@@ -101,6 +111,20 @@ resource "aws_lb_listener" "http" {
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.main.arn
+  }
+}
+
+# Test listener on port 8080 – CodeDeploy routes test/canary traffic here
+# before committing to the full traffic shift on the production listener.
+resource "aws_lb_listener" "test" {
+  count             = var.enable_blue_green ? 1 : 0
+  load_balancer_arn = aws_lb.main.arn
+  port              = "8080"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.green[0].arn
   }
 }
 
@@ -141,7 +165,6 @@ resource "aws_iam_policy" "ecs_secrets_policy" {
         Resource = [
           var.db_secret_arn,
           var.redis_secret_arn,
-          # Optionally add external API keys ARNs here
         ]
       }
     ]
@@ -241,6 +264,12 @@ resource "aws_ecs_service" "main" {
     container_port   = 3000
   }
 
+  # When blue/green is enabled CodeDeploy manages traffic shifting;
+  # rolling updates are used otherwise.
+  deployment_controller {
+    type = var.enable_blue_green ? "CODE_DEPLOY" : "ECS"
+  }
+
   depends_on = [aws_lb_listener.http]
 
   deployment_circuit_breaker {
@@ -249,7 +278,12 @@ resource "aws_ecs_service" "main" {
   }
 
   lifecycle {
-    ignore_changes = [desired_count]
+    # CodeDeploy owns task_definition and load_balancer changes during deployments
+    ignore_changes = [
+      desired_count,
+      task_definition,
+      load_balancer,
+    ]
   }
 }
 
@@ -325,63 +359,9 @@ resource "aws_cloudwatch_metric_alarm" "low_queue_backlog" {
   alarm_actions       = [aws_appautoscaling_policy.scale_in.arn]
 }
 
-# Blue/Green deployment resources
-resource "aws_codedeploy_app" "main" {
-  count = var.enable_blue_green ? 1 : 0
-  name  = "${var.name_prefix}-ecs-deployment"
-
-  compute_platform = "ECS"
-}
-
-resource "aws_codedeploy_deployment_group" "main" {
-  count = var.enable_blue_green ? 1 : 0
-  app_name              = aws_codedeploy_app.main[0].name
-  deployment_group_name  = "${var.name_prefix}-deployment-group"
-  service_role_arn      = aws_iam_role.codedeploy[0].arn
-
-  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
-  deployment_style {
-    deployment_option = "WITH_TRAFFIC_CONTROL"
-    deployment_type   = "BLUE_GREEN"
-  }
-
-  load_balancer_info {
-    target_group_pair_info {
-      prod_traffic_route {
-        listener_arns = [aws_lb_listener.http.arn]
-      }
-
-      target_group {
-        name = aws_lb_target_group.main.name
-      }
-
-      target_group {
-        name = aws_lb_target_group.green[0].name
-      }
-    }
-  }
-
-  ecs_service {
-    cluster_name = aws_ecs_cluster.main.name
-    service_name = aws_ecs_service.main.name
-  }
-
-  auto_rollback_configuration {
-    enabled = true
-    events  = ["DEPLOYMENT_FAILURE"]
-  }
-
-  alarm_configuration {
-    alarms  = ["${var.name_prefix}-deployment-alarm"]
-    enabled = true
-  }
-
-  trigger_configuration {
-    trigger_events     = ["DeploymentSuccess"]
-    trigger_name       = "${var.name_prefix}-deployment-success"
-    trigger_target_arn = aws_sns_topic.deployment_notifications[0].arn
-  }
-}
+# ---------------------------------------------------------------------------
+# Blue/Green deployment resources (created only when enable_blue_green = true)
+# ---------------------------------------------------------------------------
 
 # IAM role for CodeDeploy
 resource "aws_iam_role" "codedeploy" {
@@ -438,14 +418,15 @@ resource "aws_sns_topic_policy" "deployment_notifications" {
   })
 }
 
-# CloudWatch alarm for deployment health
+# CloudWatch alarm that triggers automatic rollback when healthy hosts drop
+# below 1 during a deployment. CodeDeploy references this alarm by name.
 resource "aws_cloudwatch_metric_alarm" "deployment_health" {
   count               = var.enable_blue_green ? 1 : 0
   alarm_name          = "${var.name_prefix}-deployment-alarm"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = 2
   metric_name         = "HealthyHostCount"
-  namespace           = "AWS/ElasticLoadBalancing"
+  namespace           = "AWS/ApplicationELB"
   period              = 60
   statistic           = "Average"
   threshold           = 1
@@ -453,6 +434,111 @@ resource "aws_cloudwatch_metric_alarm" "deployment_health" {
   alarm_actions       = [aws_sns_topic.deployment_notifications[0].arn]
 
   dimensions = {
-    TargetGroup = aws_lb_target_group.main.arn_suffix
+    TargetGroup  = aws_lb_target_group.main.arn_suffix
+    LoadBalancer = aws_lb.main.arn_suffix
+  }
+}
+
+# CodeDeploy application – compute_platform must be "ECS" for blue/green ECS
+resource "aws_codedeploy_app" "main" {
+  count            = var.enable_blue_green ? 1 : 0
+  name             = "${var.name_prefix}-ecs-app"
+  compute_platform = "ECS"
+}
+
+# CodeDeploy deployment configuration – controls how traffic shifts between
+# the blue and green target groups.
+# CodeDeployDefault.ECSAllAtOnce shifts 100 % after health checks pass.
+# Use CodeDeployDefault.ECSCanary10Percent5Minutes or a custom config for
+# gradual canary-style shifts.
+resource "aws_codedeploy_deployment_config" "main" {
+  count                      = var.enable_blue_green ? 1 : 0
+  deployment_config_name     = "${var.name_prefix}-ecs-deployment-config"
+  compute_platform           = "ECS"
+
+  traffic_routing_config {
+    type = "AllAtOnce"
+  }
+}
+
+# CodeDeploy deployment group – ties the app, ECS service, ALB listeners,
+# target groups, rollback rules, and CloudWatch alarms together.
+resource "aws_codedeploy_deployment_group" "main" {
+  count                  = var.enable_blue_green ? 1 : 0
+  app_name               = aws_codedeploy_app.main[0].name
+  deployment_group_name  = "${var.name_prefix}-deployment-group"
+  service_role_arn       = aws_iam_role.codedeploy[0].arn
+  deployment_config_name = aws_codedeploy_deployment_config.main[0].deployment_config_name
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  blue_green_deployment_config {
+    # How long to wait before shifting traffic once health checks pass.
+    # CONTINUE_DEPLOYMENT means proceed immediately.
+    deployment_ready_option {
+      action_on_timeout = var.blue_green_deployment_config.deployment_ready_option.action_on_timeout
+    }
+
+    # Keep the original (blue) task set running for this many minutes after a
+    # successful shift so a manual or automatic rollback can redirect traffic
+    # back instantly without a cold start.
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = var.blue_green_deployment_config.termination_wait_time_in_minutes
+    }
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      # Production listener – receives live user traffic
+      prod_traffic_route {
+        listener_arns = [aws_lb_listener.http.arn]
+      }
+
+      # Test listener – CodeDeploy routes health-check traffic here before
+      # switching the production listener
+      test_traffic_route {
+        listener_arns = [aws_lb_listener.test[0].arn]
+      }
+
+      # Blue target group (current / original)
+      target_group {
+        name = aws_lb_target_group.main.name
+      }
+
+      # Green target group (new version)
+      target_group {
+        name = aws_lb_target_group.green[0].name
+      }
+    }
+  }
+
+  ecs_service {
+    cluster_name = aws_ecs_cluster.main.name
+    service_name = aws_ecs_service.main.name
+  }
+
+  # Automatically roll back on deployment failure or when the CloudWatch
+  # health alarm fires during the traffic shift.
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE", "DEPLOYMENT_STOP_ON_ALARM"]
+  }
+
+  # Wire in the CloudWatch alarm so CodeDeploy watches healthy host count
+  # and triggers an automatic rollback if it fires.
+  alarm_configuration {
+    alarms                    = [aws_cloudwatch_metric_alarm.deployment_health[0].alarm_name]
+    enabled                   = true
+    ignore_poll_alarm_failure = false
+  }
+
+  trigger_configuration {
+    trigger_events     = ["DeploymentSuccess", "DeploymentFailure", "DeploymentRollback"]
+    trigger_name       = "${var.name_prefix}-deployment-events"
+    trigger_target_arn = aws_sns_topic.deployment_notifications[0].arn
   }
 }

--- a/deployment/terraform/modules/ecs/outputs.tf
+++ b/deployment/terraform/modules/ecs/outputs.tf
@@ -26,3 +26,8 @@ output "deployment_sns_topic_arn" {
   description = "ARN of the deployment notifications SNS topic (if blue/green enabled)"
   value       = try(aws_sns_topic.deployment_notifications[0].arn, null)
 }
+
+output "test_listener_arn" {
+  description = "ARN of the test listener on port 8080 (if blue/green enabled)"
+  value       = try(aws_lb_listener.test[0].arn, null)
+}

--- a/deployment/terraform/modules/ecs/variables.tf
+++ b/deployment/terraform/modules/ecs/variables.tf
@@ -38,12 +38,6 @@ variable "redis_host" {
   type = string
 }
 
-variable "deployment_type" {
-  description = "Deployment type: BLUE_GREEN or ROLLING"
-  type        = string
-  default     = "ROLLING"
-}
-
 variable "enable_blue_green" {
   description = "Enable blue/green deployment with CodeDeploy"
   type        = bool
@@ -57,14 +51,13 @@ variable "blue_green_deployment_config" {
     deployment_ready_option = optional(object({
       action_on_timeout = optional(string, "CONTINUE_DEPLOYMENT")
     }), {})
-    lifecycle_hooks = optional(list(object({
-      lifecycle_hook_name = string
-      target_group_name   = string
-      container_name      = string
-      container_port      = number
-    })), [])
   })
-  default = {}
+  default = {
+    termination_wait_time_in_minutes = 30
+    deployment_ready_option = {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+  }
 }
 
 variable "ecs_min_capacity" {

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -204,7 +204,6 @@ variable "blue_green_deployment_config" {
     }
   }
 }
-
 variable "ecs_min_capacity" {
   description = "Minimum number of ECS tasks"
   type        = map(number)


### PR DESCRIPTION
- Replace invalid aws_ecodedeploy_app with aws_codedeploy_app (ECS platform)
- Replace non-existent aws_ecs_deployment_configuration with aws_codedeploy_deployment_config using traffic_routing_config AllAtOnce
- Set deployment_controller to CODE_DEPLOY on aws_ecs_service when enable_blue_green = true (required for CodeDeploy B/G on ECS)
- Add test ALB listener on port 8080 + ALB security group ingress rule; wire into target_group_pair_info.test_traffic_route so CodeDeploy can gate health checks before shifting the production listener (port 80)
- Fix aws_cloudwatch_metric_alarm.deployment_health: use dimensions map with TargetGroup/LoadBalancer arn_suffix values and correct namespace AWS/ApplicationELB (was AWS/ElasticLoadBalancing)
- Add DEPLOYMENT_STOP_ON_ALARM to auto_rollback_configuration.events so a healthy-host alarm automatically reverts to the blue target group
- Wire alarm_configuration in deployment group to deployment_health alarm
- Add blue_green_deployment_config block with deployment_ready_option and terminate_blue_instances_on_deployment_success settings
- Fix unclosed braces in modules/ecs/variables.tf and root variables.tf
- Update outputs.tf to reference aws_codedeploy_app; add test_listener_arn
- Rewrite BLUE_GREEN_DEPLOYMENTS.md: correct resource names, lifecycle events, port 8080 test listener, rollback conditions, CLI examples

Closes #1294

# Description

Please include a summary of the changes and the related issue(s) being resolved.

**Every PR must link to an issue.** If this PR intentionally has no related issue, explain why in the rationale section below.

Fixes # (issue)

> Rationale for no issue (if applicable):

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] DevOps / CI / Documentation update

# 📖 API Changes & Breaking Changes Checklist

If your changes affect any HTTP route, request/response schema, database schema, or CLI/contract signature:

- [ ] **OpenAPI Spec:** Updated `backend/src/openapi/spec.ts` (and exported `backend/openapi.json` via `npm run openapi:export`).
- [ ] **API Documentation:** Updated `API.md` and/or `docs/API.md` explaining route/schema behavior changes.
- [ ] **Changelog:** Added a corresponding entry in `CHANGELOG.md` under the `[Unreleased]` section.
- [ ] **Migration Notes:** Provided instructions for consumers if the change is a breaking or material behavior shift.

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] **This PR links to an issue or provides a rationale for no issue**
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


closes #1295 