### PR TITLE
feat: add Sentry observability integration to ErrorBoundary

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -41,6 +41,8 @@ VITE_SENTRY_DSN=
 VITE_SENTRY_ENVIRONMENT=development
 # Sentry release tag (use the full git SHA for the deployed build)
 VITE_SENTRY_RELEASE=
+# Optional app version shown in error reports (falls back to the Sentry release)
+VITE_APP_VERSION=
 VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
 VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0
 VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE=1

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -1,16 +1,20 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 
+const captureException = vi.fn()
+const getAppVersion = vi.fn(() => 'test-release')
+const sanitizeError = vi.fn((error: Error) => error)
+const sanitizeObservabilityText = vi.fn((value: string) => value)
+
 vi.mock('../observability', () => ({
-    Sentry: {
-        captureException: vi.fn(),
-    },
+    Sentry: { captureException },
+    getAppVersion,
+    sanitizeError,
+    sanitizeObservabilityText,
 }))
 
+const getPublicKey = vi.fn(() => null)
 vi.mock('../utils/walletManager', () => ({
-    walletManager: {
-        getPublicKey: vi.fn(() => null),
-    },
+    walletManager: { getPublicKey },
 }))
 
 import { ErrorBoundary } from './ErrorBoundary'
@@ -28,6 +32,7 @@ describe('ErrorBoundary', () => {
     afterEach(() => {
         cleanup()
         vi.clearAllMocks()
+        window.history.replaceState({}, '', '/')
     })
 
     it('renders children when no error occurs', () => {
@@ -54,8 +59,10 @@ describe('ErrorBoundary', () => {
         consoleError.mockRestore()
     })
 
-    it('reports the error to Sentry with context', () => {
+    it('reports the error to Sentry with safe context when a child throws', () => {
         const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+        getPublicKey.mockReturnValue('GABC123')
+        window.history.replaceState({}, '', '/portfolio?token=must-not-be-reported#private-key')
 
         render(
             <ErrorBoundary fallbackTitle="PortfolioSection">
@@ -69,10 +76,14 @@ describe('ErrorBoundary', () => {
             expect.objectContaining({
                 extra: expect.objectContaining({
                     componentStack: expect.any(String),
+                    route: '/portfolio',
+                    userId: 'GABC123',
+                    appVersion: 'test-release',
                     section: 'PortfolioSection',
                 }),
             }),
         )
+        expect(JSON.stringify(Sentry.captureException.mock.calls[0])).not.toContain('must-not-be-reported')
 
         consoleError.mockRestore()
     })

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 import { RefreshCw } from 'lucide-react'
-import { Sentry } from '../observability'
+import { getAppVersion, sanitizeError, sanitizeObservabilityText, Sentry } from '../observability'
 import { walletManager } from '../utils/walletManager'
 
 interface Props {
@@ -39,12 +39,13 @@ export class ErrorBoundary extends Component<Props, State> {
         } catch {
             // walletManager not available
         }
-        Sentry.captureException(error, {
+        Sentry.captureException(sanitizeError(error), {
             extra: {
-                componentStack: errorInfo.componentStack,
+                componentStack: errorInfo.componentStack ? sanitizeObservabilityText(errorInfo.componentStack) : undefined,
                 route,
                 userId,
-                section: this.props.fallbackTitle,
+                appVersion: getAppVersion(),
+                section: this.props.fallbackTitle ? sanitizeObservabilityText(this.props.fallbackTitle) : undefined,
             },
             tags: {
                 errorBoundary: 'section',

--- a/frontend/src/observability.test.ts
+++ b/frontend/src/observability.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeError, sanitizeObservabilityText } from './observability'
+
+describe('observability data sanitization', () => {
+    it('redacts bearer tokens, key-value secrets, and Stellar secret keys', () => {
+        const stellarSecret = `S${'A'.repeat(55)}`
+        const value = sanitizeObservabilityText(
+            `Bearer abc.def.ghi apiKey=coingecko-secret private_key: ${stellarSecret} publicKey=GABC123`,
+        )
+
+        expect(value).not.toContain('abc.def.ghi')
+        expect(value).not.toContain('coingecko-secret')
+        expect(value).not.toContain(stellarSecret)
+        expect(value).toContain('publicKey=GABC123')
+        expect(value).toContain('[REDACTED]')
+    })
+
+    it('returns a sanitized Error without changing the original error', () => {
+        const original = new Error('request failed with token=super-secret')
+        const sanitized = sanitizeError(original)
+
+        expect(sanitized).not.toBe(original)
+        expect(sanitized.message).toBe('request failed with token=[REDACTED]')
+        expect(original.message).toContain('super-secret')
+    })
+})

--- a/frontend/src/observability.ts
+++ b/frontend/src/observability.ts
@@ -1,6 +1,8 @@
 import * as Sentry from '@sentry/react'
+import type { Event } from '@sentry/react'
 
 const enabled = import.meta.env.VITE_SENTRY_ENABLED === 'true' && !!import.meta.env.VITE_SENTRY_DSN
+const REDACTED = '[REDACTED]'
 
 const pickFirstDefined = (...values: Array<string | undefined>): string | undefined => {
     for (const value of values) {
@@ -11,16 +13,61 @@ const pickFirstDefined = (...values: Array<string | undefined>): string | undefi
     return undefined
 }
 
+/**
+ * Remove credentials and private-key-like values from strings before they reach
+ * the reporting SDK. Public Stellar addresses (G...) are intentionally retained.
+ */
+export function sanitizeObservabilityText(value: string): string {
+    return value
+        .replace(/bearer\s+[a-z0-9._~+/=-]+/gi, `Bearer ${REDACTED}`)
+        .replace(/\b(?:access[_-]?token|auth[_-]?token|refresh[_-]?token|api[_-]?key|private[_-]?key|secret)\s*[:=]\s*[^\s,;]+/gi, (match) => {
+            const separator = match.includes('=') ? '=' : ':'
+            const key = match.slice(0, match.indexOf(separator)).trim()
+            return `${key}${separator}${REDACTED}`
+        })
+        .replace(/\bS[A-Z2-7]{55}\b/g, REDACTED)
+}
+
+export function sanitizeError(error: Error): Error {
+    const safeError = new Error(sanitizeObservabilityText(error.message))
+    safeError.name = sanitizeObservabilityText(error.name)
+    if (error.stack) safeError.stack = sanitizeObservabilityText(error.stack)
+    return safeError
+}
+
+function scrubEvent(event: Event): Event {
+    const safeEvent = { ...event }
+    if (safeEvent.message) safeEvent.message = sanitizeObservabilityText(safeEvent.message)
+    if (safeEvent.exception?.values) {
+        safeEvent.exception = {
+            ...safeEvent.exception,
+            values: safeEvent.exception.values.map((exception) => ({
+                ...exception,
+                value: exception.value ? sanitizeObservabilityText(exception.value) : exception.value,
+                stacktrace: exception.stacktrace
+                    ? { ...exception.stacktrace, frames: exception.stacktrace.frames?.map((frame) => ({
+                        ...frame,
+                        filename: frame.filename ? sanitizeObservabilityText(frame.filename) : frame.filename,
+                        function: frame.function ? sanitizeObservabilityText(frame.function) : frame.function,
+                    })) }
+                    : exception.stacktrace,
+            })),
+        }
+    }
+    return safeEvent
+}
+
 export function initializeObservability(): void {
     if (!enabled) return
 
     const environment = pickFirstDefined(import.meta.env.VITE_SENTRY_ENVIRONMENT, import.meta.env.MODE, 'development')
-    const release = pickFirstDefined(import.meta.env.VITE_SENTRY_RELEASE)
+    const release = pickFirstDefined(import.meta.env.VITE_SENTRY_RELEASE, import.meta.env.VITE_APP_VERSION)
 
     Sentry.init({
         dsn: import.meta.env.VITE_SENTRY_DSN,
         environment,
         release,
+        beforeSend: (event) => scrubEvent(event),
         integrations: [
             Sentry.browserTracingIntegration(),
             Sentry.replayIntegration(),
@@ -29,6 +76,10 @@ export function initializeObservability(): void {
         replaysSessionSampleRate: Number(import.meta.env.VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE ?? 0),
         replaysOnErrorSampleRate: Number(import.meta.env.VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE ?? 1),
     })
+}
+
+export function getAppVersion(): string {
+    return pickFirstDefined(import.meta.env.VITE_APP_VERSION, import.meta.env.VITE_SENTRY_RELEASE, 'unknown') ?? 'unknown'
 }
 
 export { Sentry }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -13,6 +13,7 @@ interface ImportMetaEnv {
     readonly VITE_SENTRY_DSN?: string
     readonly VITE_SENTRY_ENVIRONMENT?: string
     readonly VITE_SENTRY_RELEASE?: string
+    readonly VITE_APP_VERSION?: string
     readonly VITE_SENTRY_TRACES_SAMPLE_RATE?: string
     readonly VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE?: string
     readonly VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE?: string


### PR DESCRIPTION
Summary
Integrate Sentry reporting with ErrorBoundary for uncaught render errors.
Attach safe diagnostic context, including pathname-only route, public wallet ID when available, app version, component stack, and affected section.
Add event sanitization to prevent bearer tokens, API keys, secrets, private keys, and Stellar secret-key-like values from being sent.
Add tests covering reporting invocation, contextual metadata, route redaction, and sensitive-data sanitization.
Document the optional VITE_APP_VERSION configuration.
Testing
Focused Vitest execution was attempted but is currently blocked by the repository’s Vite/Vitest dependency mismatch.
TypeScript validation was attempted; the repository has pre-existing syntax errors in frontend/src/components/upstream_dashboard.tsx. No diagnostics were reported for the modified observability or error-boundary files.

Closes #1265 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional app version reporting for error diagnostics.
  * Error reports now automatically redact sensitive credentials, tokens, and private keys while preserving safe public information.
  * Added configurable app version support through the frontend environment settings.

* **Tests**
  * Expanded coverage for sensitive-data redaction and sanitized error reporting.
  * Added validation that URL tokens are excluded from submitted error context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->