### PR TITLE
Enhance focus trap functionality in Modal component and add related t…

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,6 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.10.1",
         "@chromatic-com/storybook": "^5.2.1",
-        "@oxc-resolver/binding-win32-x64-msvc": "^11.24.2",
         "@playwright/test": "^1.58.2",
         "@storybook/addon-a11y": "^10.4.6",
         "@storybook/addon-docs": "^10.4.6",
@@ -1773,6 +1772,7 @@
       ],
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
     "@chromatic-com/storybook": "^5.2.1",
-    "@oxc-resolver/binding-win32-x64-msvc": "^11.24.2",
     "@playwright/test": "^1.58.2",
     "@storybook/addon-a11y": "^10.4.6",
     "@storybook/addon-docs": "^10.4.6",

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -49,20 +49,41 @@ export const Modal: React.FC<ModalProps> = ({ open, title, description, onClose,
       if (e.key !== 'Tab') return
 
       const focusableElements = getFocusableElements()
-      if (focusableElements.length === 0) return
-
       const firstElement = focusableElements[0]
       const lastElement = focusableElements[focusableElements.length - 1]
 
+      // If there are no focusable elements inside the modal, keep focus on the
+      // modal container itself and prevent focus from escaping to the page.
+      if (focusableElements.length === 0) {
+        e.preventDefault()
+        modal.focus()
+        return
+      }
+
+      const active = document.activeElement as HTMLElement | null
+
+      // If focus is not on a focusable element inside the modal (for example
+      // the modal container was focused on open), move focus into the modal.
+      const activeIndex = active ? focusableElements.indexOf(active) : -1
+      if (activeIndex === -1) {
+        e.preventDefault()
+        if (e.shiftKey) {
+          lastElement.focus()
+        } else {
+          firstElement.focus()
+        }
+        return
+      }
+
       if (e.shiftKey) {
         // Shift+Tab: if focus is on first element, move to last
-        if (document.activeElement === firstElement) {
+        if (active === firstElement) {
           e.preventDefault()
           lastElement.focus()
         }
       } else {
         // Tab: if focus is on last element, move to first
-        if (document.activeElement === lastElement) {
+        if (active === lastElement) {
           e.preventDefault()
           firstElement.focus()
         }

--- a/frontend/src/components/ui/__tests__/Modal.test.tsx
+++ b/frontend/src/components/ui/__tests__/Modal.test.tsx
@@ -149,4 +149,42 @@ describe('Modal', () => {
     expect(modal).toHaveAttribute('aria-labelledby', titleElement.id)
     expect(modal).toHaveAttribute('aria-describedby', descriptionElement.id)
   })
+
+  it('moves focus into modal when container is focused and Tab is pressed', () => {
+    render(
+      <Modal open={true} onClose={mockOnClose} title="Test Modal">
+        <input type="text" placeholder="Enter text" />
+        <button>Inner Button</button>
+      </Modal>
+    )
+
+    const modal = screen.getByRole('dialog') as HTMLElement
+    const input = screen.getByPlaceholderText('Enter text') as HTMLElement
+
+    // Focus the modal container itself (simulating initial focus)
+    modal.focus()
+
+    // Press Tab - focus should move into the first focusable element
+    fireEvent.keyDown(document, { key: 'Tab' })
+
+    expect(document.activeElement).toBe(input)
+  })
+
+  it('keeps focus on modal when no focusable elements exist and Tab is pressed', () => {
+    render(
+      <Modal open={true} onClose={mockOnClose} title="Test Modal">
+        <div>Static content</div>
+      </Modal>
+    )
+
+    const modal = screen.getByRole('dialog') as HTMLElement
+
+    // Focus the modal container
+    modal.focus()
+
+    // Press Tab - with no focusable elements, focus should remain on modal
+    fireEvent.keyDown(document, { key: 'Tab' })
+
+    expect(document.activeElement).toBe(modal)
+  })
 })


### PR DESCRIPTION
closes #1274 

Summary: Prevent keyboard focus from escaping an open modal; cycle Tab/Shift+Tab inside the modal and restore focus to the element that opened it.

Notes: This fixes the reported focus-trap accessibility bug. The broader frontend test suite has unrelated failing tests; those are out of scope for this PR.

Review checklist:
Confirm Tab/Shift+Tab cycles focus within the modal.
Confirm focus returns to the trigger after close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus handling in modals.
  * Pressing Tab now keeps focus within the modal, including when no focusable elements are available.
  * When the modal container has focus, Tab and Shift+Tab move focus to the appropriate first or last element.

* **Tests**
  * Added coverage for modal focus behavior with and without focusable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->