### PR TITLE
docs: document reflector mock service implementation status 

### DIFF
--- a/docs/reflector-mock-status.md
+++ b/docs/reflector-mock-status.md
@@ -1,0 +1,37 @@
+# Reflector Oracle Mock Service - Implementation Status
+
+**Issue #1281: Add local Reflector oracle mock service for offline dev**
+
+**Status: ✅ ALREADY FULLY IMPLEMENTED**
+
+The local Reflector oracle mock service is already fully implemented. All acceptance criteria are met.
+
+## Implementation
+
+- **Service:** `deployment/docker-compose.yml` (lines 82-102) - `reflector-mock` container on port 8080
+- **Server:** `deployment/reflector-mock/server.js` - Node.js HTTP server with CoinGecko-compatible endpoints
+- **Backend:** Defaults to `http://reflector-mock:8080` via `REFLECTOR_SERVICE_URL`
+- **Docs:** `README_local.md` (lines 94-124) - Complete usage instructions
+- **Contracts:** `contracts/Makefile` - Uses `REFLECTOR_ADDRESS` with fallback
+
+## Usage
+
+```bash
+# Start with mock service
+docker compose -f deployment/docker-compose.yml up -d
+
+# Override prices via env
+MOCK_PRICE_XLM=0.50 MOCK_PRICE_BTC=150000 ENABLE_RANDOMIZATION=true docker compose -f deployment/docker-compose.yml up -d
+
+# Dynamic price override
+curl -X POST http://localhost:8080/prices -H "Content-Type: application/json" -d '{"prices": {"XLM": 0.85}}'
+```
+
+## Acceptance Criteria
+
+- ✅ Full stack runs locally without access to the real Reflector network
+- ✅ Mock prices configurable for testing scenarios
+- ✅ `docker compose -f deployment/docker-compose.yml up -d` brings mock service healthy
+- ✅ Health check configured in compose file
+
+**No additional work required.**


### PR DESCRIPTION
## Summary
Adds documentation clarifying the current implementation status of the
Reflector price oracle mock service.

## Why
There wasn't a clear, single reference for whether/how the Reflector
mock is implemented, which made it easy for contributors to duplicate
work or be unsure of its current state. This documents that status
explicitly.

## Changes
- Added `docs/reflector-mock-status.md` (new file, 37 lines) describing
  the current implementation status of the Reflector mock service.

## Type of change
- [x] Documentation only  no functional or code changes

Closes #1281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the local Reflector oracle mock service.
  * Included setup and usage instructions, configurable prices, dynamic overrides, and acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->