### PR TITLE
feat(frontend): surface bulk-import loading and per-row validation errors

### DIFF
--- a/frontend/src/hooks/mutations/useBulkImport.test.tsx
+++ b/frontend/src/hooks/mutations/useBulkImport.test.tsx
@@ -1,18 +1,31 @@
 import React from 'react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { useBulkImport } from './useBulkImport'
+import { parseBulkImportFailure, useBulkImport } from './useBulkImport'
 import type { BulkImportSuccessResponse, BulkImportRowError } from './useBulkImport'
 
-const mockApiRequest = vi.hoisted(() => vi.fn())
-
 vi.mock('../../config/api', () => ({
-  apiRequest: mockApiRequest,
   ENDPOINTS: {
     PORTFOLIO_IMPORT: '/api/v1/portfolio/import',
   },
+  API_CONFIG: {
+    BASE_URL: 'http://localhost:3001',
+  },
 }))
+
+vi.mock('../../services/authService', () => ({
+  getAccessToken: () => null,
+}))
+
+function jsonResponse(status: number, body: unknown): Promise<Response> {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+}
 
 function createTestClient() {
   return new QueryClient({
@@ -29,9 +42,33 @@ function withClient(qc: QueryClient) {
   }
 }
 
+describe('parseBulkImportFailure', () => {
+  it('reads the backend failValidation body (top-level errors + meta)', () => {
+    const parsed = parseBulkImportFailure({
+      error: 'VALIDATION_ERROR',
+      message: 'Import failed: validation errors',
+      code: 'VALIDATION_ERROR',
+      errors: [{ row: 1, field: 'asset', message: 'Unknown asset' }],
+      meta: { totalRows: 2, validRows: 1 },
+    })
+
+    expect(parsed.message).toContain('validation errors')
+    expect(parsed.rowErrors).toEqual([{ row: 1, field: 'asset', message: 'Unknown asset' }])
+    expect(parsed.totalRows).toBe(2)
+    expect(parsed.validRows).toBe(1)
+  })
+})
+
 describe('useBulkImport', () => {
+  const fetchMock = vi.fn()
+
   beforeEach(() => {
-    vi.clearAllMocks()
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('exposes success response on successful bulk import', async () => {
@@ -39,7 +76,12 @@ describe('useBulkImport', () => {
       portfolioId: 'portfolio-abc',
       status: 'created',
     }
-    mockApiRequest.mockResolvedValue(successResponse)
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: successResponse }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
 
     const qc = createTestClient()
     const { result } = renderHook(() => useBulkImport(), {
@@ -59,23 +101,24 @@ describe('useBulkImport', () => {
 
     expect(result.current.data).toEqual(successResponse)
     expect(result.current.isError).toBe(false)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.rowErrors).toEqual([])
   })
 
-  it('surfaces per-row validation errors in the error object', async () => {
+  it('surfaces per-row validation errors from the backend failValidation format', async () => {
     const rowErrors: BulkImportRowError[] = [
       { row: 0, field: 'asset', message: 'Invalid asset symbol' },
       { row: 1, field: 'allocation_pct', message: 'Allocations must sum to 100' },
     ]
-    const apiError = new Error('Import failed: validation errors') as any
-    apiError.status = 400
-    apiError.code = 'VALIDATION_ERROR'
-    apiError.details = {
-      error: 'VALIDATION_ERROR',
-      message: 'Import failed: validation errors',
-      errors: rowErrors,
-      meta: { totalRows: 2, validRows: 0 },
-    }
-    mockApiRequest.mockRejectedValue(apiError)
+    fetchMock.mockResolvedValue(
+      jsonResponse(400, {
+        error: 'VALIDATION_ERROR',
+        message: 'Import failed: validation errors',
+        code: 'VALIDATION_ERROR',
+        errors: rowErrors,
+        meta: { totalRows: 2, validRows: 0 },
+      }),
+    )
 
     const qc = createTestClient()
     const { result } = renderHook(() => useBulkImport(), {
@@ -97,14 +140,14 @@ describe('useBulkImport', () => {
     })
 
     expect(result.current.error?.rowErrors).toEqual(rowErrors)
-    expect(result.current.error?.totalRows).toBe(2)
-    expect(result.current.error?.validRows).toBe(0)
+    expect(result.current.rowErrors).toEqual(rowErrors)
+    expect(result.current.totalRows).toBe(2)
+    expect(result.current.validRows).toBe(0)
     expect(result.current.error?.message).toContain('validation errors')
   })
 
   it('handles generic API errors without rowErrors', async () => {
-    const genericError = new Error('Network error')
-    mockApiRequest.mockRejectedValue(genericError)
+    fetchMock.mockRejectedValue(new Error('Network error'))
 
     const qc = createTestClient()
     const { result } = renderHook(() => useBulkImport(), {
@@ -121,15 +164,17 @@ describe('useBulkImport', () => {
     })
 
     expect(result.current.error?.rowErrors).toBeUndefined()
+    expect(result.current.rowErrors).toEqual([])
     expect(result.current.error?.message).toBe('Network error')
   })
 
-  it('resolves after the API call completes', async () => {
-    let resolvePromise: (value: BulkImportSuccessResponse) => void = () => {}
-    const pendingPromise = new Promise<BulkImportSuccessResponse>((resolve) => {
-      resolvePromise = resolve
-    })
-    mockApiRequest.mockReturnValue(pendingPromise)
+  it('exposes loading state while the request is in flight', async () => {
+    let resolvePromise: (value: Response) => void = () => {}
+    fetchMock.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolvePromise = resolve
+      }),
+    )
 
     const qc = createTestClient()
     const { result } = renderHook(() => useBulkImport(), {
@@ -143,12 +188,22 @@ describe('useBulkImport', () => {
       })
     })
 
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true)
+    })
+
     act(() => {
-      resolvePromise({ portfolioId: 'p-1', status: 'created' })
+      resolvePromise(
+        new Response(JSON.stringify({ portfolioId: 'p-1', status: 'created' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
     })
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true)
     })
+    expect(result.current.isLoading).toBe(false)
   })
 })

--- a/frontend/src/hooks/mutations/useBulkImport.ts
+++ b/frontend/src/hooks/mutations/useBulkImport.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query'
-import { apiRequest, ENDPOINTS } from '../../config/api'
-import type { ApiClientError } from '../../config/api'
+import { API_CONFIG, ENDPOINTS } from '../../config/api'
+import { getAccessToken } from '../../services/authService'
 
 export type BulkImportRowError = {
   row: number
@@ -29,44 +29,131 @@ export type BulkImportPayload = {
   contentType: 'application/json' | 'text/csv'
 }
 
+export type BulkImportError = Error & {
+  rowErrors?: BulkImportRowError[]
+  totalRows?: number
+  validRows?: number
+  code?: string
+}
+
+function asRowError(value: unknown): BulkImportRowError | null {
+  if (!value || typeof value !== 'object') return null
+  const rec = value as Record<string, unknown>
+  if (typeof rec.message !== 'string') return null
+  const rawRow = rec.row
+  const row = typeof rawRow === 'number' ? rawRow : Number(rawRow ?? 0)
+  const field = typeof rec.field === 'string' ? rec.field : 'unknown'
+  return { row: Number.isFinite(row) ? row : 0, field, message: rec.message }
+}
+
+function extractRowErrors(source: unknown): BulkImportRowError[] {
+  if (!source || typeof source !== 'object') return []
+  const rec = source as Record<string, unknown>
+  const errorObj = rec.error && typeof rec.error === 'object' ? (rec.error as Record<string, unknown>) : null
+  const details = errorObj?.details
+  const detailsObj = details && typeof details === 'object' && !Array.isArray(details)
+    ? (details as Record<string, unknown>)
+    : null
+
+  const candidates = [rec.errors, details, detailsObj?.errors, errorObj?.errors]
+  for (const candidate of candidates) {
+    if (!Array.isArray(candidate)) continue
+    const parsed = candidate.map(asRowError).filter((row): row is BulkImportRowError => row !== null)
+    if (parsed.length > 0) return parsed
+  }
+  return []
+}
+
+function extractMeta(source: unknown): { totalRows?: number; validRows?: number } {
+  if (!source || typeof source !== 'object') return {}
+  const rec = source as Record<string, unknown>
+  const meta = rec.meta && typeof rec.meta === 'object' ? (rec.meta as Record<string, unknown>) : rec
+  return {
+    totalRows: typeof meta.totalRows === 'number' ? meta.totalRows : undefined,
+    validRows: typeof meta.validRows === 'number' ? meta.validRows : undefined,
+  }
+}
+
+function extractMessage(source: unknown, fallback: string): string {
+  if (!source || typeof source !== 'object') return fallback
+  const rec = source as Record<string, unknown>
+  if (typeof rec.message === 'string' && rec.message) return rec.message
+  const errorObj = rec.error
+  if (errorObj && typeof errorObj === 'object' && typeof (errorObj as { message?: unknown }).message === 'string') {
+    return (errorObj as { message: string }).message
+  }
+  return fallback
+}
+
+/** Parse the backend bulk-import validation body (failValidation) or an API envelope. */
+export function parseBulkImportFailure(body: unknown, fallbackMessage = 'Import failed'): BulkImportError {
+  const err = new Error(extractMessage(body, fallbackMessage)) as BulkImportError
+  const rowErrors = extractRowErrors(body)
+  if (rowErrors.length > 0) err.rowErrors = rowErrors
+  const meta = extractMeta(body)
+  if (meta.totalRows != null) err.totalRows = meta.totalRows
+  if (meta.validRows != null) err.validRows = meta.validRows
+  if (body && typeof body === 'object') {
+    const rec = body as Record<string, unknown>
+    const code = rec.code ?? (rec.error && typeof rec.error === 'object' ? (rec.error as { code?: unknown }).code : rec.error)
+    if (typeof code === 'string') err.code = code
+  }
+  return err
+}
+
+function importUrl(): string {
+  const base = API_CONFIG.BASE_URL.replace(/\/$/, '')
+  return `${base}${ENDPOINTS.PORTFOLIO_IMPORT}`
+}
+
+async function bulkImportRequest({ content, contentType }: BulkImportPayload): Promise<BulkImportSuccessResponse> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Content-Type': contentType,
+  }
+  const token = getAccessToken()
+  if (token) headers.Authorization = `Bearer ${token}`
+
+  let response: Response
+  try {
+    response = await fetch(importUrl(), {
+      method: 'POST',
+      headers,
+      body: content,
+      credentials: 'omit',
+    })
+  } catch (err) {
+    throw err instanceof Error ? err : new Error('Import failed')
+  }
+
+  const body = await response.json().catch(() => null)
+
+  if (!response.ok) {
+    throw parseBulkImportFailure(body, `Import failed (${response.status})`)
+  }
+
+  const payload =
+    body && typeof body === 'object' && 'data' in body && (body as { data?: unknown }).data != null
+      ? (body as { data: BulkImportSuccessResponse }).data
+      : (body as BulkImportSuccessResponse | null)
+
+  if (!payload?.portfolioId) {
+    throw new Error('Import succeeded but no portfolio id was returned')
+  }
+
+  return payload
+}
+
 export function useBulkImport() {
-  return useMutation<
-    BulkImportSuccessResponse,
-    Error & { rowErrors?: BulkImportRowError[]; totalRows?: number; validRows?: number },
-    BulkImportPayload
-  >({
-    mutationFn: async ({ content, contentType }) => {
-      try {
-        const data = await apiRequest<BulkImportSuccessResponse>(
-          ENDPOINTS.PORTFOLIO_IMPORT,
-          {
-            method: 'POST',
-            headers: {
-              Accept: 'application/json',
-              'Content-Type': contentType,
-            },
-            body: content,
-          },
-        )
-        return data
-      } catch (err: unknown) {
-        const apiErr = err as ApiClientError
-        if (apiErr.details) {
-          const validation = apiErr.details as BulkImportValidationError
-          const combined = new Error(
-            validation.message || apiErr.message || 'Import failed',
-          ) as Error & {
-            rowErrors?: BulkImportRowError[]
-            totalRows?: number
-            validRows?: number
-          }
-          combined.rowErrors = validation.errors
-          combined.totalRows = validation.meta?.totalRows
-          combined.validRows = validation.meta?.validRows
-          throw combined
-        }
-        throw err
-      }
-    },
+  const mutation = useMutation<BulkImportSuccessResponse, BulkImportError, BulkImportPayload>({
+    mutationFn: bulkImportRequest,
   })
+
+  return {
+    ...mutation,
+    isLoading: mutation.isPending,
+    rowErrors: mutation.error?.rowErrors ?? [],
+    totalRows: mutation.error?.totalRows,
+    validRows: mutation.error?.validRows,
+  }
 }


### PR DESCRIPTION
## Summary

Makes `useBulkImport` a reusable mutation hook that `BulkPortfolioImport` can consume for loading, overall failure, and per-row validation errors.

The backend `failValidation` helper returns a non-envelope body (`errors` + `meta` at the top level). The previous hook only read `ApiClientError.details`, so those row errors never surfaced. This change parses that backend format directly.

### What changed

- `useBulkImport` posts to `/api/v1/portfolio/import` and parses both success envelopes and the `failValidation` error body (`errors[]`, `meta.totalRows`, `meta.validRows`).
- Exported `parseBulkImportFailure()` so the per-row format is testable in isolation.
- The hook now exposes `isLoading`, `rowErrors`, `totalRows`, and `validRows` alongside the standard React Query mutation fields.
- Tests cover mocked success, mocked per-row validation errors, generic network failure, and in-flight loading state.

`BulkPortfolioImport` already calls this hook; it keeps working via `mutateAsync` / `isPending` and now receives correctly parsed row errors from the real backend response shape.

## Verification

- `cd frontend && npx vitest run src/hooks/mutations/useBulkImport.test.tsx src/components/__tests__/BulkPortfolioImport.test.tsx`
- All 11 tests passed (5 hook + 6 component).

## Release Notes

- [x] User-facing change
- [ ] Breaking change
- [ ] No release note needed

Bulk import now reports per-row validation errors from the backend instead of a generic HTTP failure, and the import button shows a loading state while the request is in flight.

Closes #1270

