### PR TITLE
feat(frontend): disable allocation edits when update_allocations is unsupported

### DIFF
--- a/frontend/src/components/AllocationForm.test.tsx
+++ b/frontend/src/components/AllocationForm.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, cleanup } from '@testing-library/react'
 import AllocationForm from './AllocationForm'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { ContractCapabilityReport } from '../lib/contractCapabilities'
 
 describe('AllocationForm', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
     const defaultAllocations = [
         { asset: 'XLM', percentage: 60 },
         { asset: 'USDC', percentage: 40 },
@@ -12,6 +16,7 @@ describe('AllocationForm', () => {
     const fullyCapableReport: ContractCapabilityReport = {
         severity: 'ok',
         title: 'OK',
+        message: 'OK',
         writesEnabled: true,
         expectedSchemaVersion: 1,
         availableMethods: ['update_allocations'],
@@ -20,6 +25,7 @@ describe('AllocationForm', () => {
     const uncapableReport: ContractCapabilityReport = {
         severity: 'warning',
         title: 'Warning',
+        message: 'Warning',
         writesEnabled: true,
         expectedSchemaVersion: 1,
         availableMethods: [], // Missing update_allocations
@@ -37,10 +43,45 @@ describe('AllocationForm', () => {
         
         const wrapper = screen.getByTitle(/Block the write; keep the existing allocations visible read-only/i)
         expect(wrapper).toBeInTheDocument()
+        expect(screen.getByTestId('update-allocations-disabled-reason')).toHaveTextContent(/read-only/i)
 
         const inputs = screen.getAllByRole('spinbutton')
         expect(inputs[0]).toBeDisabled()
         expect(screen.getByRole('button', { name: /Submit Portfolio/i })).toBeDisabled()
+    })
+
+    it('disables controls when the capabilities() flag is false', () => {
+        const flagFalseReport: ContractCapabilityReport = {
+            ...fullyCapableReport,
+            capabilities: { update_allocations: false },
+        }
+        render(<AllocationForm allocations={defaultAllocations} onChange={vi.fn()} contractCapabilityReport={flagFalseReport} />)
+
+        expect(screen.getByTestId('update-allocations-disabled-reason')).toBeInTheDocument()
+        expect(screen.getAllByRole('spinbutton')[0]).toBeDisabled()
+        expect(screen.getByRole('button', { name: /Submit Portfolio/i })).toBeDisabled()
+    })
+
+    it('handles a missing capabilities() field on older contracts without crashing', () => {
+        const olderContract: ContractCapabilityReport = {
+            severity: 'warning',
+            title: 'Legacy',
+            message: 'No capabilities() field',
+            writesEnabled: true,
+            expectedSchemaVersion: 1,
+            availableMethods: [],
+            capabilities: undefined,
+        }
+        render(<AllocationForm allocations={defaultAllocations} onChange={vi.fn()} contractCapabilityReport={olderContract} />)
+
+        expect(screen.getByTestId('update-allocations-disabled-reason')).toBeInTheDocument()
+        expect(screen.getAllByRole('spinbutton')[0]).toBeDisabled()
+    })
+
+    it('does not crash when the capability report is null', () => {
+        render(<AllocationForm allocations={defaultAllocations} onChange={vi.fn()} contractCapabilityReport={null} />)
+        expect(screen.getAllByRole('spinbutton')[0]).toBeDisabled()
+        expect(screen.getByTestId('update-allocations-disabled-reason')).toBeInTheDocument()
     })
 
     it('remains enabled if capability report is undefined', () => {

--- a/frontend/src/components/AllocationForm.tsx
+++ b/frontend/src/components/AllocationForm.tsx
@@ -76,9 +76,10 @@ export default function AllocationForm({ allocations, onChange, disabled, contra
 
     const isFormDisabled = disabled || !allocationsSupported
     const canSubmit = isValidTotal && !hasAnyFieldError && !isFormDisabled
+    const disabledReason = fallbackMessage || 'This contract cannot update allocations. Editing is disabled.'
 
     return (
-        <div className="space-y-4" title={!allocationsSupported ? (fallbackMessage || 'Action not supported') : undefined}>
+        <div className="space-y-4" title={!allocationsSupported ? disabledReason : undefined}>
             <div className="flex items-center justify-between">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
                     Asset Allocations
@@ -93,6 +94,17 @@ export default function AllocationForm({ allocations, onChange, disabled, contra
                     Add Asset
                 </button>
             </div>
+
+            {!allocationsSupported && (
+                <p
+                    role="status"
+                    data-testid="update-allocations-disabled-reason"
+                    className="flex items-center gap-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-200"
+                >
+                    <AlertCircle className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                    {disabledReason}
+                </p>
+            )}
 
             {allocations.map((allocation, index) => {
                 const fieldError = getAllocationError(allocation.percentage)

--- a/frontend/src/lib/contractCapabilities.test.ts
+++ b/frontend/src/lib/contractCapabilities.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import {
+    canUpdateAllocations,
+    readUpdateAllocationsCapabilityFlag,
+    blockedWriteFallback,
+    type ContractCapabilityReport,
+} from './contractCapabilities'
+
+function report(
+    overrides: Partial<ContractCapabilityReport> = {},
+): ContractCapabilityReport {
+    return {
+        severity: 'ok',
+        title: 'OK',
+        message: 'ok',
+        writesEnabled: true,
+        expectedSchemaVersion: 1,
+        availableMethods: ['update_allocations'],
+        ...overrides,
+    }
+}
+
+describe('readUpdateAllocationsCapabilityFlag', () => {
+    it('returns true when the flag is present and enabled', () => {
+        expect(readUpdateAllocationsCapabilityFlag({ update_allocations: true })).toBe(true)
+        expect(readUpdateAllocationsCapabilityFlag({ updateAllocations: true })).toBe(true)
+        expect(readUpdateAllocationsCapabilityFlag(true)).toBe(true)
+    })
+
+    it('returns false when the flag is present and disabled', () => {
+        expect(readUpdateAllocationsCapabilityFlag({ update_allocations: false })).toBe(false)
+        expect(readUpdateAllocationsCapabilityFlag(false)).toBe(false)
+    })
+
+    it('returns missing for older contracts that omit capabilities()', () => {
+        expect(readUpdateAllocationsCapabilityFlag(undefined)).toBe('missing')
+        expect(readUpdateAllocationsCapabilityFlag(null)).toBe('missing')
+        expect(readUpdateAllocationsCapabilityFlag({})).toBe('missing')
+        expect(readUpdateAllocationsCapabilityFlag(0)).toBe('missing')
+    })
+
+    it('does not throw on malformed capabilities payloads', () => {
+        expect(() => readUpdateAllocationsCapabilityFlag('nope')).not.toThrow()
+        expect(() => readUpdateAllocationsCapabilityFlag(['update_allocations'])).not.toThrow()
+        expect(readUpdateAllocationsCapabilityFlag('nope')).toBe('missing')
+    })
+})
+
+describe('canUpdateAllocations', () => {
+    it('treats a true capabilities() flag as supported', () => {
+        expect(
+            canUpdateAllocations(
+                report({
+                    availableMethods: [],
+                    capabilities: { update_allocations: true },
+                }),
+            ),
+        ).toBe(true)
+    })
+
+    it('treats a false capabilities() flag as unsupported even if the method is listed', () => {
+        expect(
+            canUpdateAllocations(
+                report({
+                    availableMethods: ['update_allocations'],
+                    capabilities: { update_allocations: false },
+                }),
+            ),
+        ).toBe(false)
+    })
+
+    it('falls back to availableMethods when capabilities() is missing', () => {
+        expect(canUpdateAllocations(report({ capabilities: undefined }))).toBe(true)
+        expect(
+            canUpdateAllocations(
+                report({ availableMethods: [], capabilities: undefined }),
+            ),
+        ).toBe(false)
+    })
+
+    it('handles a null report without crashing', () => {
+        expect(canUpdateAllocations(null)).toBe(false)
+    })
+})
+
+describe('blockedWriteFallback for update_allocations', () => {
+    it('blocks writes when the capabilities() flag is false', () => {
+        const message = blockedWriteFallback(
+            report({ capabilities: { update_allocations: false } }),
+            'update_allocations',
+        )
+        expect(message).toMatch(/read-only/i)
+    })
+})

--- a/frontend/src/lib/contractCapabilities.ts
+++ b/frontend/src/lib/contractCapabilities.ts
@@ -115,6 +115,23 @@ export const CONTRACT_CAPABILITY_MATRIX: readonly ContractCapability[] = [
 
 export type ContractCapabilitySeverity = 'ok' | 'warning' | 'error'
 
+/**
+ * Raw `capabilities()` payload from a contract. Older deployments omit this
+ * field entirely (no method / no bitmask), so callers must treat `null` /
+ * `undefined` as "unknown" rather than throwing.
+ */
+export type ContractCapabilitiesField =
+    | number
+    | boolean
+    | Record<string, unknown>
+    | null
+    | undefined
+
+export const UPDATE_ALLOCATIONS_METHOD = 'update_allocations'
+
+export const UPDATE_ALLOCATIONS_UNSUPPORTED_MESSAGE =
+    'This contract cannot update allocations. Editing is disabled.'
+
 export interface ContractCapabilityReport {
     severity: ContractCapabilitySeverity
     title: string
@@ -126,6 +143,11 @@ export interface ContractCapabilityReport {
     /** Capabilities considered usable given the current deployment state. */
     availableMethods: string[]
     details?: string
+    /**
+     * On-chain `capabilities()` response when the connected deployment
+     * exposes one. Absent on older contracts that predate the field.
+     */
+    capabilities?: ContractCapabilitiesField
 }
 
 interface ReadinessCheckLike {
@@ -254,9 +276,46 @@ export function isCapabilitySupported(
     return report.availableMethods.includes(method)
 }
 
-/** Whether the deployment supports updating target allocations natively. */
+/**
+ * Read the `update_allocations` flag from a contract `capabilities()` payload.
+ *
+ * Returns `true` / `false` when the flag is present, or `'missing'` when the
+ * deployment predates `capabilities()` or the payload cannot be interpreted.
+ * Never throws — older contracts and malformed responses degrade safely.
+ */
+export function readUpdateAllocationsCapabilityFlag(
+    capabilities: unknown,
+): boolean | 'missing' {
+    try {
+        if (capabilities == null) return 'missing'
+        if (typeof capabilities === 'boolean') return capabilities
+        if (typeof capabilities === 'object' && !Array.isArray(capabilities)) {
+            const rec = capabilities as Record<string, unknown>
+            if ('update_allocations' in rec) return Boolean(rec.update_allocations)
+            if ('updateAllocations' in rec) return Boolean(rec.updateAllocations)
+            return 'missing'
+        }
+        // Current on-chain bitmask has no AllocationUpdate bit (see
+        // docs/soroban-cookbook.md). A bare number is "field present, flag
+        // not encoded" — treat as missing rather than unsupported.
+        return 'missing'
+    } catch {
+        return 'missing'
+    }
+}
+
+/**
+ * Whether the deployment supports updating target allocations natively.
+ *
+ * The on-chain `capabilities()` flag is authoritative when present. Older
+ * contracts that omit the field fall back to `availableMethods`.
+ */
 export function canUpdateAllocations(report: ContractCapabilityReport | null): boolean {
-    return isCapabilitySupported(report, 'update_allocations')
+    if (!report) return false
+    const flag = readUpdateAllocationsCapabilityFlag(report.capabilities)
+    if (flag === false) return false
+    if (flag === true) return true
+    return isCapabilitySupported(report, UPDATE_ALLOCATIONS_METHOD)
 }
 
 /**
@@ -270,6 +329,10 @@ export function blockedWriteFallback(
 ): string | null {
     const capability = CONTRACT_CAPABILITY_MATRIX.find((c) => c.method === method)
     if (!capability || capability.kind !== 'write') return null
+    if (method === UPDATE_ALLOCATIONS_METHOD) {
+        if (report?.writesEnabled && canUpdateAllocations(report)) return null
+        return capability.fallback
+    }
     if (report?.writesEnabled && isCapabilitySupported(report, method)) return null
     return capability.fallback
 }


### PR DESCRIPTION
## Summary

Makes allocation editing capability-aware so the UI disables writes when the connected contract does not support `update_allocations`.

### What changed

- Added `readUpdateAllocationsCapabilityFlag()` in `frontend/src/lib/contractCapabilities.ts` to read the on-chain `capabilities()` field (boolean, `{ update_allocations }` object, or camelCase). Malformed payloads and older deployments that omit `capabilities()` entirely return `'missing'` instead of throwing.
- `canUpdateAllocations()` now treats a present `false` flag as unsupported, a present `true` flag as supported, and falls back to `availableMethods` when the field is missing (legacy contracts).
- `blockedWriteFallback('update_allocations')` uses the same helper so write guards stay consistent with the form.
- `AllocationForm` disables add/edit/remove/submit controls when unsupported and shows a visible status banner plus a `title` tooltip explaining that allocations stay read-only.
- Tests cover supported, flag-false, missing `capabilities()`, null report (no crash), and report-not-loaded (controls stay enabled until detection finishes).

## Verification

- `cd frontend && npx vitest run src/lib/contractCapabilities.test.ts src/components/AllocationForm.test.tsx`
- All 15 tests passed.

## Release Notes

- [x] User-facing change
- [ ] Breaking change
- [ ] No release note needed

Allocation editors are disabled with an explanation when the connected contract cannot update allocations, including older deployments that have no `capabilities()` field.

Closes #1275

