### PR TITLE
fix(ecs): correct syntax and typos in autoscaling terraform code

### DIFF
--- a/deployment/terraform/modules/ecs/main.tf
+++ b/deployment/terraform/modules/ecs/main.tf
@@ -321,7 +321,7 @@ resource "aws_cloudwatch_metric_alarm" "low_queue_backlog" {
 }
 
 # Blue/Green deployment resources
-resource "aws_ecodedeploy_app" "main" {
+resource "aws_codedeploy_app" "main" {
   count = var.enable_blue_green ? 1 : 0
   name  = "${var.name_prefix}-ecs-deployment"
 
@@ -359,7 +359,7 @@ resource "aws_ecs_deployment_configuration" "main" {
 
 resource "aws_codedeploy_deployment_group" "main" {
   count = var.enable_blue_green ? 1 : 0
-  app_name              = aws_ecodedeploy_app.main[0].name
+  app_name              = aws_codedeploy_app.main[0].name
   deployment_group_name  = "${var.name_prefix}-deployment-group"
   service_role_arn      = aws_iam_role.codedeploy[0].arn
 

--- a/deployment/terraform/modules/ecs/outputs.tf
+++ b/deployment/terraform/modules/ecs/outputs.tf
@@ -14,7 +14,7 @@ output "green_target_group_arn" {
 
 output "codedeploy_app_name" {
   description = "Name of the CodeDeploy application (if blue/green enabled)"
-  value       = try(aws_ecodedeploy_app.main[0].name, null)
+  value       = try(aws_codedeploy_app.main[0].name, null)
 }
 
 output "deployment_group_name" {

--- a/deployment/terraform/modules/ecs/variables.tf
+++ b/deployment/terraform/modules/ecs/variables.tf
@@ -65,6 +65,8 @@ variable "blue_green_deployment_config" {
     })), [])
   })
   default = {}
+}
+
 variable "ecs_min_capacity" {
   description = "Minimum number of tasks to run"
   type        = number


### PR DESCRIPTION
Closes  #1276

# Description

This PR fixes configuration and syntax errors in the ECS Terraform module to ensure the newly added autoscaling policies and CloudWatch alarms can be successfully planned and applied. Specifically, it resolves a missing closing brace in `variables.tf` and corrects a typographical error (`aws_ecodedeploy_app` to `aws_codedeploy_app`) in `main.tf` and `outputs.tf`.



## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] DevOps / CI / Documentation update

# 📖 API Changes & Breaking Changes Checklist

If your changes affect any HTTP route, request/response schema, database schema, or CLI/contract signature:

- [ ] **OpenAPI Spec:** Updated `backend/src/openapi/spec.ts` (and exported `backend/openapi.json` via `npm run openapi:export`).
- [ ] **API Documentation:** Updated `API.md` and/or `docs/API.md` explaining route/schema behavior changes.
- [ ] **Changelog:** Added a corresponding entry in `CHANGELOG.md` under the `[Unreleased]` section.
- [ ] **Migration Notes:** Provided instructions for consumers if the change is a breaking or material behavior shift.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] **This PR links to an issue or provides a rationale for no issue**
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected blue/green deployment configuration so CodeDeploy applications and deployment groups are referenced properly.
  * Fixed the exported CodeDeploy application name to resolve correctly.
* **Style**
  * Added minor whitespace formatting to deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->