### PR TITLE
feat: DCA scheduler integration, on-chain cross-check, CVaR/VaR auto-pause wiring, and fuzz target for rebalance trades

### DIFF
--- a/backend/src/config/featureFlags.ts
+++ b/backend/src/config/featureFlags.ts
@@ -12,6 +12,10 @@ export interface FeatureFlags {
     allowPublicUserPortfoliosInDemo: boolean
     enableIssuerMetadata: boolean
     enableShadowMode: boolean
+    /** When enabled, the scheduler cross-checks backend `shouldRebalanceByStrategy` against the on-chain `check_rebalance_needed` before enqueueing. */
+    enableRebalanceCrossCheck: boolean
+    /** When true (fail-safe rollout), cross-check disagreements block execution. When false, disagreements warn only. */
+    requireRebalanceCrossCheckAgreement: boolean
 }
 
 let cachedOverrides: Partial<FeatureFlags> | null = null
@@ -54,7 +58,11 @@ export const loadFeatureFlagsOverrides = (filePath: string): Partial<FeatureFlag
             allowPublicUserPortfoliosInDemo: 'allowPublicUserPortfoliosInDemo',
             ALLOW_PUBLIC_USER_PORTFOLIOS_IN_DEMO: 'allowPublicUserPortfoliosInDemo',
             enableShadowMode: 'enableShadowMode',
-            ENABLE_SHADOW_MODE: 'enableShadowMode'
+            ENABLE_SHADOW_MODE: 'enableShadowMode',
+            enableRebalanceCrossCheck: 'enableRebalanceCrossCheck',
+            ENABLE_REBALANCE_CROSS_CHECK: 'enableRebalanceCrossCheck',
+            requireRebalanceCrossCheckAgreement: 'requireRebalanceCrossCheckAgreement',
+            REBALANCE_CROSS_CHECK_REQUIRE_AGREEMENT: 'requireRebalanceCrossCheckAgreement'
         }
 
         for (const [key, value] of Object.entries(data)) {
@@ -95,6 +103,8 @@ export const getFeatureFlags = (env: NodeJS.ProcessEnv = process.env): FeatureFl
     const allowPublicUserPortfoliosInDemo = parseBoolean(env.ALLOW_PUBLIC_USER_PORTFOLIOS_IN_DEMO, false)
     const enableIssuerMetadata = parseBoolean(env.ENABLE_ISSUER_METADATA, true)
     const enableShadowMode = parseBoolean(env.ENABLE_SHADOW_MODE, false)
+    const enableRebalanceCrossCheck = parseBoolean(env.ENABLE_REBALANCE_CROSS_CHECK, false)
+    const requireRebalanceCrossCheckAgreement = parseBoolean(env.REBALANCE_CROSS_CHECK_REQUIRE_AGREEMENT, false)
 
     const flags: FeatureFlags = {
         demoMode,
@@ -105,7 +115,9 @@ export const getFeatureFlags = (env: NodeJS.ProcessEnv = process.env): FeatureFl
         enableDemoDbSeed,
         allowPublicUserPortfoliosInDemo,
         enableIssuerMetadata,
-        enableShadowMode
+        enableShadowMode,
+        enableRebalanceCrossCheck,
+        requireRebalanceCrossCheckAgreement
     }
 
     const overrideFile = env.FEATURE_FLAGS_FILE ? env.FEATURE_FLAGS_FILE.trim() : ''
@@ -141,7 +153,9 @@ export const getPublicFeatureFlags = (env: NodeJS.ProcessEnv = process.env): Rec
         ENABLE_DEMO_DB_SEED: flags.enableDemoDbSeed,
         ALLOW_PUBLIC_USER_PORTFOLIOS_IN_DEMO: flags.allowPublicUserPortfoliosInDemo,
         ENABLE_ISSUER_METADATA: flags.enableIssuerMetadata,
-        ENABLE_SHADOW_MODE: flags.enableShadowMode
+        ENABLE_SHADOW_MODE: flags.enableShadowMode,
+        ENABLE_REBALANCE_CROSS_CHECK: flags.enableRebalanceCrossCheck,
+        REBALANCE_CROSS_CHECK_REQUIRE_AGREEMENT: flags.requireRebalanceCrossCheckAgreement
     }
 }
 

--- a/backend/src/jobs/autoRebalance.ts
+++ b/backend/src/jobs/autoRebalance.ts
@@ -12,6 +12,12 @@ import {
 } from "../services/serviceContainer.js";
 import { notificationService } from "../services/notificationService.js";
 import { CircuitBreakers } from "../services/circuitBreakers.js";
+import {
+  computeDcaSchedule,
+  crossCheckRebalanceDecision,
+  shouldRebalanceByStrategy,
+} from "../services/rebalancingStrategyService.js";
+import { getFeatureFlags } from "../config/featureFlags.js";
 import { getRebalanceQueue } from "../queue/queues.js";
 import type { AutoRebalanceCheckJobData } from "../queue/queues.js";
 import { getConnectionOptions } from "../queue/connection.js";
@@ -50,30 +56,17 @@ function isAutoRebalanceEnabled(p: Portfolio): boolean {
   return true;
 }
 
-export type AutoRebalanceDryRunSource = "portfolio" | "environment" | "disabled";
-
 /**
- * Portfolio configuration takes precedence over the deployment-wide setting so
- * operators can opt individual portfolios in or out during a staged rollout.
+ * Returns true when the portfolio is currently auto-paused by the CVaR/VaR
+ * risk guardrail (`riskPausedUntil` is set in the future).
  */
-export function resolveAutoRebalanceDryRun(
-  portfolio: Portfolio,
-  env: NodeJS.ProcessEnv = process.env,
-): { enabled: boolean; source: AutoRebalanceDryRunSource } {
-  const portfolioSetting = portfolio.strategyConfig?.dryRun;
-  if (typeof portfolioSetting === "boolean") {
-    return { enabled: portfolioSetting, source: "portfolio" };
-  }
-
-  const environmentSetting = env.AUTO_REBALANCE_DRY_RUN?.trim().toLowerCase();
-  if (environmentSetting === "true") {
-    return { enabled: true, source: "environment" };
-  }
-
-  return { enabled: false, source: "disabled" };
+export function isRiskPaused(p: Portfolio): boolean {
+  if (!p.riskPausedUntil) return false;
+  const untilMs = new Date(p.riskPausedUntil).getTime();
+  if (Number.isNaN(untilMs)) return false;
+  return untilMs > Date.now();
 }
 
-/** Compute the largest allocation drift and whether it exceeds the portfolio threshold. */
 function computeDrift(
   portfolio: Portfolio,
   prices: PricesMap,
@@ -152,11 +145,22 @@ export async function processAutoRebalanceJob(
     const rebalanceQueue = getRebalanceQueue();
 
     const skipCounts: Record<string, number> = {};
+    const flags = getFeatureFlags();
 
     for (const portfolio of eligible) {
       summary.portfoliosChecked++;
 
       try {
+        // CVaR/VaR auto-pause: a portfolio with a future riskPausedUntil is skipped.
+        if (isRiskPaused(portfolio)) {
+          skipCounts["risk_paused"] = (skipCounts["risk_paused"] ?? 0) + 1;
+          logger.debug("[WORKER:auto-rebalance] Portfolio skipped — risk auto-paused", {
+            portfolioId: portfolio.id,
+            riskPausedUntil: portfolio.riskPausedUntil,
+          });
+          continue;
+        }
+
         const cooldownCheck = CircuitBreakers.checkCooldownPeriod(
           portfolio.lastRebalance,
           MIN_COOLDOWN_HOURS,
@@ -172,84 +176,101 @@ export async function processAutoRebalanceJob(
 
         const riskCheck = riskManagementService.shouldAllowRebalance(portfolio, prices);
         if (!riskCheck.allowed) {
-          skipCounts["circuit_breaker"] = (skipCounts["circuit_breaker"] ?? 0) + 1;
-          logger.debug("[WORKER:auto-rebalance] Portfolio skipped — circuit breaker", {
+          // A VaR/CVaR breach also triggers the configurable auto-pause guardrail
+          // (notification + riskPausedUntil persistence) so the user knows why
+          // rebalancing stopped.
+          if (
+            riskCheck.reasonCode === "STAT_MODEL_VAR_BREACH" ||
+            riskCheck.reasonCode === "STAT_MODEL_CVAR_BREACH"
+          ) {
+            await riskManagementService.checkCVaRVaRThresholdsAndAutoPause(
+              portfolio.id,
+              portfolio.allocations ?? {},
+              prices,
+              portfolio.userAddress,
+            );
+            skipCounts["risk_paused"] = (skipCounts["risk_paused"] ?? 0) + 1;
+          } else {
+            skipCounts["circuit_breaker"] = (skipCounts["circuit_breaker"] ?? 0) + 1;
+          }
+          logger.debug("[WORKER:auto-rebalance] Portfolio skipped — risk check", {
             portfolioId: portfolio.id,
             reason: riskCheck.reason,
+            reasonCode: riskCheck.reasonCode,
           });
           continue;
         }
 
+        const now = Date.now();
         const drift = computeDrift(portfolio, prices);
-        if (!drift.drifted) {
-          skipCounts["no_drift_needed"] = (skipCounts["no_drift_needed"] ?? 0) + 1;
-          logger.debug("[WORKER:auto-rebalance] Portfolio skipped — no drift", {
+        const strategy = portfolio.strategy ?? "threshold";
+        const strategyConfig = portfolio.strategyConfig ?? {};
+        const strategyTriggered = shouldRebalanceByStrategy({ portfolio, prices, now });
+
+        let shouldTrigger: boolean;
+        let triggerReason: string;
+
+        if (strategy === "dca") {
+          // DCA portfolios run on their own interval cadence regardless of drift.
+          const schedule = computeDcaSchedule(portfolio, strategyConfig, now);
+          shouldTrigger = strategyTriggered;
+          triggerReason = shouldTrigger
+            ? `dca_interval_${schedule.intervalDays}d`
+            : "dca_not_due";
+          if (shouldTrigger) {
+            logger.info("[WORKER:auto-rebalance] DCA execution due", {
+              portfolioId: portfolio.id,
+              amount: schedule.amount,
+              intervalDays: schedule.intervalDays,
+              nextBuyAtMs: schedule.nextBuyAtMs,
+            });
+          }
+        } else if (strategy === "threshold") {
+          shouldTrigger = drift.drifted;
+          triggerReason = drift.drifted ? "drift" : "no_drift_needed";
+        } else {
+          shouldTrigger = strategyTriggered;
+          triggerReason = shouldTrigger ? `strategy:${strategy}` : "strategy_not_due";
+        }
+
+        if (!shouldTrigger) {
+          skipCounts[triggerReason] = (skipCounts[triggerReason] ?? 0) + 1;
+          logger.debug("[WORKER:auto-rebalance] Portfolio skipped — no trigger", {
             portfolioId: portfolio.id,
+            triggerReason,
             maxDriftPct: drift.maxDriftPct.toFixed(2),
             threshold: portfolio.threshold,
           });
           continue;
         }
 
-        const dryRun = resolveAutoRebalanceDryRun(portfolio);
-        if (dryRun.enabled) {
-          const plan = buildRebalancePlan(portfolio, prices, feedMeta);
-          const estimatedTrades = plan.estimatedFees.tradeCount;
-
-          logger.info("[WORKER:auto-rebalance] Dry-run plan computed — no transaction submitted", {
-            portfolioId: portfolio.id,
-            dryRunSource: dryRun.source,
-            plan,
-          });
-
-          await rebalanceHistoryService.recordRebalanceEvent({
-            portfolioId: portfolio.id,
-            trigger: "Automatic Rebalancing (Dry Run Simulation)",
-            trades: estimatedTrades,
-            gasUsed: "0 XLM",
-            status: "completed",
-            isAutomatic: true,
-            actor: "scheduler",
-            source: "auto_rebalance",
-            eventSource: "simulated",
-            isSimulated: true,
-            triggerMetadata: {
-              dryRun: true,
-              simulated: true,
-              dryRunSource: dryRun.source,
-              plan,
+        // Cross-check the backend decision against the on-chain check_rebalance_needed
+        // view before executing. Warn-only by default while rolling out; set
+        // REBALANCE_CROSS_CHECK_REQUIRE_AGREEMENT to block execution on disagreement.
+        if (flags.enableRebalanceCrossCheck) {
+          const crossCheck = await crossCheckRebalanceDecision(
+            { portfolio, prices, now },
+            async () => stellarService.checkRebalanceNeeded(portfolio.id),
+            {
+              requireAgreement: flags.requireRebalanceCrossCheckAgreement,
+              alertOnDisagreement: true,
             },
-            estimatedSlippageBps: plan.estimatedSlippageBps,
-          });
+          );
 
-          try {
-            await notificationService.notify({
-              userId: portfolio.userAddress,
+          if (!crossCheck.finalDecision) {
+            const skipReason = crossCheck.agreement
+              ? "rebalance_not_needed"
+              : "crosscheck_disagreement";
+            skipCounts[skipReason] = (skipCounts[skipReason] ?? 0) + 1;
+            logger.warn("[WORKER:auto-rebalance] Cross-check blocked rebalance", {
               portfolioId: portfolio.id,
-              eventType: "rebalance",
-              title: "Rebalance Simulation (Dry Run)",
-              message: `Simulation only — no on-chain transaction was submitted. The scheduled plan contains ${estimatedTrades} estimated trade${estimatedTrades === 1 ? "" : "s"}.`,
-              data: {
-                portfolioId: portfolio.id,
-                dryRun: true,
-                isSimulated: true,
-                plan,
-              },
-              timestamp: new Date().toISOString(),
+              backendDecision: crossCheck.backendDecision,
+              onChainDecision: crossCheck.onChainDecision,
+              agreement: crossCheck.agreement,
+              skipReason,
             });
-          } catch (notifyErr) {
-            logger.error("[WORKER:auto-rebalance] Dry-run notification failed (non-fatal)", {
-              portfolioId: portfolio.id,
-              error: notifyErr instanceof Error ? notifyErr.message : String(notifyErr),
-            });
+            continue;
           }
-
-          summary.portfoliosSimulated++;
-          continue;
-        }
-
-        if (!rebalanceQueue) {
-          throw new Error("Rebalance queue unavailable");
         }
 
         await rebalanceQueue.add(
@@ -267,6 +288,7 @@ export async function processAutoRebalanceJob(
           portfolioId: portfolio.id,
           maxDriftPct: drift.maxDriftPct.toFixed(2),
           threshold: portfolio.threshold,
+          reason: triggerReason,
         });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/backend/src/services/rebalancingStrategyService.ts
+++ b/backend/src/services/rebalancingStrategyService.ts
@@ -21,6 +21,17 @@ export interface CrossCheckConfig {
     alertOnDisagreement: boolean
 }
 
+export interface DcaSchedule {
+    /** Days between scheduled buys (from `dcaIntervalDays` ?? `intervalDays` ?? 7). */
+    intervalDays: number
+    /** Milliseconds between scheduled buys. */
+    intervalMs: number
+    /** Amount to buy each interval in the portfolio's base unit (from `dcaAmount`, default 0). */
+    amount: number
+    /** Timestamp of the next scheduled buy (lastRebalance + intervalMs). */
+    nextBuyAtMs: number
+}
+
 /**
  * Determines if a portfolio should be rebalanced based on its configured strategy.
  */
@@ -108,10 +119,32 @@ function dcaStrategy(
     config: RebalanceStrategyConfig,
     now: number
 ): boolean {
+    const schedule = computeDcaSchedule(portfolio, config, now)
+    // A DCA buy requires a configured amount – nothing to buy otherwise.
+    if (schedule.amount <= 0) return false
+    return now >= schedule.nextBuyAtMs
+}
+
+/**
+ * Computes the scheduled DCA buy amount/interval and the next due timestamp
+ * from a portfolio's strategy config. Mirrors the contract-side DCA capability
+ * (`configure_dca` amount + interval) so the backend scheduler can trigger DCA
+ * executions on their own cadence.
+ */
+export function computeDcaSchedule(
+    portfolio: Portfolio,
+    config: RebalanceStrategyConfig,
+    _now?: number
+): DcaSchedule {
     const intervalDays = config.dcaIntervalDays ?? config.intervalDays ?? 7
-    const lastMs = new Date(portfolio.lastRebalance).getTime()
     const intervalMs = intervalDays * 24 * 60 * 60 * 1000
-    return now - lastMs >= intervalMs
+    const lastMs = new Date(portfolio.lastRebalance).getTime()
+    return {
+        intervalDays,
+        intervalMs,
+        amount: config.dcaAmount ?? 0,
+        nextBuyAtMs: lastMs + intervalMs,
+    }
 }
 
 export const REBALANCE_STRATEGIES: { value: RebalanceStrategyType; label: string; description: string }[] = [

--- a/backend/src/services/serviceContainer.ts
+++ b/backend/src/services/serviceContainer.ts
@@ -5,8 +5,19 @@ import { isRedisAvailable } from '../queue/connection.js'
 import { ReflectorService } from './reflector.js'
 import { logger } from '../utils/logger.js'
 
-const riskManagementService = new RiskManagementService()
+const riskManagementService = new RiskManagementService({
+    // Configurable CVaR/VaR auto-pause thresholds (falls back to class defaults).
+    var95: parseOptionalNumber(process.env.RISK_AUTOPAUSE_VAR95),
+    cvar95: parseOptionalNumber(process.env.RISK_AUTOPAUSE_CVAR95),
+    pauseDurationMs: parseOptionalNumber(process.env.RISK_AUTOPAUSE_DURATION_MS),
+})
 const rebalanceHistoryService = new RebalanceHistoryService(riskManagementService)
+
+function parseOptionalNumber(raw: string | undefined): number | undefined {
+    if (raw === undefined || raw.trim() === '') return undefined
+    const parsed = Number(raw)
+    return Number.isFinite(parsed) ? parsed : undefined
+}
 
 type DependencyStatus = 'ok' | 'degraded' | 'down'
 

--- a/backend/src/test/autoRebalance.scheduler.test.ts
+++ b/backend/src/test/autoRebalance.scheduler.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Job } from 'bullmq'
+import type { AutoRebalanceCheckJobData } from '../queue/queues.js'
+
+// ── Shared mocks (hoisted so vi.mock factories can reference them) ──────────
+const mocks = vi.hoisted(() => ({
+    queueAdd: vi.fn().mockResolvedValue({ id: 'job-1' }),
+    checkRebalanceNeeded: vi.fn().mockResolvedValue(true),
+    shouldAllowRebalance: vi.fn().mockReturnValue({ allowed: true, reason: 'OK', alerts: [] }),
+    checkCVaRVaRThresholdsAndAutoPause: vi.fn().mockResolvedValue({}),
+    getAllPortfolios: vi.fn(),
+    getCurrentPrices: vi.fn(),
+    checkCooldownPeriod: vi.fn().mockReturnValue({ safe: true }),
+    checkMarketConditions: vi.fn().mockReturnValue({ safe: true }),
+}))
+
+vi.mock('bullmq', () => ({
+    Job: class {},
+    Worker: class {},
+}))
+
+vi.mock('../utils/requestContext.js', () => ({
+    runWithRequestContext: async (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+vi.mock('../utils/logger.js', () => ({
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    logAudit: vi.fn(),
+}))
+
+vi.mock('../services/portfolioStorage.js', () => ({
+    portfolioStorage: { getAllPortfolios: mocks.getAllPortfolios },
+}))
+
+vi.mock('../services/stellar.js', () => {
+    class StellarService {
+        checkRebalanceNeeded = mocks.checkRebalanceNeeded
+    }
+    return { StellarService }
+})
+
+vi.mock('../services/reflector.js', () => {
+    class ReflectorService {
+        getCurrentPrices = mocks.getCurrentPrices
+    }
+    return { ReflectorService }
+})
+
+vi.mock('../services/serviceContainer.js', () => ({
+    riskManagementService: {
+        shouldAllowRebalance: mocks.shouldAllowRebalance,
+        checkCVaRVaRThresholdsAndAutoPause: mocks.checkCVaRVaRThresholdsAndAutoPause,
+    },
+}))
+
+vi.mock('../services/circuitBreakers.js', () => ({
+    CircuitBreakers: {
+        checkMarketConditions: mocks.checkMarketConditions,
+        checkCooldownPeriod: mocks.checkCooldownPeriod,
+    },
+}))
+
+vi.mock('../queue/queues.js', () => ({
+    getRebalanceQueue: () => ({ add: mocks.queueAdd }),
+}))
+
+vi.mock('../queue/connection.js', () => ({
+    getConnectionOptions: () => ({}),
+}))
+
+vi.mock('../queue/workers/workerRuntime.js', () => ({
+    createWorkerRuntimeStatus: () => ({ schedulerRegistered: false }),
+    markWorkerFailed: vi.fn(),
+    markWorkerJobCompleted: vi.fn(),
+    markWorkerJobFailed: vi.fn(),
+    markWorkerReady: vi.fn(),
+    markWorkerStarting: vi.fn(),
+    markWorkerStopped: vi.fn(),
+    snapshotWorkerRuntimeStatus: vi.fn(),
+    handleFinalFailure: vi.fn(),
+}))
+
+import { isRiskPaused, processAutoRebalanceJob } from '../jobs/autoRebalance.js'
+import type { Portfolio } from '../types/index.js'
+
+const PRICES = {
+    XLM: { price: 0.35, change: 0, timestamp: 1, source: 'external' as const },
+    USDC: { price: 1.0, change: 0, timestamp: 1, source: 'external' as const },
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const mockJob = (overrides: Partial<Job<AutoRebalanceCheckJobData>> = {}): Job<AutoRebalanceCheckJobData> =>
+    ({
+        id: 'job-1',
+        data: { triggeredBy: 'scheduler', correlationId: 'corr-1' },
+        ...overrides,
+    }) as unknown as Job<AutoRebalanceCheckJobData>
+
+const dcaPortfolio = (overrides: Partial<Portfolio> = {}): Portfolio => {
+    const now = Date.now()
+    return {
+        id: 'p-dca',
+        userAddress: 'GTEST',
+        allocations: { XLM: 50, USDC: 50 },
+        threshold: 5,
+        strategy: 'dca',
+        strategyConfig: { dcaAmount: 100, dcaIntervalDays: 7 },
+        balances: { XLM: 200, USDC: 100 },
+        totalValue: 170,
+        createdAt: new Date(now - 30 * DAY_MS).toISOString(),
+        // Due: 8 days since the last buy with a 7-day interval.
+        lastRebalance: new Date(now - 8 * DAY_MS).toISOString(),
+        version: 1,
+        ...overrides,
+    }
+}
+
+const thresholdPortfolio = (overrides: Partial<Portfolio> = {}): Portfolio => ({
+    id: 'p-threshold',
+    userAddress: 'GTEST',
+    allocations: { XLM: 50, USDC: 50 },
+    threshold: 5,
+    balances: { XLM: 200, USDC: 100 },
+    totalValue: 170,
+    createdAt: new Date(Date.now() - 30 * DAY_MS).toISOString(),
+    lastRebalance: new Date(Date.now() - 2 * DAY_MS).toISOString(),
+    version: 1,
+    ...overrides,
+})
+
+describe('processAutoRebalanceJob — strategy dispatch', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mocks.getCurrentPrices.mockResolvedValue(PRICES)
+        mocks.shouldAllowRebalance.mockReturnValue({ allowed: true, reason: 'OK', alerts: [] })
+        mocks.checkCooldownPeriod.mockReturnValue({ safe: true })
+        mocks.checkMarketConditions.mockReturnValue({ safe: true })
+        mocks.checkRebalanceNeeded.mockResolvedValue(true)
+        delete process.env.ENABLE_REBALANCE_CROSS_CHECK
+        delete process.env.REBALANCE_CROSS_CHECK_REQUIRE_AGREEMENT
+    })
+
+    afterEach(() => {
+        delete process.env.ENABLE_REBALANCE_CROSS_CHECK
+        delete process.env.REBALANCE_CROSS_CHECK_REQUIRE_AGREEMENT
+    })
+
+    it('triggers a DCA portfolio when its interval cadence is due', async () => {
+        mocks.getAllPortfolios.mockResolvedValue([dcaPortfolio()])
+
+        const summary = await processAutoRebalanceJob(mockJob())
+
+        expect(summary.portfoliosTriggered).toBe(1)
+        expect(mocks.queueAdd).toHaveBeenCalledWith(
+            'rebalance-p-dca',
+            expect.objectContaining({ portfolioId: 'p-dca', triggeredBy: 'auto' }),
+            expect.anything()
+        )
+    })
+
+    it('does not enqueue a DCA portfolio when the interval has not elapsed', async () => {
+        mocks.getAllPortfolios.mockResolvedValue([
+            dcaPortfolio({ lastRebalance: new Date(Date.now() - 1 * DAY_MS).toISOString() }),
+        ])
+
+        const summary = await processAutoRebalanceJob(mockJob())
+
+        expect(summary.portfoliosTriggered).toBe(0)
+        expect(mocks.queueAdd).not.toHaveBeenCalled()
+        expect(summary.portfoliosSkipped).toEqual(
+            expect.arrayContaining([expect.objectContaining({ reason: 'dca_not_due', count: 1 })])
+        )
+    })
+
+    it('does not trigger DCA when the strategy config disables the strategy', async () => {
+        mocks.getAllPortfolios.mockResolvedValue([
+            dcaPortfolio({ strategyConfig: { dcaAmount: 100, dcaIntervalDays: 7, enabled: false } }),
+        ])
+
+        const summary = await processAutoRebalanceJob(mockJob())
+
+        expect(summary.portfoliosChecked).toBe(0)
+        expect(mocks.queueAdd).not.toHaveBeenCalled()
+    })
+
+    it('preserves the drift-based threshold behaviour for threshold portfolios', async () => {
+        mocks.getAllPortfolios.mockResolvedValue([thresholdPortfolio()])
+
+        const summary = await processAutoRebalanceJob(mockJob())
+
+        expect(summary.portfoliosTriggered).toBe(1)
+        expect(mocks.queueAdd).toHaveBeenCalledWith(
+            'rebalance-p-threshold',
+            expect.objectContaining({ portfolioId: 'p-threshold' }),
+            expect.anything()
+        )
+    })
+})
+describe('processAutoRebalanceJob — CVaR/VaR auto-pause integration', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mocks.getCurrentPrices.mockResolvedValue(PRICES)
+        mocks.checkCooldownPeriod.mockReturnValue({ safe: true })
+        mocks.checkMarketConditions.mockReturnValue({ safe: true })
+        mocks.checkRebalanceNeeded.mockResolvedValue(true)
+    })
+
+    it('skips portfolios that are already auto-paused (riskPausedUntil in the future)', async () => {
+        mocks.getAllPortfolios.mockResolvedValue([
+            dcaPortfolio({
+                riskPausedUntil: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+            }),
+        ])
+
+        const summary = await processAutoRebalanceJob(mockJob())
+
+        expect(summary.portfoliosTriggered).toBe(0)
+        expect(mocks.queueAdd).not.toHaveBeenCalled()
+        expect(summary.portfoliosSkipped).toEqual(
+            expect.arrayContaining([expect.objectContaining({ reason: 'risk_paused', count: 1 })])
+        )
+    })
+
+    it('fires the auto-pause guardrail when the stat model blocks a VaR breach and then skips', async () => {
+        mocks.getAllPortfolios.mockResolvedValue([dcaPortfolio()])
+        mocks.shouldAllowRebalance.mockReturnValue({
+            allowed: false,
+            reason: 'Rebalance blocked by VaR limit',
+            reasonCode: 'STAT_MODEL_VAR_BREACH',
+            alerts: [],
+        })
+
+        const summary = await processAutoRebalanceJob(mockJob())
+
+        expect(mocks.checkCVaRVaRThresholdsAndAutoPause).toHaveBeenCalledWith(
+            'p-dca',
+            { XLM: 50, USDC: 50 },
+            PRICES,
+            'GTEST'
+        )
+        expect(mocks.queueAdd).not.toHaveBeenCalled()
+        expect(summary.portfoliosSkipped).toEqual(
+            expect.arrayContaining([expect.objectContaining({ reason: 'risk_paused', count: 1 })])
+        )
+    })
+
+    it('does not fire the auto-pause guardrail for non-VaR/CVaR blocks', async () => {
+        mocks.getAllPortfolios.mockResolvedValue([dcaPortfolio()])
+        mocks.shouldAllowRebalance.mockReturnValue({
+            allowed: false,
+            reason: 'Circuit breaker active',
+            reasonCode: 'CIRCUIT_BREAKER_ACTIVE',
+            alerts: [],
+        })
+
+        const summary = await processAutoRebalanceJob(mockJob())
+
+        expect(mocks.checkCVaRVaRThresholdsAndAutoPause).not.toHaveBeenCalled()
+        expect(mocks.queueAdd).not.toHaveBeenCalled()
+        expect(summary.portfoliosSkipped).toEqual(
+            expect.arrayContaining([expect.objectContaining({ reason: 'circuit_breaker', count: 1 })])
+        )
+    })
+})
+describe('processAutoRebalanceJob — on-chain cross-check', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mocks.getCurrentPrices.mockResolvedValue(PRICES)
+        mocks.shouldAllowRebalance.mockReturnValue({ allowed: true, reason: 'OK', alerts: [] })
+        mocks.checkCooldownPeriod.mockReturnValue({ safe: true })
+        mocks.checkMarketConditions.mockReturnValue({ safe: true })
+        mocks.getAllPortfolios.mockResolvedValue([dcaPortfolio()])
+    })
+
+    afterEach(() => {
+        delete process.env.ENABLE_REBALANCE_CROSS_CHECK
+        delete process.env.REBALANCE_CROSS_CHECK_REQUIRE_AGREEMENT
+    })
+
+    it('blocks execution when the on-chain check disagrees and requireAgreement is enabled', async () => {
+        process.env.ENABLE_REBALANCE_CROSS_CHECK = 'true'
+        process.env.REBALANCE_CROSS_CHECK_REQUIRE_AGREEMENT = 'true'
+        mocks.checkRebalanceNeeded.mockResolvedValue(false) // disagrees with the backend DCA decision
+
+        const summary = await processAutoRebalanceJob(mockJob())
+
+        expect(summary.portfoliosTriggered).toBe(0)
+        expect(mocks.queueAdd).not.toHaveBeenCalled()
+        expect(summary.portfoliosSkipped).toEqual(
+            expect.arrayContaining([expect.objectContaining({ reason: 'crosscheck_disagreement', count: 1 })])
+        )
+    })
+
+    it('warns but still executes on disagreement in warn-only mode', async () => {
+        process.env.ENABLE_REBALANCE_CROSS_CHECK = 'true'
+        mocks.checkRebalanceNeeded.mockResolvedValue(false) // disagrees with the backend DCA decision
+
+        const summary = await processAutoRebalanceJob(mockJob())
+
+        expect(summary.portfoliosTriggered).toBe(1)
+        expect(mocks.queueAdd).toHaveBeenCalledWith(
+            'rebalance-p-dca',
+            expect.objectContaining({ portfolioId: 'p-dca' }),
+            expect.anything()
+        )
+    })
+
+    it('executes normally when cross-check is disabled', async () => {
+        mocks.checkRebalanceNeeded.mockResolvedValue(false)
+
+        const summary = await processAutoRebalanceJob(mockJob())
+
+        expect(summary.portfoliosTriggered).toBe(1)
+        expect(mocks.queueAdd).toHaveBeenCalled()
+    })
+})
+
+describe('isRiskPaused', () => {
+    it('returns true when riskPausedUntil is in the future', () => {
+        const p = { riskPausedUntil: new Date(Date.now() + 3_600_000).toISOString() } as Portfolio
+        expect(isRiskPaused(p)).toBe(true)
+    })
+
+    it('returns false when riskPausedUntil is absent', () => {
+        expect(isRiskPaused({} as Portfolio)).toBe(false)
+    })
+
+    it('returns false when riskPausedUntil has already elapsed', () => {
+        const p = { riskPausedUntil: new Date(Date.now() - 3_600_000).toISOString() } as Portfolio
+        expect(isRiskPaused(p)).toBe(false)
+    })
+
+    it('returns false when riskPausedUntil is not a valid date', () => {
+        const p = { riskPausedUntil: 'not-a-date' } as Portfolio
+        expect(isRiskPaused(p)).toBe(false)
+    })
+})

--- a/backend/src/test/rebalancingStrategy.service.test.ts
+++ b/backend/src/test/rebalancingStrategy.service.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { shouldRebalanceByStrategy, REBALANCE_STRATEGIES } from '../services/rebalancingStrategyService.js'
+import {
+    computeDcaSchedule,
+    crossCheckRebalanceDecision,
+    shouldRebalanceByStrategy,
+    REBALANCE_STRATEGIES,
+} from '../services/rebalancingStrategyService.js'
 import type { Portfolio, PricesMap } from '../types/index.js'
 
 const basePortfolio = (overrides: Partial<Portfolio> = {}): Portfolio => ({
@@ -23,7 +28,7 @@ const stablePrices: PricesMap = {
 describe('rebalancingStrategyService', () => {
     it('covers all exported strategy types', () => {
         const strategyTypes = REBALANCE_STRATEGIES.map(s => s.value).sort()
-        expect(strategyTypes).toEqual(['custom', 'periodic', 'threshold', 'volatility'])
+        expect(strategyTypes).toEqual(['custom', 'dca', 'periodic', 'threshold', 'volatility'])
     })
 
     it('triggers threshold strategy when drift exceeds configured threshold', () => {
@@ -94,5 +99,129 @@ describe('rebalancingStrategyService', () => {
         expect(reloaded.strategyConfig).toEqual(persisted.strategyConfig)
         expect(beforeRestart).toBe(afterRestart)
         expect(afterRestart).toBe(false)
+    })
+
+    describe('DCA strategy schedule computation', () => {
+        const DCA_PORTFOLIO = basePortfolio({
+            strategy: 'dca',
+            strategyConfig: { dcaAmount: 100, dcaIntervalDays: 30 },
+            lastRebalance: '2026-01-01T00:00:00.000Z'
+        })
+
+        it('computes scheduled buy amount and interval from strategyConfig', () => {
+            const schedule = computeDcaSchedule(DCA_PORTFOLIO, DCA_PORTFOLIO.strategyConfig!)
+            expect(schedule.intervalDays).toBe(30)
+            expect(schedule.intervalMs).toBe(30 * 24 * 60 * 60 * 1000)
+            expect(schedule.amount).toBe(100)
+            expect(schedule.nextBuyAtMs).toBe(
+                new Date('2026-01-01T00:00:00.000Z').getTime() + schedule.intervalMs
+            )
+        })
+
+        it('falls back to intervalDays and the 7-day default when DCA fields are absent', () => {
+            const intervalFallback = computeDcaSchedule(
+                basePortfolio({ strategy: 'dca', strategyConfig: { intervalDays: 14 } }),
+                { intervalDays: 14 }
+            )
+            expect(intervalFallback.intervalDays).toBe(14)
+            expect(intervalFallback.amount).toBe(0)
+
+            const defaults = computeDcaSchedule(basePortfolio({ strategy: 'dca' }), {})
+            expect(defaults.intervalDays).toBe(7)
+            expect(defaults.amount).toBe(0)
+        })
+
+        it('triggers only after the DCA interval has elapsed', () => {
+            const dueAt = new Date('2026-01-01T00:00:00.000Z').getTime() + 30 * 24 * 60 * 60 * 1000
+            expect(shouldRebalanceByStrategy({ portfolio: DCA_PORTFOLIO, prices: stablePrices, now: dueAt - 1 })).toBe(false)
+            expect(shouldRebalanceByStrategy({ portfolio: DCA_PORTFOLIO, prices: stablePrices, now: dueAt })).toBe(true)
+        })
+
+        it('does not trigger when no buy amount is configured', () => {
+            const noAmount = basePortfolio({
+                strategy: 'dca',
+                strategyConfig: { dcaAmount: 0, dcaIntervalDays: 7 },
+                lastRebalance: '2026-01-01T00:00:00.000Z'
+            })
+            const dueAt = new Date('2026-01-01T00:00:00.000Z').getTime() + 8 * 24 * 60 * 60 * 1000
+            expect(shouldRebalanceByStrategy({ portfolio: noAmount, prices: stablePrices, now: dueAt })).toBe(false)
+        })
+
+        it('is drift-independent – triggers even when allocations are in balance', () => {
+            const balanced = basePortfolio({
+                strategy: 'dca',
+                strategyConfig: { dcaAmount: 100, dcaIntervalDays: 30 },
+                balances: { BTC: 100, ETH: 100 },
+                lastRebalance: '2026-01-01T00:00:00.000Z'
+            })
+            const dueAt = new Date('2026-01-01T00:00:00.000Z').getTime() + 30 * 24 * 60 * 60 * 1000
+            expect(shouldRebalanceByStrategy({ portfolio: balanced, prices: stablePrices, now: dueAt })).toBe(true)
+        })
+    })
+
+    describe('crossCheckRebalanceDecision', () => {
+        const driftedCtx = () => ({
+            portfolio: basePortfolio({
+                strategy: 'threshold',
+                threshold: 5,
+                balances: { BTC: 1.8, ETH: 0.2 }
+            }),
+            prices: stablePrices
+        })
+
+        it('agrees and executes when backend and on-chain decisions match', async () => {
+            const result = await crossCheckRebalanceDecision(driftedCtx(), async () => true)
+            expect(result.backendDecision).toBe(true)
+            expect(result.onChainDecision).toBe(true)
+            expect(result.agreement).toBe(true)
+            expect(result.finalDecision).toBe(true)
+            expect(result.warning).toBeUndefined()
+        })
+
+        it('warns but does not block when decisions disagree in warn-only mode', async () => {
+            const result = await crossCheckRebalanceDecision(driftedCtx(), async () => false, {
+                requireAgreement: false,
+                alertOnDisagreement: true
+            })
+            expect(result.backendDecision).toBe(true)
+            expect(result.onChainDecision).toBe(false)
+            expect(result.agreement).toBe(false)
+            // Backend decision wins during warn-only rollout.
+            expect(result.finalDecision).toBe(true)
+            expect(result.warning).toBeDefined()
+        })
+
+        it('blocks execution on disagreement when requireAgreement is enabled (fail-safe)', async () => {
+            const result = await crossCheckRebalanceDecision(driftedCtx(), async () => false, {
+                requireAgreement: true,
+                alertOnDisagreement: true
+            })
+            expect(result.agreement).toBe(false)
+            expect(result.finalDecision).toBe(false)
+        })
+
+        it('falls back to the backend decision when the on-chain check fails', async () => {
+            const result = await crossCheckRebalanceDecision(
+                driftedCtx(),
+                async () => { throw new Error('rpc unavailable') }
+            )
+            expect(result.backendDecision).toBe(true)
+            expect(result.onChainDecision).toBe(true)
+            expect(result.agreement).toBe(true)
+            expect(result.finalDecision).toBe(true)
+            expect(result.warning).toBeDefined()
+        })
+
+        it('agrees on no-op when both sides agree that no rebalance is needed', async () => {
+            const calmCtx = () => ({
+                portfolio: basePortfolio({ strategy: 'threshold', threshold: 5 }),
+                prices: stablePrices
+            })
+            const result = await crossCheckRebalanceDecision(calmCtx(), async () => false)
+            expect(result.backendDecision).toBe(false)
+            expect(result.onChainDecision).toBe(false)
+            expect(result.agreement).toBe(true)
+            expect(result.finalDecision).toBe(false)
+        })
     })
 })

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,84 @@
+# Stellar Portfolio Rebalancer — Soroban Contract
+
+Soroban smart contract for the Stellar Portfolio Rebalancer. It manages
+portfolios on-chain (create/deposit/withdraw), computes rebalance trades, and
+exposes the strategy-aware lifecycle (`check_rebalance_needed`,
+`preview_rebalance`, `execute_rebalance`, `configure_dca`, `execute_dca`, ...).
+
+See [`CONTRACT_ABI.md`](./CONTRACT_ABI.md) for the full contract surface and
+[`BENCHMARKS.md`](./BENCHMARKS.md) for benchmark results.
+
+## Toolchain
+
+The contract pins `soroban-sdk = "27.0.2"`. Use the pinned nightly toolchain
+that matches this SDK (see `.rust-toolchain.toml` if present, or the soroban
+docs). Contract unit tests run with:
+
+```bash
+cargo test --features testutils
+```
+
+## Fuzzing with `cargo fuzz`
+
+The `fuzz/` sub-crate contains libFuzzer harnesses for the pure portfolio math
+(`calculate_rebalance_trades`, allocation validation, and price
+conversion helpers). Fuzzing catches panics and overflow/underflow that can't
+be reached by the hand-written test vectors.
+
+### Prerequisites
+
+- Rust **nightly** (libFuzzer-style targets require nightly).
+- [`cargo-fuzz`](https://rust-fuzz.github.io/book/cargo-fuzz.html):
+
+```bash
+rustup toolchain install nightly
+rustup component add llvm-tools-preview --toolchain nightly
+cargo install cargo-fuzz
+```
+
+### Running a target
+
+Run any target from the repository root (or from `contracts/`):
+
+```bash
+cargo +nightly fuzz run fuzz_rebalance_trades
+```
+
+Other targets:
+
+```bash
+cargo +nightly fuzz run fuzz_rebalance       # trades from fixed-layout byte chunks
+cargo +nightly fuzz run fuzz_allocations     # validate_allocations / boundary constants
+cargo +nightly fuzz run fuzz_oracle_prices   # balance_to_value / value_to_balance, incl. price == 0
+```
+
+Useful flags:
+
+```bash
+# Run for a fixed duration (seconds)
+cargo +nightly fuzz run fuzz_rebalance_trades -- -max_total_time=300
+
+# Minimise a reproducer found in the corpus or by a crash
+cargo +nightly fuzz tmin fuzz_rebalance_trades /path/to/crash-artifact
+
+# Reduce the corpus
+cargo +nightly fuzz cmin fuzz_rebalance_trades
+```
+
+### Target guide
+
+| Target | Input model | Invariant asserted |
+| --- | --- | --- |
+| `fuzz_rebalance_trades` | `#[derive(Arbitrary)]` struct: asset count, allocation bps, balance seeds, price seeds, decimals, extreme-total-value flag. Allocations are normalised to sum to `ALLOCATION_DENOMINATOR` with no zero-weight assets. | `calculate_rebalance_trades` never panics; every trade is above `MIN_TRADE_AMOUNT_STROOPS` and stays away from the `i128` boundaries; normalised allocations pass `validate_allocations`. |
+| `fuzz_rebalance` | Fixed 3-byte-per-asset layout (`[pct, balance, price]`). | Same postconditions on `calculate_rebalance_trades` trades. |
+| `fuzz_allocations` | Arbitrary percentage maps plus single-asset cases. | `validate_allocations` returns `Ok`-equivalent booleans without panicking; MIN/MAX constants stay ordered. |
+| `fuzz_oracle_prices` | Raw 16-byte `(price, balance)` pairs plus hand-picked extremes. | `balance_to_value` / `value_to_balance` never panic, including `price == 0`. |
+
+### Corpus & CI
+
+- Seed corpora (when added) live under `fuzz/corpus/<target>/`.
+- A reasonable smoke gate is a few minutes per target:
+
+```bash
+cargo +nightly fuzz run fuzz_rebalance_trades -- -max_total_time=120
+```

--- a/contracts/fuzz/Cargo.toml
+++ b/contracts/fuzz/Cargo.toml
@@ -9,6 +9,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
+arbitrary = { version = "1.3", features = ["derive"] }
 
 [dependencies.portfolio-rebalancer]
 path = ".."
@@ -35,6 +36,13 @@ bench = false
 [[bin]]
 name = "fuzz_allocations"
 path = "fuzz_targets/fuzz_allocations.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_rebalance_trades"
+path = "fuzz_targets/fuzz_rebalance_trades.rs"
 test = false
 doc = false
 bench = false

--- a/contracts/fuzz/fuzz_targets/fuzz_rebalance.rs
+++ b/contracts/fuzz/fuzz_targets/fuzz_rebalance.rs
@@ -6,7 +6,8 @@ use soroban_sdk::{Address, Env, Map};
 
 use portfolio_rebalancer::portfolio::{calculate_rebalance_trades, validate_allocations};
 use portfolio_rebalancer::types::{
-    PauseReason, Portfolio, MAX_PORTFOLIO_ASSETS, MIN_TRADE_AMOUNT_STROOPS,
+    CircuitBreakerConfig, PauseReason, Portfolio, StrategyConfig, StrategyType,
+    MAX_PORTFOLIO_ASSETS, MIN_TRADE_AMOUNT_STROOPS,
 };
 
 fuzz_target!(|data: &[u8]| {
@@ -85,6 +86,13 @@ fuzz_target!(|data: &[u8]| {
         },
         is_active: true,
         pause_reason: PauseReason::None,
+        circuit_breaker_config: CircuitBreakerConfig {
+            window_seconds: 3600,
+            spike_threshold_bps: 100,
+        },
+        global_max_slippage_bps: 300,
+        strategy: StrategyType::Threshold,
+        strategy_config: StrategyConfig::default(),
     };
 
     // Must never panic for any input

--- a/contracts/fuzz/fuzz_targets/fuzz_rebalance_trades.rs
+++ b/contracts/fuzz/fuzz_targets/fuzz_rebalance_trades.rs
@@ -1,0 +1,190 @@
+#![no_main]
+
+//! Fuzz target for `calculate_rebalance_trades` overflow/underflow robustness.
+//!
+//! Unlike the byte-chunk targets (which hand-roll the input layout) this target
+//! uses `#[derive(Arbitrary)]` over a dedicated input struct so the fuzzer can
+//! treat each portfolio dimension independently. Inputs are mapped into
+//! structurally valid Soroban maps and run through the real contract function:
+//! the target asserts the function never panics and that every produced trade
+//! stays within sane i128 bounds above the minimum trade size.
+
+use arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, Map};
+
+use portfolio_rebalancer::portfolio::{calculate_rebalance_trades, validate_allocations};
+use portfolio_rebalancer::types::{
+    CircuitBreakerConfig, PauseReason, Portfolio, StrategyConfig, StrategyType,
+    ALLOCATION_DENOMINATOR, DEFAULT_ASSET_DECIMALS, MAX_ASSET_DECIMALS, MAX_PORTFOLIO_ASSETS,
+    MIN_TRADE_AMOUNT_STROOPS,
+};
+
+/// Randomized but structurally valid portfolio/asset inputs.
+#[derive(Arbitrary, Clone, Debug)]
+struct FuzzTradeInput {
+    /// Number of assets to build (capped at `MAX_PORTFOLIO_ASSETS`).
+    num_assets: u8,
+    /// Allocation basis points per asset (sum is normalised to `ALLOCATION_DENOMINATOR`).
+    allocations_bps: Vec<u16>,
+    /// Balance seeds per asset; sign and magnitude are derived deterministically.
+    balance_seeds: Vec<u64>,
+    /// Price seeds per asset; `0` exercises the zero-price division-by-zero path.
+    price_seeds: Vec<u64>,
+    /// Asset decimals per asset (clamped to the contract's `[0, MAX_ASSET_DECIMALS]` range).
+    decimals: Vec<u32>,
+    /// When the low 2 bits are clear, an extra-large `total_value` is used to
+    /// stress the `target_value = total * pct / denominator` math.
+    extreme_total_value: u8,
+/// Normalises allocation basis points to sum exactly to `ALLOCATION_DENOMINATOR`
+/// with no zero allocations, producing a portfolio that `validate_allocations`
+/// accepts. Returns `None` when the input can't be normalised.
+fn normalise_allocations(raw: &[u16], n: usize) -> Option<Vec<u32>> {
+    if n == 0 || n > MAX_PORTFOLIO_ASSETS as usize {
+        return None;
+    }
+    let total: u64 = raw.iter().take(n).map(|&p| p as u64).sum();
+    if total == 0 {
+        return None;
+    }
+
+    let mut out: Vec<u32> = raw
+        .iter()
+        .take(n)
+        .map(|&p| ((p as u64 * ALLOCATION_DENOMINATOR as u64) / total) as u32)
+        .collect();
+    // `validate_allocations` rejects zero-weight assets – promote any to 1.
+    for v in out.iter_mut() {
+        if *v == 0 {
+            *v = 1;
+        }
+    }
+
+    let sum: u32 = out.iter().sum();
+    if sum > ALLOCATION_DENOMINATOR {
+        return None;
+    }
+    out[n - 1] += ALLOCATION_DENOMINATOR - sum;
+    if out[n - 1] == 0 || out.iter().sum::<u32>() != ALLOCATION_DENOMINATOR {
+        return None;
+    }
+    Some(out)
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 32 {
+        return;
+    }
+
+    let mut unstructured = Unstructured::new(data);
+    let Ok(input) = FuzzTradeInput::arbitrary(&mut unstructured) else {
+        return;
+    };
+
+    let n = (input.num_assets as usize).min(MAX_PORTFOLIO_ASSETS as usize);
+    let Some(allocs) = normalise_allocations(&input.allocations_bps, n) else {
+        return;
+    };
+
+    let env = Env::default();
+    let mut target_allocations: Map<Address, u32> = Map::new(&env);
+    let mut current_balances: Map<Address, i128> = Map::new(&env);
+    let mut prices: Map<Address, i128> = Map::new(&env);
+    let mut asset_decimals: Map<Address, u32> = Map::new(&env);
+
+    for (idx, &pct) in allocs.iter().enumerate() {
+        let asset = Address::generate(&env);
+
+        let seed = input.balance_seeds.get(idx).copied().unwrap_or(0);
+        // Bounded magnitude (≤ ~1e11 stroops) with a mix of positive/negative balances.
+        let magnitude = (seed % 100_000_000_000) as i128;
+        let balance = if seed % 7 == 0 { -magnitude } else { magnitude };
+
+        let price_seed = input.price_seeds.get(idx).copied().unwrap_or(0);
+        // 0 exercises the price==0 path; otherwise stay well inside i128 range.
+        let price: i128 = if price_seed % 32 == 0 {
+            0
+        } else {
+            (price_seed % 10_000_000_000_000) as i128
+        };
+
+        let decimals = input
+            .decimals
+            .get(idx)
+            .copied()
+            .unwrap_or(DEFAULT_ASSET_DECIMALS)
+            % (MAX_ASSET_DECIMALS + 1);
+
+        target_allocations.set(asset.clone(), pct);
+        current_balances.set(asset.clone(), balance);
+        prices.set(asset.clone(), price);
+        asset_decimals.set(asset, decimals);
+    }
+
+    // The normalised allocations must always validate.
+    assert!(
+        validate_allocations(&target_allocations),
+        "normalised allocations failed validation"
+    );
+// Total value either matches the portfolio's own compute or is an intentionally
+    // extreme i128 (stresses the `total_value * pct` multiplication in the contract).
+    let computed_total: i128 = {
+        let mut tv = 0i128;
+        for (asset, bal) in current_balances.iter() {
+            if let Some(p) = prices.get(asset) {
+                tv = tv.saturating_add(bal.saturating_mul(p).saturating_div(10_000_000_000_000));
+            }
+        }
+        tv
+    };
+    let total_value = if input.extreme_total_value & 0b11 == 0 {
+        computed_total.saturating_add(i128::from(i64::MAX)).saturating_mul(10)
+    } else {
+        computed_total
+    };
+
+    let user = Address::generate(&env);
+    let portfolio = Portfolio {
+        user,
+        target_allocations,
+        current_balances,
+        asset_decimals,
+        rebalance_threshold: 5,
+        slippage_tolerance: 100,
+        slippage_policy_version: 1,
+        last_rebalance: 0,
+        total_value,
+        is_active: true,
+        pause_reason: PauseReason::None,
+        circuit_breaker_config: CircuitBreakerConfig {
+            window_seconds: 3600,
+            spike_threshold_bps: 100,
+        },
+        global_max_slippage_bps: 300,
+        strategy: StrategyType::Threshold,
+        strategy_config: StrategyConfig::default(),
+    };
+
+    // Must never panic for any input, regardless of overflow/underflow shape.
+    let trades = calculate_rebalance_trades(&env, &portfolio, &prices);
+
+    // Checked-arithmetic style assertions on everything that reaches the output:
+    // trades must be above the minimum size and must not sit at i128 boundaries
+    // (which would indicate silent overflow).
+    for (_, amount) in trades.iter() {
+        assert!(
+            amount.abs() > MIN_TRADE_AMOUNT_STROOPS,
+            "trade below minimum slipped through: {amount}"
+        );
+        assert!(
+            amount > i128::MIN + MIN_TRADE_AMOUNT_STROOPS,
+            "trade underflowed near i128::MIN: {amount}"
+        );
+        assert!(
+            amount < i128::MAX - MIN_TRADE_AMOUNT_STROOPS,
+            "trade overflowed near i128::MAX: {amount}"
+        );
+    }
+});
+}


### PR DESCRIPTION
closes #1390  closes #1389 closes #1388 closes #1375.



- #1390 DCA: add computeDcaSchedule (dcaAmount/dcaIntervalDays with intervalDays + 7day fallback) and drift-independent DCA dispatch in rebalancingStrategyService.ts; autoRebalance job now triggers DCA portfolios on their own cadence via the existing 15-minute auto-rebalance-check schedule.

- #1389 Cross-check: scheduler calls both backend shouldRebalanceByStrategy and on-chain StellarService.checkRebalanceNeeded before enqueueing when ENABLE_REBALANCE_CROSS_CHECK is set; disagreements are logged, and REBALANCE_CROSS_CHECK_REQUIRE_AGREEMENT enables fail-safe blocking during rollout.

- #1388 CVaR/VaR auto-pause: autoRebalance worker now respects riskPausedUntil, invokes checkCVaRVaRThresholdsAndAutoPause on stat-model VaR/CVaR blocks (notification + pause persisted), and thresholds are configurable via RISK_AUTOPAUSE_VAR95/CVAR95/DURATION_MS env vars through serviceContainer.

- Tests: rebalancingStrategy.service.test.ts extended with DCA interval computation/triggering and cross-check agreement/disagreement scenarios; new autoRebalance.scheduler.test.ts covers DCA dispatch, risk-pause integration, and cross-check blocking/warn-only modes.

Contracts (#1375):

- New fuzz_rebalance_trades target using arbitrary-derived structs for randomized but structurally valid portfolios; asserts calculate_rebalance_trades never panics, allocations normalize to ALLOCATION_DENOMINATOR, and trades stay above MIN_TRADE_AMOUNT_STROOPS and away from i128 boundaries.

- Register target in fuzz/Cargo.toml, add arbitrary 1.3 dependency, fix fuzz_rebalance.rs to compile against the current 15-field Portfolio struct, and document cargo fuzz usage in contracts/README.md.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Auto-rebalancing now supports DCA schedules, threshold drift, and custom strategy triggers.
  - Added CVaR/VaR risk safeguards that can pause portfolios automatically.
  - Added optional validation against on-chain rebalance decisions, with configurable warning or blocking behavior.
  - Added configurable DCA amounts, intervals, and next-buy scheduling.
  - New feature flags are available for controlling rebalance cross-check behavior.

- **Documentation**
  - Added contract usage, testing, and fuzzing guidance.

- **Tests**
  - Expanded coverage for scheduling, risk pauses, cross-checks, and trade-calculation safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->